### PR TITLE
ER runner: forward event updates to Gundi as EventUpdate PATCHes (GUNDI-5386)

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -16,7 +16,7 @@ from app.services.state import IntegrationStateManager
 from .configurations import AuthenticateConfig, EventFilterDateField, PullObservationsConfig, PullEventsConfig, \
     ERAuthenticationType, ShowPermissionsConfig
 from ..services.activity_logger import activity_logger, log_action_activity
-from ..services.gundi import send_events_to_gundi, send_observations_to_gundi
+from ..services.gundi import send_events_to_gundi, send_observations_to_gundi, update_event_in_gundi
 
 logger = logging.getLogger(__name__)
 
@@ -412,25 +412,93 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
         event_filter["event_category"] = pull_config.event_categories
     json_filter = json.dumps(event_filter)
     logger.info(f"Extracting events with filter '{event_filter}'...")
-    # Process events in batches
+    # Process events in batches. Per-event state in Redis (keyed by ER event UUID)
+    # distinguishes never-seen events (post as new) from previously-forwarded events
+    # whose updated_at has advanced (emit one update_event per detected change).
+    events_new = 0
+    events_updated = 0  # distinct events that had at least one change emitted
+    updates_emitted = 0  # individual update_event calls (notes + field changes)
+    events_skipped_unchanged = 0
     async with er_client as earth_ranger:
         async for event_batch in earth_ranger.get_events(filter=json_filter, batch_size=BATCH_SIZE):
-            transformed_events = transform_events_to_gundi_schema(events=event_batch)
-            if not transformed_events:
-                continue  # No data to send
-            logger.info(f"Sending {len(transformed_events)} events to Gundi...")
-            await send_events_to_gundi(events=transformed_events, integration_id=integration_id)
-            total_events += len(transformed_events)
-    # Update state
+            for er_event in event_batch:
+                er_event_uuid = er_event.get("id")
+                if not er_event_uuid:
+                    logger.warning("ER event payload missing 'id'; skipping.", extra={"event": er_event})
+                    continue
+                state_record = await state_manager.get_state(
+                    integration_id=integration_id,
+                    action_id="pull_events",
+                    source_id=er_event_uuid,
+                )
+                if not state_record.get("gundi_object_id"):
+                    # Never seen this ER event before → post it to Gundi as new.
+                    transformed = transform_events_to_gundi_schema(events=[er_event])
+                    if not transformed:
+                        continue
+                    response = await send_events_to_gundi(
+                        events=transformed, integration_id=integration_id
+                    )
+                    gundi_object_id = _extract_object_id_from_post_events_response(response)
+                    if not gundi_object_id:
+                        logger.error(
+                            "Could not extract object_id from post_events response; "
+                            "skipping state persistence for this event.",
+                            extra={"er_event_id": er_event_uuid, "response": response},
+                        )
+                        continue
+                    # Mark all existing notes as already-seen (no bulk-forward on first sight).
+                    note_ids = [n["id"] for n in er_event.get("notes") or [] if n.get("id")]
+                    await _save_event_state(
+                        integration_id=integration_id,
+                        er_event_uuid=er_event_uuid,
+                        gundi_object_id=gundi_object_id,
+                        er_event=er_event,
+                        seen_note_ids=note_ids,
+                    )
+                    events_new += 1
+                    continue
+
+                # Seen before. Defensive freshness check: same updated_at → no work to do.
+                if state_record.get("updated_at") == er_event.get("updated_at"):
+                    events_skipped_unchanged += 1
+                    continue
+
+                # Updated event → emit one update_event per detected change.
+                emitted, new_seen_note_ids = await _emit_event_updates(
+                    er_event=er_event,
+                    state_record=state_record,
+                    integration_id=integration_id,
+                )
+                updates_emitted += emitted
+                if emitted > 0:
+                    events_updated += 1
+                # Refresh state to reflect what we forwarded this run.
+                await _save_event_state(
+                    integration_id=integration_id,
+                    er_event_uuid=er_event_uuid,
+                    gundi_object_id=state_record["gundi_object_id"],
+                    er_event=er_event,
+                    seen_note_ids=new_seen_note_ids,
+                )
+    # Save watermark.
     state = {"last_execution": execution_timestamp}
-    logger.debug(f"Saving state for integration {integration}, action pull_events:\n{state}")
+    logger.debug(f"Saving watermark for integration {integration}, action pull_events:\n{state}")
     await state_manager.set_state(
         integration_id=integration_id,
         action_id="pull_events",
         state=state
     )
-    logger.info(f"Extracted {total_events} events.")
-    return {"events_extracted": total_events}
+    logger.info(
+        f"pull_events done. new={events_new} updated={events_updated} "
+        f"updates_emitted={updates_emitted} skipped_unchanged={events_skipped_unchanged}"
+    )
+    return {
+        "events_extracted": events_new,
+        "events_updated": events_updated,
+        "updates_emitted": updates_emitted,
+        "events_skipped_unchanged": events_skipped_unchanged,
+    }
 
 
 @activity_logger()
@@ -642,4 +710,91 @@ def transform_observations_to_gundi_schema(observations):
         else:
             transformed_data.append(transformed_observation)
     return transformed_data
+
+
+# Maps an ER event field name to the corresponding key the sensors-API
+# EventCreateUpdateSerializer accepts on PATCH (see cdip PR #428). For each
+# entry: (er_event_field, serializer_patch_field, state_record_key).
+_ER_FIELD_DIFF_MAP = (
+    ("state", "status", "state"),      # ER 'state' → cdip 'status'
+    ("priority", "priority", "priority"),
+    ("title", "title", "title"),
+)
+
+
+def _extract_object_id_from_post_events_response(response):
+    """Pull the Gundi-assigned object_id out of a post_events response.
+
+    post_events always wraps in a list on the wire — even for a single event —
+    so the response is normally a list of dicts. Be defensive about dict
+    responses too in case the API surface ever shifts.
+    """
+    if isinstance(response, list):
+        if not response:
+            return None
+        first = response[0]
+        if isinstance(first, dict):
+            return first.get("object_id")
+        return None
+    if isinstance(response, dict):
+        return response.get("object_id")
+    return None
+
+
+async def _save_event_state(integration_id, er_event_uuid, gundi_object_id, er_event, seen_note_ids):
+    """Persist per-event state under (pull_events, er_event_uuid)."""
+    await state_manager.set_state(
+        integration_id=integration_id,
+        action_id="pull_events",
+        source_id=er_event_uuid,
+        state={
+            "gundi_object_id": gundi_object_id,
+            "updated_at": er_event.get("updated_at"),
+            "state": er_event.get("state"),
+            "priority": er_event.get("priority"),
+            "title": er_event.get("title"),
+            "seen_note_ids": list(seen_note_ids),
+        },
+    )
+
+
+async def _emit_event_updates(er_event, state_record, integration_id):
+    """Emit one Gundi update_event per detected change on a previously-seen event.
+
+    Returns a tuple (emitted_count, new_seen_note_ids). The caller persists
+    the updated state after we return so a transient failure mid-loop leaves
+    the watermark untouched and the next run can re-detect.
+    """
+    gundi_object_id = state_record["gundi_object_id"]
+    seen_note_ids = list(state_record.get("seen_note_ids", []))
+    seen_set = set(seen_note_ids)
+    emitted = 0
+
+    # New notes — one update_event each, preserves author + timestamp per comment.
+    for note in er_event.get("notes") or []:
+        note_id = note.get("id")
+        if not note_id or note_id in seen_set:
+            continue
+        await update_event_in_gundi(
+            gundi_object_id=gundi_object_id,
+            changes={"notes": [note]},
+            integration_id=integration_id,
+        )
+        seen_note_ids.append(note_id)
+        seen_set.add(note_id)
+        emitted += 1
+
+    # Field changes — one update_event per changed field.
+    for er_field, patch_field, state_key in _ER_FIELD_DIFF_MAP:
+        new_value = er_event.get(er_field)
+        if new_value == state_record.get(state_key):
+            continue
+        await update_event_in_gundi(
+            gundi_object_id=gundi_object_id,
+            changes={patch_field: new_value},
+            integration_id=integration_id,
+        )
+        emitted += 1
+
+    return emitted, seen_note_ids
 

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -82,8 +82,15 @@ async def test_execute_pull_events_action(
     assert mock_state_manager.get_state.called
     assert mock_state_manager.set_state.called
     assert mock_erclient_class.return_value.get_events.called
-    assert mock_gundi_sensors_client_class.return_value.post_events.call_count == 2
-    assert response == {"events_extracted": len(events_batch_one) + len(events_batch_two)}
+    # One post_events per event now (per-event state lookup) — was batched before GUNDI-5386.
+    total = len(events_batch_one) + len(events_batch_two)
+    assert mock_gundi_sensors_client_class.return_value.post_events.call_count == total
+    assert response == {
+        "events_extracted": total,
+        "events_updated": 0,
+        "updates_emitted": 0,
+        "events_skipped_unchanged": 0,
+    }
 
 
 @pytest.mark.asyncio
@@ -693,3 +700,168 @@ async def test_show_permissions_surfaces_raw_slugs_and_uuids(
     # Slugs are sorted strings, not display names.
     assert data["Event Type Slugs"] == sorted(data["Event Type Slugs"])
     assert all(isinstance(uuid, str) for uuid in data["Subject Group UUIDs"])
+
+
+# ---------------------------------------------------------------------------
+# GUNDI-5386: pull_events new-vs-update branching
+# ---------------------------------------------------------------------------
+
+from app.actions.handlers import _emit_event_updates, _extract_object_id_from_post_events_response
+
+
+def test_extract_object_id_from_post_events_response():
+    """Pulls object_id out of the typical list-wrapped response, and degrades cleanly."""
+    assert _extract_object_id_from_post_events_response(
+        [{"object_id": "abc-123", "created_at": "..."}]
+    ) == "abc-123"
+    assert _extract_object_id_from_post_events_response(
+        {"object_id": "single-dict-fallback"}
+    ) == "single-dict-fallback"
+    assert _extract_object_id_from_post_events_response([]) is None
+    assert _extract_object_id_from_post_events_response(None) is None
+    assert _extract_object_id_from_post_events_response("not-json") is None
+
+
+@pytest.mark.asyncio
+async def test_emit_event_updates_for_new_note(mocker):
+    """A single new note in the ER event payload → one update_event_in_gundi call."""
+    mock_update = mocker.patch("app.actions.handlers.update_event_in_gundi")
+    mock_update.return_value = async_return({})
+    state_record = {
+        "gundi_object_id": "gundi-obj-1",
+        "updated_at": "2026-06-01T00:00:00Z",
+        "state": "active",
+        "priority": 100,
+        "title": "Snare check",
+        "seen_note_ids": ["note-a"],
+    }
+    er_event = {
+        "id": "er-uuid-1",
+        "updated_at": "2026-06-02T00:00:00Z",
+        "state": "active",
+        "priority": 100,
+        "title": "Snare check",
+        "notes": [
+            {"id": "note-a", "text": "old"},
+            {"id": "note-b", "text": "fresh observation"},
+        ],
+    }
+    emitted, new_seen = await _emit_event_updates(
+        er_event=er_event, state_record=state_record, integration_id="int-1"
+    )
+    assert emitted == 1
+    assert mock_update.call_count == 1
+    call_kwargs = mock_update.call_args.kwargs
+    assert call_kwargs["gundi_object_id"] == "gundi-obj-1"
+    assert call_kwargs["changes"] == {"notes": [{"id": "note-b", "text": "fresh observation"}]}
+    assert "note-a" in new_seen and "note-b" in new_seen
+
+
+@pytest.mark.asyncio
+async def test_emit_event_updates_for_field_changes(mocker):
+    """Status, priority, and title changes each emit a separate update_event."""
+    mock_update = mocker.patch("app.actions.handlers.update_event_in_gundi")
+    mock_update.return_value = async_return({})
+    state_record = {
+        "gundi_object_id": "gundi-obj-2",
+        "updated_at": "2026-06-01T00:00:00Z",
+        "state": "new",
+        "priority": 100,
+        "title": "Old title",
+        "seen_note_ids": [],
+    }
+    er_event = {
+        "id": "er-uuid-2",
+        "updated_at": "2026-06-02T00:00:00Z",
+        "state": "active",       # changed
+        "priority": 200,         # changed
+        "title": "New title",    # changed
+        "notes": [],
+    }
+    emitted, _ = await _emit_event_updates(
+        er_event=er_event, state_record=state_record, integration_id="int-2"
+    )
+    assert emitted == 3
+    # Each change goes into the PATCH body under the cdip-side field name (status, not state).
+    sent_changes = [c.kwargs["changes"] for c in mock_update.call_args_list]
+    assert {"status": "active"} in sent_changes
+    assert {"priority": 200} in sent_changes
+    assert {"title": "New title"} in sent_changes
+
+
+@pytest.mark.asyncio
+async def test_emit_event_updates_skips_when_nothing_changed(mocker):
+    """No new notes and no field diffs → zero update_event_in_gundi calls."""
+    mock_update = mocker.patch("app.actions.handlers.update_event_in_gundi")
+    mock_update.return_value = async_return({})
+    state_record = {
+        "gundi_object_id": "gundi-obj-3",
+        "updated_at": "2026-06-01T00:00:00Z",
+        "state": "active",
+        "priority": 100,
+        "title": "Snare check",
+        "seen_note_ids": ["note-x"],
+    }
+    er_event = {
+        "id": "er-uuid-3",
+        "updated_at": "2026-06-02T00:00:00Z",
+        "state": "active",
+        "priority": 100,
+        "title": "Snare check",
+        "notes": [{"id": "note-x", "text": "still here"}],
+    }
+    emitted, _ = await _emit_event_updates(
+        er_event=er_event, state_record=state_record, integration_id="int-3"
+    )
+    assert emitted == 0
+    mock_update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pull_events_skips_event_when_updated_at_unchanged(
+        mocker, mock_gundi_client_v2, mock_erclient_class,
+        mock_get_gundi_api_key, mock_gundi_sensors_client_class, er_integration_v2_provider,
+        mock_publish_event, mock_gundi_client_v2_class, mock_config_manager_er_provider,
+        events_batch_one
+):
+    """If a previously-seen ER event reappears with the same updated_at, we no-op."""
+    # State manager that returns a per-event record whose updated_at matches the first event.
+    first_event = events_batch_one[0]
+    mock_state_manager = mocker.MagicMock()
+
+    async def fake_get_state(integration_id, action_id, source_id="no-source"):
+        if source_id == first_event["id"]:
+            return {
+                "gundi_object_id": "gundi-obj-existing",
+                "updated_at": first_event["updated_at"],
+                "state": first_event.get("state"),
+                "priority": first_event.get("priority"),
+                "title": first_event.get("title"),
+                "seen_note_ids": [],
+            }
+        return {"last_execution": "2023-11-17T11:20:00+0200"}
+
+    mock_state_manager.get_state.side_effect = fake_get_state
+    mock_state_manager.set_state.return_value = async_return(None)
+    # Single-event batch keeps the test focused.
+    from app.actions.tests.conftest import AsyncIterator
+    mock_erclient_class.return_value.get_events.return_value = AsyncIterator([[first_event]])
+
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager_er_provider)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.actions.handlers.state_manager", mock_state_manager)
+    mocker.patch("app.actions.handlers.AsyncERClient", mock_erclient_class)
+    mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class)
+    mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
+
+    response = await execute_action(
+        integration_id=str(er_integration_v2_provider.id),
+        action_id="pull_events",
+    )
+
+    mock_gundi_sensors_client_class.return_value.post_events.assert_not_called()
+    assert response["events_skipped_unchanged"] == 1
+    assert response["events_extracted"] == 0

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -52,6 +52,33 @@ async def send_events_to_gundi(events: List[dict], **kwargs) -> dict:
 
 
 @stamina.retry(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0)
+async def update_event_in_gundi(gundi_object_id: str, changes: dict, **kwargs) -> dict:
+    """
+    PATCH an existing Gundi event by its Gundi-side object_id.
+
+    The `changes` dict is forwarded verbatim to the sensors API as the request
+    body. Each key is one of the fields accepted by EventCreateUpdateSerializer
+    (e.g. ``status``, ``priority``, ``title``, ``notes``); the values overwrite
+    the event's state. The same dict appears as ``changes`` on the downstream
+    EventUpdate that cdip-routing dispatches to destination integrations.
+
+    Per the GUNDI-5386 design, callers emit ONE update per logical change so
+    each shows up as a separate downstream comment.
+
+    :param gundi_object_id: The UUID Gundi returned when the original Event was
+        posted (stored in IntegrationStateManager per ER event UUID).
+    :param changes: Patch body. Examples: ``{"status": "active"}``,
+        ``{"priority": 200}``, ``{"notes": [{"id": ..., "text": ..., "author": ..., "created_at": ...}]}``.
+    :param kwargs: integration_id: The UUID of the related integration.
+    :return: The API response dict.
+    """
+    integration_id = kwargs.get("integration_id")
+    assert integration_id, "integration_id is required"
+    sensors_api_client = await _get_sensors_api_client(integration_id=str(integration_id))
+    return await sensors_api_client.update_event(event_id=gundi_object_id, data=changes)
+
+
+@stamina.retry(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0)
 async def send_event_attachments_to_gundi(event_id: str, attachments: List[tuple], **kwargs) -> dict:
     """
     Send Event Attachments to Gundi using the REST API v2


### PR DESCRIPTION
## Summary

Implements the EarthRanger-side half of [GUNDI-5386](https://allenai.atlassian.net/browse/GUNDI-5386). The pull_events action now distinguishes never-seen events from edits to previously-forwarded events, and emits one Gundi `sender.update_event()` PATCH per detected change.

This depends on **cdip PR #428** (already merged), which extended `EventCreateUpdateSerializer` with `priority` and `notes` write-only fields. The CMORE-side half (consume EventUpdate → post comment) lands in a follow-up PR against `gundi-integration-cmore`.

## How detection works

Per-event state in Redis keyed by ER event UUID:

```
key:   integration_state.{integration_id}.pull_events.{er_event_uuid}
value: {
    "gundi_object_id":  uuid Gundi returned at first post_events,
    "updated_at":       last-forwarded ER event.updated_at,
    "state":            last-forwarded ER state,
    "priority":         last-forwarded ER priority,
    "title":            last-forwarded ER title,
    "seen_note_ids":    [note IDs already forwarded]
}
```

Per event in a pulled batch:

| Condition | Action |
|---|---|
| No state record yet | post to Gundi as new event; seed state with all current note IDs marked "already seen" (no bulk-forward of historical notes) |
| State record present, `updated_at` unchanged | no-op (defensive — ER's update_date filter window can re-return unchanged rows) |
| State record present, newer `updated_at` | emit one `sender.update_event()` PATCH per change: one per new note, one per changed state/priority/title field |

## PATCH bodies sent to Gundi

| Change | PATCH body |
|---|---|
| New note | `{"notes": [<full note dict>]}` |
| Status changed | `{"status": "active"}` (cdip-side name for ER's `state`) |
| Priority changed | `{"priority": 200}` |
| Title changed | `{"title": "..."}` |

Each PATCH triggers cdip to publish a downstream `EventUpdateReceived` system event (auto-published by `EventCreateUpdateSerializer.update()` → `send_event_update_to_routing()`), which cdip-routing dispatches to the CMORE runner via the generic-model path.

## Failure semantics (acceptable trade-off for v1)

State is saved at the end of processing each event, not incrementally between emissions. If `update_event_in_gundi` raises after some changes have been forwarded but before all are done, the next pull will re-emit the surviving changes plus the failed one — potentially duplicating already-posted comments on the CMORE side. Acceptable because: stamina retries handle transient HTTP errors automatically, the failure mode is rare, and Gundi events are idempotent at the event-id level (only the comment burst on CMORE would duplicate, and operators can clean up manually if it happens).

## Test plan

- [x] **89 tests pass locally.** Suite includes 5 new tests:
  - `test_extract_object_id_from_post_events_response` — defensive unwrap covering list-wrapped, single-dict, empty, None, and garbage responses
  - `test_emit_event_updates_for_new_note` — one new note → one PATCH with `{"notes": [<note>]}`
  - `test_emit_event_updates_for_field_changes` — status/priority/title changes → 3 separate PATCHes with cdip-side field names
  - `test_emit_event_updates_skips_when_nothing_changed` — same-state event → zero PATCHes
  - `test_pull_events_skips_event_when_updated_at_unchanged` — same `updated_at` round-trip → response counts the event as `skipped_unchanged`
- [x] Existing `test_execute_pull_events_action` updated to the new per-event call shape (one `post_events` per event in the batch; expanded response dict).
- [ ] CI green
- [ ] Smoke against dev: post a new ER event, observe Gundi trace; edit status, observe an `EventUpdate` with `changes={"status": "..."}` on the routing topic.

## Response shape (was → is)

Before:
```python
{"events_extracted": N}
```

After:
```python
{
    "events_extracted": <new-event count>,
    "events_updated": <distinct events with at least one change>,
    "updates_emitted": <total update_event calls>,
    "events_skipped_unchanged": <events with same updated_at>,
}
```

## Out of scope

- CMORE-side EventUpdate consumption + comment formatting — separate PR against `gundi-integration-cmore`.
- TTL/cleanup for old per-event state records — listed under the GUNDI-5386 acceptance criteria but kept out of this PR; either Redis TTL on each set or a periodic prune action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GUNDI-5386]: https://allenai.atlassian.net/browse/GUNDI-5386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ