### PR TITLE
Bring stranded filter-defaults + slug-doc commits to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # gundi-integration-action-runner
 Template repo for integration in Gundi v2.
 
+## Integration type slug
+
+The canonical Gundi integration-type slug for this runner is **`earth_ranger`**. It matches `gundi_core.schemas.v1.DestinationTypes.EarthRanger` and every fixture across `cdip-routing` and the gundi-integration repos. Always use `earth_ranger` (with underscore) when:
+
+- Setting `INTEGRATION_TYPE_SLUG` in deployed env config
+- Running `python app/register.py --slug ...` from CLI or VS Code launch tasks
+- Referencing this integration type elsewhere in the system
+
+An `earthranger` (no underscore) IntegrationType existed historically as a registration accident and is being cleaned up — see [the explanation thread on PR #13](https://github.com/PADAS/gundi-integration-earthranger/pull/13).
+
 ## Usage
 - Fork this repo
 - Implement your own actions in `actions/handlers.py`

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -105,18 +105,35 @@ class PullObservationsConfig(PullActionConfiguration):
     start_datetime: str = FieldWithUIOptions(
         ...,
         title="Start Datetime",
-        description="ISO-8601 timestamp. Observations recorded on or after this moment are pulled.",
+        description=(
+            "ISO-8601 timestamp filtering observations by their recorded_at. "
+            "Used only on the FIRST run, or whenever 'force_run_since_start' is true. "
+            "After a successful run the action tracks its own watermark and ignores this value "
+            "until the next manual reset."
+        ),
         format="date-time",
         ui_options=UIOptions(widget="date-time"),
     )
     end_datetime: Optional[str] = FieldWithUIOptions(
         None,
         title="End Datetime",
-        description="Optional ISO-8601 timestamp. If set, observations recorded after this moment are skipped.",
+        description=(
+            "Optional ISO-8601 ceiling on recorded_at. Sent to ER on every run, even after the "
+            "internal watermark has advanced — leave empty for ongoing pulls and only set it for "
+            "bounded historical backfills."
+        ),
         format="date-time",
         ui_options=UIOptions(widget="date-time"),
     )
-    force_run_since_start: bool = False
+    force_run_since_start: bool = FieldWithUIOptions(
+        False,
+        title="Force Run From Start Datetime",
+        description=(
+            "Resets the internal watermark for one run, so the next pull starts at "
+            "'start_datetime' instead. Toggle off again after the catch-up run completes — "
+            "otherwise every subsequent run will re-pull from start_datetime."
+        ),
+    )
     subject_group_ids: List[str] = Field(
         default_factory=list,
         title="Subject Group UUIDs",
@@ -137,18 +154,35 @@ class PullEventsConfig(PullActionConfiguration):
     start_datetime: str = FieldWithUIOptions(
         ...,
         title="Start Datetime",
-        description="ISO-8601 timestamp. Events created on or after this moment are pulled.",
+        description=(
+            "ISO-8601 timestamp filtering events by their event_time (when the event occurred, "
+            "NOT when it was created in ER). Used only on the FIRST run, or whenever "
+            "'force_run_since_start' is true. After a successful run the action tracks its own "
+            "watermark and ignores this value until the next manual reset."
+        ),
         format="date-time",
         ui_options=UIOptions(widget="date-time"),
     )
     end_datetime: Optional[str] = FieldWithUIOptions(
         None,
         title="End Datetime",
-        description="Optional ISO-8601 timestamp. If set, events created after this moment are skipped.",
+        description=(
+            "Optional ISO-8601 ceiling on event_time. Sent to ER on every run, even after the "
+            "internal watermark has advanced — leave empty for ongoing pulls and only set it for "
+            "bounded historical backfills."
+        ),
         format="date-time",
         ui_options=UIOptions(widget="date-time"),
     )
-    force_run_since_start: bool = False
+    force_run_since_start: bool = FieldWithUIOptions(
+        False,
+        title="Force Run From Start Datetime",
+        description=(
+            "Resets the internal watermark for one run, so the next pull starts at "
+            "'start_datetime' instead. Toggle off again after the catch-up run completes — "
+            "otherwise every subsequent run will re-pull from start_datetime."
+        ),
+    )
     event_types: List[str] = Field(
         default_factory=list,
         title="Event Types",

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from pydantic import Field, SecretStr
 
-from app.services.utils import GlobalUISchemaOptions
+from app.services.utils import FieldWithUIOptions, GlobalUISchemaOptions, UIOptions
 from .core import AuthActionConfiguration, GenericActionConfiguration, PullActionConfiguration, ExecutableActionMixin
 
 
@@ -102,8 +102,20 @@ class ShowPermissionsConfig(GenericActionConfiguration, ExecutableActionMixin):
 
 
 class PullObservationsConfig(PullActionConfiguration):
-    start_datetime: str
-    end_datetime: Optional[str] = None
+    start_datetime: str = FieldWithUIOptions(
+        ...,
+        title="Start Datetime",
+        description="ISO-8601 timestamp. Observations recorded on or after this moment are pulled.",
+        format="date-time",
+        ui_options=UIOptions(widget="date-time"),
+    )
+    end_datetime: Optional[str] = FieldWithUIOptions(
+        None,
+        title="End Datetime",
+        description="Optional ISO-8601 timestamp. If set, observations recorded after this moment are skipped.",
+        format="date-time",
+        ui_options=UIOptions(widget="date-time"),
+    )
     force_run_since_start: bool = False
     subject_group_ids: List[str] = Field(
         default_factory=list,
@@ -122,8 +134,20 @@ class PullObservationsConfig(PullActionConfiguration):
 
 
 class PullEventsConfig(PullActionConfiguration):
-    start_datetime: str
-    end_datetime: Optional[str] = None
+    start_datetime: str = FieldWithUIOptions(
+        ...,
+        title="Start Datetime",
+        description="ISO-8601 timestamp. Events created on or after this moment are pulled.",
+        format="date-time",
+        ui_options=UIOptions(widget="date-time"),
+    )
+    end_datetime: Optional[str] = FieldWithUIOptions(
+        None,
+        title="End Datetime",
+        description="Optional ISO-8601 timestamp. If set, events created after this moment are skipped.",
+        format="date-time",
+        ui_options=UIOptions(widget="date-time"),
+    )
     force_run_since_start: bool = False
     event_types: List[str] = Field(
         default_factory=list,

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -13,6 +13,19 @@ class ERAuthenticationType(str, Enum):
     USERNAME_PASSWORD = "username_password"
 
 
+class EventFilterDateField(str, Enum):
+    """Which ER timestamp on an Event the start/end window applies to.
+
+    Maps to ER's three event filter keys:
+      EVENT_TIME → date_range (Event.event_time)
+      CREATED_AT → create_date (Event.created_at)
+      UPDATED_AT → update_date (Event.updated_at)
+    """
+    EVENT_TIME = "event_time"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+
+
 class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
     authentication_type: ERAuthenticationType = Field(
         ERAuthenticationType.TOKEN,
@@ -155,8 +168,8 @@ class PullEventsConfig(PullActionConfiguration):
         ...,
         title="Start Datetime",
         description=(
-            "ISO-8601 timestamp filtering events by their event_time (when the event occurred, "
-            "NOT when it was created in ER). Used only on the FIRST run, or whenever "
+            "ISO-8601 timestamp filtering events by the field selected in "
+            "'filter_date_field' (default: updated_at). Used only on the FIRST run, or whenever "
             "'force_run_since_start' is true. After a successful run the action tracks its own "
             "watermark and ignores this value until the next manual reset."
         ),
@@ -167,12 +180,25 @@ class PullEventsConfig(PullActionConfiguration):
         None,
         title="End Datetime",
         description=(
-            "Optional ISO-8601 ceiling on event_time. Sent to ER on every run, even after the "
-            "internal watermark has advanced — leave empty for ongoing pulls and only set it for "
-            "bounded historical backfills."
+            "Optional ISO-8601 ceiling on the field selected in 'filter_date_field'. "
+            "Sent to ER on every run, even after the internal watermark has advanced — leave "
+            "empty for ongoing pulls and only set it for bounded historical backfills."
         ),
         format="date-time",
         ui_options=UIOptions(widget="date-time"),
+    )
+    filter_date_field: EventFilterDateField = FieldWithUIOptions(
+        EventFilterDateField.UPDATED_AT,
+        title="Filter By Date Field",
+        description=(
+            "Which ER timestamp the start/end window applies to. "
+            "'updated_at' (the default) catches backdated events and late edits on subsequent "
+            "runs because the watermark compares against when ER last touched the row. "
+            "'created_at' is similar but ignores edits after the event first appears. "
+            "'event_time' filters by when the event actually occurred and will silently miss "
+            "events whose event_time predates the current watermark — use only for bounded "
+            "historical backfills."
+        ),
     )
     force_run_since_start: bool = FieldWithUIOptions(
         False,
@@ -204,6 +230,6 @@ class PullEventsConfig(PullActionConfiguration):
     )
 
     ui_global_options: GlobalUISchemaOptions = GlobalUISchemaOptions(
-        order=["start_datetime", "end_datetime", "event_types", "event_categories", "force_run_since_start"],
+        order=["start_datetime", "end_datetime", "filter_date_field", "event_types", "event_categories", "force_run_since_start"],
     )
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -13,8 +13,8 @@ from gundi_core.events import LogLevel
 from gundi_core.schemas.v2 import Integration
 from app.services.utils import find_config_for_action
 from app.services.state import IntegrationStateManager
-from .configurations import AuthenticateConfig, PullObservationsConfig, PullEventsConfig, ERAuthenticationType, \
-    ShowPermissionsConfig
+from .configurations import AuthenticateConfig, EventFilterDateField, PullObservationsConfig, PullEventsConfig, \
+    ERAuthenticationType, ShowPermissionsConfig
 from ..services.activity_logger import activity_logger, log_action_activity
 from ..services.gundi import send_events_to_gundi, send_observations_to_gundi
 
@@ -24,6 +24,15 @@ logger = logging.getLogger(__name__)
 DEFAULT_CONNECT_TIMEOUT_SECONDS = 10.0
 BATCH_SIZE = 100
 state_manager = IntegrationStateManager()
+
+# Maps the operator-selected date field to the corresponding key on ER's
+# event-filter blob. ER applies these independently of each other, so only
+# one is set per pull.
+ER_EVENT_FILTER_KEY_BY_DATE_FIELD = {
+    EventFilterDateField.EVENT_TIME: "date_range",
+    EventFilterDateField.CREATED_AT: "create_date",
+    EventFilterDateField.UPDATED_AT: "update_date",
+}
 
 
 async def action_auth(integration: Integration, action_config: AuthenticateConfig):
@@ -389,13 +398,14 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
         start_datetime = pull_config.start_datetime
     else:
         start_datetime = last_execution
+    date_filter_key = ER_EVENT_FILTER_KEY_BY_DATE_FIELD[pull_config.filter_date_field]
     event_filter = {
-        "date_range": {
+        date_filter_key: {
             "lower": start_datetime
         }
     }
     if pull_config.end_datetime:
-        event_filter["date_range"]["upper"] = pull_config.end_datetime
+        event_filter[date_filter_key]["upper"] = pull_config.end_datetime
     if pull_config.event_types:
         event_filter["event_type"] = pull_config.event_types
     if pull_config.event_categories:

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -412,6 +412,51 @@ async def test_pull_events_event_type_and_category_filter_passed_to_er(
     assert er_filter["event_category"] == ["wildlife"]
 
 
+@pytest.mark.parametrize(
+    "filter_date_field, expected_er_key",
+    [
+        (None, "update_date"),                # default — no config override
+        ("updated_at", "update_date"),
+        ("event_time", "date_range"),
+        ("created_at", "create_date"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_pull_events_date_field_maps_to_er_filter_key(
+        mocker, filter_date_field, expected_er_key,
+        mock_gundi_client_v2, mock_state_manager, mock_erclient_class,
+        mock_get_gundi_api_key, mock_gundi_sensors_client_class, er_integration_v2_provider,
+        mock_publish_event, mock_gundi_client_v2_class, mock_config_manager_er_provider
+):
+    """The configured filter_date_field selects which ER filter key the date window goes into."""
+    import json
+    pull_events_data = er_integration_v2_provider.get_action_config("pull_events").data
+    if filter_date_field is not None:
+        pull_events_data["filter_date_field"] = filter_date_field
+
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager_er_provider)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.actions.handlers.state_manager", mock_state_manager)
+    mocker.patch("app.actions.handlers.AsyncERClient", mock_erclient_class)
+    mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class)
+    mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
+
+    await execute_action(
+        integration_id=str(er_integration_v2_provider.id),
+        action_id="pull_events",
+    )
+
+    er_filter = json.loads(mock_erclient_class.return_value.get_events.call_args.kwargs["filter"])
+    other_keys = {"date_range", "create_date", "update_date"} - {expected_er_key}
+    assert expected_er_key in er_filter
+    assert "lower" in er_filter[expected_er_key]
+    for k in other_keys:
+        assert k not in er_filter
+
+
 # ---------------------------------------------------------------------------
 # Filtering: _resolve_source_ids unit tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Four commits that were made on the `feat/er-filtering` branch *after* PR #13 had already merged. They were stranded — never made it to main. Bringing them in now so the next ticket ([GUNDI-5386](https://allenai.atlassian.net/browse/GUNDI-5386)) can rely on their behavior.

## Commits (in order)

1. **`5542abd` Render start/end datetime fields with a date-time picker** — adds `format: date-time` JSON-schema and `ui:widget: date-time` UI-schema hints to `start_datetime` / `end_datetime` so the Gundi portal renders proper pickers.
2. **`2a1b16d` Clarify start/end datetime semantics** — field descriptions now spell out: first-run-only watermark behavior, "sent on every run" for `end_datetime`, the one-shot `force_run_since_start` toggle, and (for events) that the filter is on `event_time` not `created_at`.
3. **`0429106` Let pull_events filter by updated_at (default), event_time, or created_at** — new `filter_date_field: EventFilterDateField` enum on `PullEventsConfig` (default `updated_at`). Handler maps the choice to ER's filter key (`update_date` / `date_range` / `create_date`). 4 new parametrized test variants. This is the dependency that lets GUNDI-5386 detect updated events on subsequent pulls.
4. **`bdf754c` Document earth_ranger as the canonical integration type slug** — README note pinning `earth_ranger` (with underscore) as the canonical slug. Cleanup work for the stray `earthranger` type tracked separately as GUNDI-5385.

## Behavior change worth flagging

Commit `0429106` flips the default filter key from `date_range` (event_time) to `update_date` (updated_at). For prod ER integrations, this means edited events get re-pulled on subsequent runs rather than being missed when their `event_time` falls behind the watermark. Strictly more inclusive — Gundi dedups by event id so re-pulls are idempotent.

## Test plan

- [x] Full suite passes locally — **84 tests**, no failures.
- [ ] CI runs the same suite on PR open.
- [ ] Deploy to dev; smoke a pull against a known ER integration to confirm filter behavior and slug rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GUNDI-5386]: https://allenai.atlassian.net/browse/GUNDI-5386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ