### PR TITLE
Resolve slugs from both v1 and v2 ER event-type endpoints

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 
 import httpx
 import stamina
-from erclient import AsyncERClient, ERClientException
+from erclient import AsyncERClient, ERClientException, VERSION_1_0, VERSION_2_0
 from erclient.er_errors import ERClientBadCredentials
 from gundi_client_v2.client import GundiClient
 from gundi_core.events import LogLevel
@@ -728,44 +728,95 @@ class EventTypeMaps:
 
 
 async def _fetch_event_type_maps(er_client) -> EventTypeMaps:
-    """Build slug→display, slug→type_id, and category_slug→category_id maps
-    from a single ER get_event_types() call.
+    """Build slug→display, slug→type_id, and category_slug→category_id maps.
 
-    Best-effort: if the lookup fails (e.g. credentials lack the permission to
-    read event types), returns an empty ``EventTypeMaps`` and logs a warning.
-    Downstream behavior on empty maps:
+    ER's EventType has a ``version`` field — each type is exclusively v1 OR
+    v2 — and the two list endpoints filter to their own version only:
 
-    - Titleless events fall back to the event_type slug (existing behavior).
-    - Operator-configured filter slugs that can't resolve get a WARNING; if
-      ALL configured slugs are unresolvable, the pull is skipped entirely
-      rather than silently fetching everything.
+    - ``GET /api/v1.0/activity/events/eventtypes``  (filter: version=v1)
+    - ``GET /api/v2.0/activity/eventtypes``         (filter: version=v2)
+
+    Neither endpoint returns the other version's types, so we query both and
+    merge. v1 responses carry a nested category dict (`id`, `value`, ...);
+    v2 responses carry only the category slug. As a fallback for category
+    UUIDs we hit ``GET /activity/events/categories`` if the merged maps
+    haven't already populated ``category_id_by_slug`` (e.g. an ER instance
+    with only v2 event types).
+
+    All three fetches are best-effort and logged independently — a 403 on
+    one doesn't break the others. If everything fails, all maps are empty;
+    downstream callers treat that as the "skip the pull" signal.
     """
+    maps = EventTypeMaps()
+
     try:
-        event_types = await er_client.get_event_types()
+        v1_types = await er_client.get_event_types(version=VERSION_1_0)
     except Exception as e:
         logger.warning(
-            "Could not fetch ER event types: %s: %s. "
-            "Operator-configured filter slugs will not resolve and titleless "
-            "events will fall back to the event_type slug.",
+            "Could not fetch ER v1 event types: %s: %s. "
+            "Slug→UUID resolution will fall back to v2-only results.",
             type(e).__name__, e,
         )
-        return EventTypeMaps()
+    else:
+        for et in v1_types:
+            _absorb_event_type(maps, et, with_category=True)
 
-    maps = EventTypeMaps()
-    for et in event_types:
-        slug = et.get("value")
-        if not slug:
-            continue
-        if et.get("display"):
-            maps.display_by_slug[slug] = et["display"]
-        if et.get("id"):
-            maps.id_by_slug[slug] = et["id"]
-        category = et.get("category") or {}
-        cat_slug = category.get("value")
-        cat_id = category.get("id")
-        if cat_slug and cat_id:
-            maps.category_id_by_slug[cat_slug] = cat_id
+    try:
+        v2_types = await er_client.get_event_types(version=VERSION_2_0)
+    except Exception as e:
+        logger.warning(
+            "Could not fetch ER v2 event types: %s: %s. "
+            "Slug→UUID resolution will fall back to v1-only results.",
+            type(e).__name__, e,
+        )
+    else:
+        for et in v2_types:
+            # v2 carries category as a bare slug, not as a nested object —
+            # we resolve category UUIDs separately below.
+            _absorb_event_type(maps, et, with_category=False)
+
+    # If we got no category UUIDs from the v1 event types (e.g. ER has only
+    # v2 types defined), the canonical categories endpoint fills the gap.
+    if not maps.category_id_by_slug:
+        try:
+            categories = await er_client.get_event_categories()
+        except Exception as e:
+            logger.warning(
+                "Could not fetch ER event categories: %s: %s. "
+                "event_category filter slugs will not resolve.",
+                type(e).__name__, e,
+            )
+        else:
+            for cat in categories:
+                cat_slug = cat.get("value")
+                cat_id = cat.get("id")
+                if cat_slug and cat_id:
+                    maps.category_id_by_slug.setdefault(cat_slug, cat_id)
+
     return maps
+
+
+def _absorb_event_type(maps: EventTypeMaps, et: dict, *, with_category: bool) -> None:
+    """Merge one ER event-type record into the shared maps.
+
+    Uses ``setdefault`` so v1 and v2 entries for the same slug (shouldn't
+    happen — version is exclusive — but be defensive) don't clobber each
+    other; first-seen wins.
+    """
+    slug = et.get("value")
+    if not slug:
+        return
+    if et.get("display"):
+        maps.display_by_slug.setdefault(slug, et["display"])
+    if et.get("id"):
+        maps.id_by_slug.setdefault(slug, et["id"])
+    if with_category:
+        category = et.get("category") or {}
+        if isinstance(category, dict):
+            cat_slug = category.get("value")
+            cat_id = category.get("id")
+            if cat_slug and cat_id:
+                maps.category_id_by_slug.setdefault(cat_slug, cat_id)
 
 
 def _resolve_slugs(configured_slugs, slug_to_id):

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -940,66 +940,134 @@ def test_transform_events_no_display_map_arg_matches_prior_behavior():
 
 
 @pytest.mark.asyncio
-async def test_fetch_event_type_maps_builds_all_three_lookups(mocker):
-    """One get_event_types() call should populate display, type-id, and
-    category-id maps from the same payload."""
+async def test_fetch_event_type_maps_merges_v1_and_v2(mocker):
+    """ER's v1 and v2 event-type endpoints each return only their own version's
+    types. The helper queries both and merges, with v1 contributing category
+    UUIDs (nested object) and v2 contributing slug→id mappings for v2-only types."""
+    from erclient import VERSION_1_0, VERSION_2_0
     er_client = mocker.MagicMock()
 
-    async def fake_get_event_types():
-        return [
-            {
-                "value": "poacher_sighting_rep",
-                "display": "Poacher Sighting Report",
-                "id": "type-uuid-1",
-                "category": {"value": "security", "id": "cat-uuid-1", "is_active": True},
-            },
-            {
-                "value": "wildlife_sighting_rep",
-                "display": "Wildlife Sighting Report",
-                "id": "type-uuid-2",
-                "category": {"value": "wildlife", "id": "cat-uuid-2", "is_active": True},
-            },
-            # Entry missing display still contributes to id_by_slug and category map.
-            {
-                "value": "no_display_rep",
-                "id": "type-uuid-3",
-                "category": {"value": "wildlife", "id": "cat-uuid-2"},
-            },
-            # Entry missing slug is skipped entirely.
-            {"display": "No Slug", "id": "type-uuid-x"},
-        ]
+    async def fake_get_event_types(version=VERSION_1_0, **kwargs):
+        if version == VERSION_1_0:
+            return [
+                {
+                    "value": "wildlife_sighting_rep",
+                    "display": "Wildlife Sighting Report",
+                    "id": "v1-type-uuid",
+                    "category": {"value": "wildlife", "id": "cat-uuid-w", "is_active": True},
+                },
+            ]
+        if version == VERSION_2_0:
+            return [
+                # v2 carries category as a bare slug, not a nested dict.
+                {
+                    "value": "coyote_carcass",
+                    "display": "Coyote Carcass",
+                    "id": "v2-type-uuid",
+                    "category": "wildlife",
+                },
+            ]
+        return []
 
     er_client.get_event_types = fake_get_event_types
     maps = await _fetch_event_type_maps(er_client)
+    # Both versions contribute to display + id maps.
     assert maps.display_by_slug == {
-        "poacher_sighting_rep": "Poacher Sighting Report",
         "wildlife_sighting_rep": "Wildlife Sighting Report",
+        "coyote_carcass": "Coyote Carcass",
     }
     assert maps.id_by_slug == {
-        "poacher_sighting_rep": "type-uuid-1",
-        "wildlife_sighting_rep": "type-uuid-2",
-        "no_display_rep": "type-uuid-3",
+        "wildlife_sighting_rep": "v1-type-uuid",
+        "coyote_carcass": "v2-type-uuid",
     }
-    # Categories dedupe — "wildlife" appears twice but maps to one UUID.
+    # v1's nested category dict populates category_id_by_slug; the v2 fetch
+    # didn't need to fall back to get_event_categories.
+    assert maps.category_id_by_slug == {"wildlife": "cat-uuid-w"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_event_type_maps_falls_back_to_categories_endpoint(mocker):
+    """If only v2 event types exist (no nested category UUIDs), the helper hits
+    the /event_categories endpoint to populate category_id_by_slug."""
+    from erclient import VERSION_1_0, VERSION_2_0
+    er_client = mocker.MagicMock()
+
+    async def fake_get_event_types(version=VERSION_1_0, **kwargs):
+        if version == VERSION_1_0:
+            return []  # ER instance has no v1 types
+        return [
+            {
+                "value": "coyote_carcass",
+                "display": "Coyote Carcass",
+                "id": "v2-type-uuid",
+                "category": "wildlife",
+            },
+        ]
+
+    async def fake_get_event_categories(**kwargs):
+        return [
+            {"value": "wildlife", "id": "cat-uuid-w", "display": "Wildlife", "is_active": True},
+            {"value": "monitoring", "id": "cat-uuid-m", "display": "Monitoring", "is_active": True},
+        ]
+
+    er_client.get_event_types = fake_get_event_types
+    er_client.get_event_categories = fake_get_event_categories
+
+    maps = await _fetch_event_type_maps(er_client)
+    assert maps.id_by_slug == {"coyote_carcass": "v2-type-uuid"}
+    # category_id_by_slug was empty after v1+v2 → categories endpoint backfilled it.
     assert maps.category_id_by_slug == {
-        "security": "cat-uuid-1",
-        "wildlife": "cat-uuid-2",
+        "wildlife": "cat-uuid-w",
+        "monitoring": "cat-uuid-m",
     }
 
 
 @pytest.mark.asyncio
-async def test_fetch_event_type_maps_degrades_to_empty_on_403(mocker):
-    """If get_event_types fails with a 403 all three maps are empty."""
+async def test_fetch_event_type_maps_v1_succeeds_v2_fails(mocker):
+    """One endpoint failing doesn't break the other."""
+    from erclient import VERSION_1_0, VERSION_2_0
     er_client = mocker.MagicMock()
 
-    async def boom():
+    async def fake_get_event_types(version=VERSION_1_0, **kwargs):
+        if version == VERSION_1_0:
+            return [
+                {
+                    "value": "wildlife_sighting_rep",
+                    "display": "Wildlife Sighting Report",
+                    "id": "v1-type-uuid",
+                    "category": {"value": "wildlife", "id": "cat-uuid-w"},
+                },
+            ]
         raise ERClientPermissionDenied(
-            "ER Forbidden ON GET https://gundi-er.pamdas.org/api/v1.0/activity/events/eventtypes.",
+            "ER Forbidden ON GET https://gundi-er.pamdas.org/api/v2.0/activity/eventtypes.",
             status_code=403,
-            response_body='{"status":{"code":403,"message":"Forbidden"}}',
+            response_body="{}",
         )
 
-    er_client.get_event_types = boom
+    er_client.get_event_types = fake_get_event_types
+    maps = await _fetch_event_type_maps(er_client)
+    assert maps.id_by_slug == {"wildlife_sighting_rep": "v1-type-uuid"}
+    assert maps.category_id_by_slug == {"wildlife": "cat-uuid-w"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_event_type_maps_degrades_to_empty_when_everything_fails(mocker):
+    """v1, v2, and categories all 403 → all maps empty (callers will skip pull)."""
+    er_client = mocker.MagicMock()
+
+    async def boom_event_types(**kwargs):
+        raise ERClientPermissionDenied(
+            "ER Forbidden", status_code=403, response_body="{}"
+        )
+
+    async def boom_categories(**kwargs):
+        raise ERClientPermissionDenied(
+            "ER Forbidden", status_code=403, response_body="{}"
+        )
+
+    er_client.get_event_types = boom_event_types
+    er_client.get_event_categories = boom_categories
+
     maps = await _fetch_event_type_maps(er_client)
     assert isinstance(maps, EventTypeMaps)
     assert maps.display_by_slug == {}


### PR DESCRIPTION
ER stores event types with a 'version' field (each type is exclusively v1 or v2). The two list endpoints filter to their own version only:

    GET /api/v1.0/activity/events/eventtypes  (filter: version=v1)
    GET /api/v2.0/activity/eventtypes         (filter: version=v2)

Querying only v1 silently misses v2-defined event types (which is what the dev-smoke turned up: 'coyote_carcass' was defined v2-only and the slug→UUID resolution returned empty).

_fetch_event_type_maps now queries both endpoints and merges the results. Two implementation notes:

- v1 responses carry a nested category dict ({id, value, display, ...}); v2 responses carry only the category slug. The shared category_id_by_slug map gets populated from v1 directly; if it stays empty after both event-type fetches (e.g. ER instance is v2-only), the helper falls back to GET /activity/events/categories to backfill category UUIDs.

- All three fetches are independently best-effort. One failing (403, network) doesn't break the others. If everything fails, all maps come back empty and downstream callers treat that as the "skip pull" signal.

Adds 4 tests covering: v1+v2 merge happy path; v2-only with categories fallback; v1-succeeds-v2-fails; everything-fails-empty-maps.

Suite: 103 passing.