### PR TITLE
Resolve event_type / event_category slugs to ER UUIDs before filtering

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -2,6 +2,8 @@ import json
 import datetime
 import logging
 from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict
 from urllib.parse import urlparse
 
 import httpx
@@ -398,20 +400,6 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
         start_datetime = pull_config.start_datetime
     else:
         start_datetime = last_execution
-    date_filter_key = ER_EVENT_FILTER_KEY_BY_DATE_FIELD[pull_config.filter_date_field]
-    event_filter = {
-        date_filter_key: {
-            "lower": start_datetime
-        }
-    }
-    if pull_config.end_datetime:
-        event_filter[date_filter_key]["upper"] = pull_config.end_datetime
-    if pull_config.event_types:
-        event_filter["event_type"] = pull_config.event_types
-    if pull_config.event_categories:
-        event_filter["event_category"] = pull_config.event_categories
-    json_filter = json.dumps(event_filter)
-    logger.info(f"Extracting events with filter '{event_filter}'...")
     # Process events in batches. Per-event state in Redis (keyed by ER event UUID)
     # distinguishes never-seen events (post as new) from previously-forwarded events
     # whose updated_at has advanced (emit one update_event per detected change).
@@ -420,12 +408,81 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
     updates_emitted = 0  # individual update_event calls (notes + field changes)
     events_skipped_unchanged = 0
     async with er_client as earth_ranger:
-        # Build a {slug → display} map once per pull so titleless events can fall back
-        # to a human-readable event-type name ("Poacher Sighting Report") instead of
-        # the raw slug ("poacher_sighting_rep") on downstream destinations like CMORE.
-        # Best-effort: if the lookup fails (e.g. credentials lack the permission), we
-        # degrade to slug-only and log a warning rather than failing the whole pull.
-        event_type_display_by_slug = await _fetch_event_type_display_map(earth_ranger)
+        # One get_event_types() call powers two things:
+        #   1) Operator-configured event_type / event_category slugs must be
+        #      resolved to UUIDs before being sent in the ER filter blob —
+        #      ER filters by event_type__id__in, not by slug.
+        #   2) Titleless events fall back to the EventType display name.
+        # Best-effort: if the lookup fails we degrade gracefully.
+        event_type_maps = await _fetch_event_type_maps(earth_ranger)
+        event_type_display_by_slug = event_type_maps.display_by_slug
+
+        # Resolve configured slugs → ER UUIDs for the filter.
+        resolved_type_ids, unresolved_types = _resolve_slugs(
+            pull_config.event_types, event_type_maps.id_by_slug
+        )
+        resolved_category_ids, unresolved_categories = _resolve_slugs(
+            pull_config.event_categories, event_type_maps.category_id_by_slug
+        )
+        if unresolved_types or unresolved_categories:
+            await log_action_activity(
+                integration_id=integration_id,
+                action_id="pull_events",
+                title="Some configured event-type/category slugs do not exist on this ER instance",
+                level=LogLevel.WARNING,
+                data={
+                    "unresolved_event_types": unresolved_types,
+                    "unresolved_event_categories": unresolved_categories,
+                },
+            )
+        # If the operator configured filters and NONE resolve, the safer action
+        # is to skip the pull rather than silently fetch everything (which is
+        # what ER does when the filter blob is dropped). Watermark is NOT
+        # advanced so a fix to the typo / permission can re-pull the window.
+        if pull_config.event_types and not resolved_type_ids:
+            await log_action_activity(
+                integration_id=integration_id,
+                action_id="pull_events",
+                title="No configured event_types resolved to ER UUIDs; skipping pull",
+                level=LogLevel.ERROR,
+                data={"configured_event_types": list(pull_config.event_types)},
+            )
+            return {
+                "events_extracted": 0,
+                "events_updated": 0,
+                "updates_emitted": 0,
+                "events_skipped_unchanged": 0,
+                "skipped_reason": "no_resolvable_event_types",
+            }
+        if pull_config.event_categories and not resolved_category_ids:
+            await log_action_activity(
+                integration_id=integration_id,
+                action_id="pull_events",
+                title="No configured event_categories resolved to ER UUIDs; skipping pull",
+                level=LogLevel.ERROR,
+                data={"configured_event_categories": list(pull_config.event_categories)},
+            )
+            return {
+                "events_extracted": 0,
+                "events_updated": 0,
+                "updates_emitted": 0,
+                "events_skipped_unchanged": 0,
+                "skipped_reason": "no_resolvable_event_categories",
+            }
+
+        date_filter_key = ER_EVENT_FILTER_KEY_BY_DATE_FIELD[pull_config.filter_date_field]
+        event_filter = {
+            date_filter_key: {"lower": start_datetime}
+        }
+        if pull_config.end_datetime:
+            event_filter[date_filter_key]["upper"] = pull_config.end_datetime
+        if resolved_type_ids:
+            event_filter["event_type"] = resolved_type_ids
+        if resolved_category_ids:
+            event_filter["event_category"] = resolved_category_ids
+        json_filter = json.dumps(event_filter)
+        logger.info(f"Extracting events with filter '{event_filter}'...")
+
         async for event_batch in earth_ranger.get_events(filter=json_filter, batch_size=BATCH_SIZE):
             for er_event in event_batch:
                 er_event_uuid = er_event.get("id")
@@ -653,28 +710,77 @@ def get_authentication_config(integration):
     return AuthenticateConfig.parse_obj(auth_action_config.data)
 
 
-async def _fetch_event_type_display_map(er_client):
-    """Build a {slug: display_name} map from ER's event-types endpoint.
+@dataclass
+class EventTypeMaps:
+    """Three lookup tables derived from a single ER get_event_types() call.
 
-    Used as a fallback so events missing their own title get a human-readable
-    label downstream (e.g. "Poacher Sighting Report") rather than the raw slug
-    ("poacher_sighting_rep"). Returns an empty dict on any failure — the caller
-    treats this as best-effort.
+    - ``display_by_slug``: slug → human-readable display name. Used as the
+      title fallback when an ER event has no title of its own.
+    - ``id_by_slug``: slug → ER EventType UUID. ER's events endpoint filters
+      by ``event_type__id__in`` (UUIDs), not by slug, so operator-supplied
+      slugs must be resolved before being sent in the filter blob.
+    - ``category_id_by_slug``: category slug → ER EventCategory UUID. Same
+      story for ``event_type__category__id__in``.
+    """
+    display_by_slug: Dict[str, str] = field(default_factory=dict)
+    id_by_slug: Dict[str, str] = field(default_factory=dict)
+    category_id_by_slug: Dict[str, str] = field(default_factory=dict)
+
+
+async def _fetch_event_type_maps(er_client) -> EventTypeMaps:
+    """Build slug→display, slug→type_id, and category_slug→category_id maps
+    from a single ER get_event_types() call.
+
+    Best-effort: if the lookup fails (e.g. credentials lack the permission to
+    read event types), returns an empty ``EventTypeMaps`` and logs a warning.
+    Downstream behavior on empty maps:
+
+    - Titleless events fall back to the event_type slug (existing behavior).
+    - Operator-configured filter slugs that can't resolve get a WARNING; if
+      ALL configured slugs are unresolvable, the pull is skipped entirely
+      rather than silently fetching everything.
     """
     try:
         event_types = await er_client.get_event_types()
     except Exception as e:
         logger.warning(
-            "Could not fetch ER event types for title-fallback map: %s: %s. "
-            "Titleless events will fall back to the event_type slug.",
+            "Could not fetch ER event types: %s: %s. "
+            "Operator-configured filter slugs will not resolve and titleless "
+            "events will fall back to the event_type slug.",
             type(e).__name__, e,
         )
-        return {}
-    return {
-        et["value"]: et.get("display")
-        for et in event_types
-        if et.get("value") and et.get("display")
-    }
+        return EventTypeMaps()
+
+    maps = EventTypeMaps()
+    for et in event_types:
+        slug = et.get("value")
+        if not slug:
+            continue
+        if et.get("display"):
+            maps.display_by_slug[slug] = et["display"]
+        if et.get("id"):
+            maps.id_by_slug[slug] = et["id"]
+        category = et.get("category") or {}
+        cat_slug = category.get("value")
+        cat_id = category.get("id")
+        if cat_slug and cat_id:
+            maps.category_id_by_slug[cat_slug] = cat_id
+    return maps
+
+
+def _resolve_slugs(configured_slugs, slug_to_id):
+    """Split ``configured_slugs`` into (resolved_ids, unresolved_slugs).
+
+    Used for both event_types and event_categories — same shape on both sides.
+    """
+    resolved = []
+    unresolved = []
+    for slug in configured_slugs:
+        if slug in slug_to_id:
+            resolved.append(slug_to_id[slug])
+        else:
+            unresolved.append(slug)
+    return resolved, unresolved
 
 
 def transform_events_to_gundi_schema(events, event_type_display_by_slug=None):

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -1,5 +1,8 @@
+import json
+
 import pytest
 from erclient import ERClientPermissionDenied
+from gundi_core.events import LogLevel
 
 from app.conftest import async_return
 from app.services.action_runner import execute_action
@@ -394,11 +397,16 @@ async def test_pull_events_event_type_and_category_filter_passed_to_er(
         mock_get_gundi_api_key, mock_gundi_sensors_client_class, er_integration_v2_provider,
         mock_publish_event, mock_gundi_client_v2_class, mock_config_manager_er_provider
 ):
-    """The configured event_types / event_categories are injected into the ER filter dict."""
+    """Operator-supplied event_type / event_category slugs are resolved to ER UUIDs
+    via get_event_types() and the UUIDs (not the slugs) are sent in the filter blob."""
     import json
     pull_events_data = er_integration_v2_provider.get_action_config("pull_events").data
-    pull_events_data["event_types"] = ["poacher_sighting_rep", "wildlife_sighting_rep"]
-    pull_events_data["event_categories"] = ["wildlife"]
+    # These slugs exist in the get_event_types_response conftest fixture:
+    #   wildlife_sighting → id 0ae08721-6b7c-4d5e-aeda-cb3d1a38926f
+    #   mapipedia_activity_rep → id cdcf6a31-5d64-4a5c-8bf9-bf7d146363d0
+    #   category "monitoring" → id 6b359461-aa53-4116-bf2c-04cc580de4ef
+    pull_events_data["event_types"] = ["wildlife_sighting", "mapipedia_activity_rep"]
+    pull_events_data["event_categories"] = ["monitoring"]
 
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
     mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
@@ -416,8 +424,15 @@ async def test_pull_events_event_type_and_category_filter_passed_to_er(
     )
 
     er_filter = json.loads(mock_erclient_class.return_value.get_events.call_args.kwargs["filter"])
-    assert er_filter["event_type"] == ["poacher_sighting_rep", "wildlife_sighting_rep"]
-    assert er_filter["event_category"] == ["wildlife"]
+    # The filter carries the resolved UUIDs from the fixture, NOT the operator's
+    # slugs — ER's events endpoint filters by event_type__id__in (UUIDs), so
+    # passing raw slugs would have ER silently drop the filter and return
+    # everything matching only the date window (the bug this test now guards).
+    assert set(er_filter["event_type"]) == {
+        "0ae08721-6b7c-4d5e-aeda-cb3d1a38926f",     # wildlife_sighting
+        "cdcf6a31-5d64-4a5c-8bf9-bf7d146363d0",     # mapipedia_activity_rep
+    }
+    assert er_filter["event_category"] == ["6b359461-aa53-4116-bf2c-04cc580de4ef"]  # monitoring
 
 
 @pytest.mark.parametrize(
@@ -873,7 +888,9 @@ async def test_pull_events_skips_event_when_updated_at_unchanged(
 # ---------------------------------------------------------------------------
 
 from app.actions.handlers import (
-    _fetch_event_type_display_map,
+    EventTypeMaps,
+    _fetch_event_type_maps,
+    _resolve_slugs,
     transform_events_to_gundi_schema,
 )
 
@@ -923,35 +940,59 @@ def test_transform_events_no_display_map_arg_matches_prior_behavior():
 
 
 @pytest.mark.asyncio
-async def test_fetch_event_type_display_map_builds_dict(mocker):
+async def test_fetch_event_type_maps_builds_all_three_lookups(mocker):
+    """One get_event_types() call should populate display, type-id, and
+    category-id maps from the same payload."""
     er_client = mocker.MagicMock()
 
     async def fake_get_event_types():
         return [
-            {"value": "poacher_sighting_rep", "display": "Poacher Sighting Report"},
-            {"value": "wildlife_sighting_rep", "display": "Wildlife Sighting Report"},
-            # Entries missing either field are skipped.
-            {"value": "no_display_rep"},
-            {"display": "No Slug"},
+            {
+                "value": "poacher_sighting_rep",
+                "display": "Poacher Sighting Report",
+                "id": "type-uuid-1",
+                "category": {"value": "security", "id": "cat-uuid-1", "is_active": True},
+            },
+            {
+                "value": "wildlife_sighting_rep",
+                "display": "Wildlife Sighting Report",
+                "id": "type-uuid-2",
+                "category": {"value": "wildlife", "id": "cat-uuid-2", "is_active": True},
+            },
+            # Entry missing display still contributes to id_by_slug and category map.
+            {
+                "value": "no_display_rep",
+                "id": "type-uuid-3",
+                "category": {"value": "wildlife", "id": "cat-uuid-2"},
+            },
+            # Entry missing slug is skipped entirely.
+            {"display": "No Slug", "id": "type-uuid-x"},
         ]
 
     er_client.get_event_types = fake_get_event_types
-    result = await _fetch_event_type_display_map(er_client)
-    assert result == {
+    maps = await _fetch_event_type_maps(er_client)
+    assert maps.display_by_slug == {
         "poacher_sighting_rep": "Poacher Sighting Report",
         "wildlife_sighting_rep": "Wildlife Sighting Report",
+    }
+    assert maps.id_by_slug == {
+        "poacher_sighting_rep": "type-uuid-1",
+        "wildlife_sighting_rep": "type-uuid-2",
+        "no_display_rep": "type-uuid-3",
+    }
+    # Categories dedupe — "wildlife" appears twice but maps to one UUID.
+    assert maps.category_id_by_slug == {
+        "security": "cat-uuid-1",
+        "wildlife": "cat-uuid-2",
     }
 
 
 @pytest.mark.asyncio
-async def test_fetch_event_type_display_map_degrades_to_empty_on_403(mocker):
-    """If get_event_types fails with a 403 we degrade to an empty map (callers
-    then fall back to the event_type slug)."""
+async def test_fetch_event_type_maps_degrades_to_empty_on_403(mocker):
+    """If get_event_types fails with a 403 all three maps are empty."""
     er_client = mocker.MagicMock()
 
     async def boom():
-        # Mirror what erclient raises in production when the integration's
-        # credentials lack the 'eventtype:view' permission.
         raise ERClientPermissionDenied(
             "ER Forbidden ON GET https://gundi-er.pamdas.org/api/v1.0/activity/events/eventtypes.",
             status_code=403,
@@ -959,8 +1000,26 @@ async def test_fetch_event_type_display_map_degrades_to_empty_on_403(mocker):
         )
 
     er_client.get_event_types = boom
-    result = await _fetch_event_type_display_map(er_client)
-    assert result == {}
+    maps = await _fetch_event_type_maps(er_client)
+    assert isinstance(maps, EventTypeMaps)
+    assert maps.display_by_slug == {}
+    assert maps.id_by_slug == {}
+    assert maps.category_id_by_slug == {}
+
+
+def test_resolve_slugs_splits_known_from_unknown():
+    """Known slugs map to their IDs; unknowns surface separately for the WARN log."""
+    resolved, unresolved = _resolve_slugs(
+        ["a", "typo", "b"], {"a": "id-a", "b": "id-b", "c": "id-c"}
+    )
+    assert resolved == ["id-a", "id-b"]
+    assert unresolved == ["typo"]
+
+
+def test_resolve_slugs_with_empty_inputs():
+    """Both axes use this helper; empty config + empty map should noop cleanly."""
+    assert _resolve_slugs([], {"a": "id"}) == ([], [])
+    assert _resolve_slugs(["a"], {}) == ([], ["a"])
 
 
 @pytest.mark.asyncio
@@ -1014,3 +1073,86 @@ async def test_pull_events_falls_back_to_slug_when_event_types_unavailable(
     assert len(post_events_calls) == 1
     posted = post_events_calls[0].kwargs["data"]
     assert posted[0]["title"] == "poacher_sighting_rep"
+
+
+@pytest.mark.asyncio
+async def test_pull_events_skips_when_all_event_type_slugs_unresolvable(
+        mocker, mock_gundi_client_v2, mock_state_manager, mock_erclient_class,
+        mock_get_gundi_api_key, mock_gundi_sensors_client_class, er_integration_v2_provider,
+        mock_publish_event, mock_gundi_client_v2_class, mock_config_manager_er_provider,
+):
+    """If every configured event_type slug fails to resolve, skip the pull and
+    log ERROR — rather than silently fetching everything because ER drops
+    invalid filter blobs."""
+    pull_events_data = er_integration_v2_provider.get_action_config("pull_events").data
+    pull_events_data["event_types"] = ["typo_one", "typo_two"]
+    pull_events_data["event_categories"] = []
+
+    mock_log = mocker.patch("app.actions.handlers.log_action_activity")
+    mock_log.return_value = async_return(None)
+
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager_er_provider)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.actions.handlers.state_manager", mock_state_manager)
+    mocker.patch("app.actions.handlers.AsyncERClient", mock_erclient_class)
+    mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class)
+    mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
+
+    response = await execute_action(
+        integration_id=str(er_integration_v2_provider.id),
+        action_id="pull_events",
+    )
+
+    mock_erclient_class.return_value.get_events.assert_not_called()
+    mock_state_manager.set_state.assert_not_called()  # watermark NOT advanced
+    assert response["skipped_reason"] == "no_resolvable_event_types"
+    # An ERROR-level activity log named the typoed slugs so ops can fix it.
+    error_log = next(
+        c for c in mock_log.call_args_list
+        if c.kwargs.get("level") == LogLevel.ERROR
+    )
+    assert error_log.kwargs["data"]["configured_event_types"] == ["typo_one", "typo_two"]
+
+
+@pytest.mark.asyncio
+async def test_pull_events_warns_about_partially_unresolvable_slugs(
+        mocker, mock_gundi_client_v2, mock_state_manager, mock_erclient_class,
+        mock_get_gundi_api_key, mock_gundi_sensors_client_class, er_integration_v2_provider,
+        mock_publish_event, mock_gundi_client_v2_class, mock_config_manager_er_provider,
+):
+    """A mix of known-good and typoed slugs logs a WARNING and proceeds with
+    the known-good ones (better than failing the whole pull)."""
+    pull_events_data = er_integration_v2_provider.get_action_config("pull_events").data
+    pull_events_data["event_types"] = ["wildlife_sighting", "typo_slug"]
+    pull_events_data["event_categories"] = []
+
+    mock_log = mocker.patch("app.actions.handlers.log_action_activity")
+    mock_log.return_value = async_return(None)
+
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager_er_provider)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.actions.handlers.state_manager", mock_state_manager)
+    mocker.patch("app.actions.handlers.AsyncERClient", mock_erclient_class)
+    mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class)
+    mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
+
+    await execute_action(
+        integration_id=str(er_integration_v2_provider.id),
+        action_id="pull_events",
+    )
+
+    # We DID call get_events — with the one resolvable slug's UUID in the filter.
+    er_filter = json.loads(mock_erclient_class.return_value.get_events.call_args.kwargs["filter"])
+    assert er_filter["event_type"] == ["0ae08721-6b7c-4d5e-aeda-cb3d1a38926f"]
+    # And we surfaced the typoed slug via a WARNING activity log.
+    warning_log = next(
+        c for c in mock_log.call_args_list
+        if c.kwargs.get("level") == LogLevel.WARNING
+    )
+    assert warning_log.kwargs["data"]["unresolved_event_types"] == ["typo_slug"]


### PR DESCRIPTION
## Why

Dev-smoke for GUNDI-5386 turned up the symptom: configuring `event_types=["coyote_carcass"]` on the ER provider resulted in events of every type reaching CMORE. The filter was being ignored.

Root cause: ER's `/activity/events` endpoint filter takes UUIDs, not slugs:

```python
# das-old/das/activity/models.py:597
if filter.get("event_type"):
    queryset = queryset.filter(event_type__id__in=filter.get("event_type"))
```

The runner was sending `["coyote_carcass"]` (slugs) where ER expected `["c119f06d-…"]` (UUIDs). ER silently drops the bad filter and returns everything matching only the date window.

## What changed

Refactored `_fetch_event_type_display_map` into `_fetch_event_type_maps`, which now builds three lookups from a single `get_event_types()` call:

| Map | Purpose |
|---|---|
| `display_by_slug` | Existing — title fallback for titleless events (PR #16) |
| `id_by_slug` | **NEW** — slug → event-type UUID for the ER filter |
| `category_id_by_slug` | **NEW** — slug → category UUID for the ER filter |

`action_pull_events` resolves operator-supplied slugs before constructing the filter blob.

## Failure-mode policies

| Scenario | Behavior |
|---|---|
| All configured slugs resolve | Filter uses UUIDs. Same intent, correct semantics. |
| Some slugs resolve, others don't | `LogLevel.WARNING` activity log naming the typoed slugs. Proceed with the resolved ones. |
| Configured axis is non-empty but resolves to ZERO | `LogLevel.ERROR` activity log. **Skip the pull** and do NOT advance the watermark — so fixing the typo / restoring permission can re-pull the missed window. |
| `get_event_types()` itself raises (e.g. 403) | Maps come back empty → same skip-with-ERROR as above. Existing title-fallback degradation preserved. |

## Tests

**101 passing** (was 97 on PR #16; +4 net new + 1 updated):

- `test_fetch_event_type_maps_builds_all_three_lookups` — one fetch, all three maps populated.
- `test_fetch_event_type_maps_degrades_to_empty_on_403` — failure path.
- `test_resolve_slugs_splits_known_from_unknown` + empty-inputs variant.
- `test_pull_events_skips_when_all_event_type_slugs_unresolvable` — full handler skip + ERROR log + no `get_events` call + no `set_state`.
- `test_pull_events_warns_about_partially_unresolvable_slugs` — proceeds with resolved UUIDs, WARN log surfaces the typo.
- Pre-existing `test_pull_events_event_type_and_category_filter_passed_to_er` updated to assert filter contains UUIDs (`0ae08721-…`, `cdcf6a31-…`, `6b359461-…`), not slugs. **This is the test that would have caught the original bug.**

## Smoke test plan

- [ ] Merge + deploy to dev
- [ ] On the ER integration configured with `event_types=["coyote_carcass"]`, trigger a pull
- [ ] Tail runner logs — verify the `"Extracting events with filter '..."` INFO line shows the resolved UUID, not the slug
- [ ] Only coyote_carcass events reach CMORE; other types are filtered out at ER
- [ ] Bonus: add a typo in the config, verify WARN activity log surfaces it without breaking the pull

🤖 Generated with [Claude Code](https://claude.com/claude-code)