### PR TITLE
Emit ER event deep-link URL in event.additional for destination cross-linking

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -379,6 +379,10 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
     auth_config = get_authentication_config(integration=integration)
     # Prepare the ER client to extract events
     url_parse = urlparse(integration.base_url)
+    # UI root used to build deep-link URLs into the ER web UI from downstream
+    # destinations (CMORE renders this in the event description so operators
+    # can click through to the source ER event).
+    er_ui_root = _er_ui_root(url_parse)
     er_client = AsyncERClient(
         service_root=f"{url_parse.scheme}://{url_parse.hostname}/api/v1.0",
         username=auth_config.username or None,
@@ -499,6 +503,7 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
                     transformed = transform_events_to_gundi_schema(
                         events=[er_event],
                         event_type_display_by_slug=event_type_display_by_slug,
+                        er_ui_root=er_ui_root,
                     )
                     if not transformed:
                         continue
@@ -834,13 +839,29 @@ def _resolve_slugs(configured_slugs, slug_to_id):
     return resolved, unresolved
 
 
-def transform_events_to_gundi_schema(events, event_type_display_by_slug=None):
+def _er_ui_root(url_parse) -> str:
+    """Strip path/query/fragment from a parsed ER integration base URL,
+    leaving just ``scheme://netloc`` (so ports survive). Returns an empty
+    string if the URL is unparseable, which downstream code treats as
+    "skip the deep-link" rather than emitting a malformed URL.
+    """
+    if not (url_parse.scheme and url_parse.netloc):
+        return ""
+    return f"{url_parse.scheme}://{url_parse.netloc}"
+
+
+def transform_events_to_gundi_schema(events, event_type_display_by_slug=None, er_ui_root=None):
     """Map an ER event payload list to the Gundi sensors-API event schema.
 
     ``event_type_display_by_slug`` is an optional {slug: display} map used as
     the title fallback when the ER event has no title of its own. If omitted
     or the slug isn't in the map, falls through to the slug itself — matching
     the prior behavior.
+
+    ``er_ui_root`` is an optional ``scheme://netloc`` string for the ER web
+    UI. When supplied, each transformed event's ``additional.er_event_url``
+    points at the source ER event (e.g. for downstream destinations to render
+    as a cross-reference link).
     """
     display_map = event_type_display_by_slug or {}
     transformed_data = []
@@ -867,11 +888,18 @@ def transform_events_to_gundi_schema(events, event_type_display_by_slug=None):
                     "lon": location.get("longitude"),
                     "lat": location.get("latitude")
                 }
-            # Save others fields in additional
-            transformed_event["additional"] = {
+            # Save other fields in additional
+            additional = {
                 key: value for key, value in event.items()
                 if key not in transformed_event.keys()
             }
+            # ER UI deep-link: scheme://host/events/{uuid}. Downstream
+            # destinations (e.g. CMORE) can surface this as a click-through
+            # cross-reference. Only set when we have both pieces.
+            er_event_id = event.get("id")
+            if er_ui_root and er_event_id:
+                additional["er_event_url"] = f"{er_ui_root}/events/{er_event_id}"
+            transformed_event["additional"] = additional
         except Exception as e:
             logger.error(
                 f"Error transforming event {event}: {e}",

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -1224,3 +1224,51 @@ async def test_pull_events_warns_about_partially_unresolvable_slugs(
         if c.kwargs.get("level") == LogLevel.WARNING
     )
     assert warning_log.kwargs["data"]["unresolved_event_types"] == ["typo_slug"]
+
+
+# ---------------------------------------------------------------------------
+# ER deep-link: er_event_url in additional, so CMORE can render a click-through.
+# ---------------------------------------------------------------------------
+
+from urllib.parse import urlparse as _urlparse
+from app.actions.handlers import _er_ui_root
+
+
+def test_er_ui_root_strips_path_query_and_fragment():
+    """Normalize the integration's base_url to scheme://netloc so we don't
+    accidentally embed '/api/v1.0' or query params into deep-link URLs."""
+    assert _er_ui_root(_urlparse("https://gundi-er.pamdas.org")) == "https://gundi-er.pamdas.org"
+    assert _er_ui_root(_urlparse("https://gundi-er.pamdas.org/api/v1.0")) == "https://gundi-er.pamdas.org"
+    assert _er_ui_root(_urlparse("https://gundi-er.pamdas.org:8443/foo?x=1")) == "https://gundi-er.pamdas.org:8443"
+    # Unparseable / blank → empty string (caller treats as "skip the deep-link").
+    assert _er_ui_root(_urlparse("")) == ""
+    assert _er_ui_root(_urlparse("not-a-url")) == ""
+
+
+def test_transform_events_emits_er_event_url_when_ui_root_provided():
+    """The deep-link is built as ``{er_ui_root}/events/{er_event_id}`` and lands
+    in additional. CMORE-side handler reads this to render a click-through."""
+    transformed = transform_events_to_gundi_schema(
+        events=[{"id": "907a54b9-808b-45a6-919c-b6dd204c32c6", "event_type": "wildlife_sighting"}],
+        er_ui_root="https://gundi-dev.staging.pamdas.org",
+    )
+    assert transformed[0]["additional"]["er_event_url"] == (
+        "https://gundi-dev.staging.pamdas.org/events/907a54b9-808b-45a6-919c-b6dd204c32c6"
+    )
+
+
+def test_transform_events_skips_er_event_url_when_ui_root_missing():
+    """No er_ui_root → no deep-link key in additional (backward compatible)."""
+    transformed = transform_events_to_gundi_schema(
+        events=[{"id": "abc", "event_type": "wildlife_sighting"}],
+    )
+    assert "er_event_url" not in transformed[0]["additional"]
+
+
+def test_transform_events_skips_er_event_url_when_event_id_missing():
+    """No event id → no deep-link key (don't emit a URL pointing to ``/events/None``)."""
+    transformed = transform_events_to_gundi_schema(
+        events=[{"event_type": "wildlife_sighting"}],
+        er_ui_root="https://gundi-dev.staging.pamdas.org",
+    )
+    assert "er_event_url" not in transformed[0]["additional"]


### PR DESCRIPTION
## Why

Operators viewing an event in a destination integration (e.g. CMORE) currently have no easy path back to the source ER event for context. This PR is half of a small two-PR feature: the ER provider runner embeds the deep-link URL on every event it forwards to Gundi, so the destination side can render a click-through.

Companion PR (lands separately in `gundi-integration-cmore`) reads `additional.er_event_url` and appends it to the CMORE event's description.

## Behavior

When `integration.base_url` is configured (which it always is for a working ER provider), every transformed event now carries:

```json
{
  "additional": {
    "er_event_url": "https://gundi-dev.staging.pamdas.org/events/907a54b9-..."
  }
}
```

URL is built from the parsed integration base_url (scheme + netloc) plus `/events/{er_event_id}`. Path/query/fragment in the configured base_url are stripped so we don't accidentally embed `/api/v1.0` or query params into UI URLs.

## What changes

- New helper `_er_ui_root(url_parse)` — strips path/query/fragment, keeps scheme+netloc (ports survive).
- `transform_events_to_gundi_schema` gains an optional `er_ui_root` kwarg.
- `action_pull_events` computes `er_ui_root` once per pull and passes it through.
- Backward-compatible: existing callers of `transform_events_to_gundi_schema` that don't pass `er_ui_root` keep their behavior — no `er_event_url` key is emitted.

## Tests

**107 passing locally** (was 103; +4 new):

- `test_er_ui_root_strips_path_query_and_fragment` — normalization across several URL shapes including bad input.
- `test_transform_events_emits_er_event_url_when_ui_root_provided` — happy path matches the user-provided example URL shape.
- `test_transform_events_skips_er_event_url_when_ui_root_missing` — backward compat.
- `test_transform_events_skips_er_event_url_when_event_id_missing` — don't emit URLs pointing at `/events/None`.

## Smoke test plan

- [ ] Merge + deploy to dev
- [ ] On the next ER pull, confirm `er_event_url` appears in the Gundi trace's stored event payload
- [ ] Once the companion CMORE PR ships, the CMORE event description shows a clickable ER deep-link

🤖 Generated with [Claude Code](https://claude.com/claude-code)