### PR TITLE
Add diagnostic logs for the ER → Gundi deep-link emission

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -383,6 +383,13 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
     # downstream destinations (CMORE) can render a click-through back to the
     # source ER event.
     er_ui_root = _er_ui_root(url_parse)
+    # Diagnostic: surface the computed UI root so an empty value (e.g. from a
+    # misconfigured base_url) explains a missing deep-link in downstream
+    # destinations like CMORE.
+    logger.info(
+        "pull_events: integration.base_url=%r → er_ui_root=%r",
+        integration.base_url, er_ui_root,
+    )
     er_client = AsyncERClient(
         service_root=f"{url_parse.scheme}://{url_parse.hostname}/api/v1.0",
         username=auth_config.username or None,
@@ -507,6 +514,17 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
                     )
                     if not transformed:
                         continue
+                    # Diagnostic: log what we're about to POST so a downstream
+                    # destination seeing an unexpected payload (e.g. CMORE
+                    # rendering provider_metadata=None) can be traced back to
+                    # the ER runner's outbound shape.
+                    logger.info(
+                        "Posting Gundi event: er_event_uuid=%r title=%r "
+                        "provider_metadata=%r",
+                        er_event_uuid,
+                        transformed[0].get("title"),
+                        transformed[0].get("provider_metadata"),
+                    )
                     response = await send_events_to_gundi(
                         events=transformed, integration_id=integration_id
                     )


### PR DESCRIPTION
## Why

dev-smoke for the cross-link feature is showing `provider_metadata=None` on the cmore side ([per gundi-integration-cmore PR #11's diagnostic logs](https://github.com/PADAS/gundi-integration-cmore/pull/11)). To narrow down which layer is dropping the field, this PR adds symmetric diagnostic logs on the ER (producer) side.

## What's added

Two `logger.info` lines in `action_pull_events`:

1. **Once per pull**, after parsing `integration.base_url`:
   ```
   pull_events: integration.base_url='https://gundi-er.pamdas.org' → er_ui_root='https://gundi-er.pamdas.org'
   ```
   An empty `er_ui_root` (e.g. from a misconfigured base_url) reveals immediately that we never stamped the deep-link in the first place.

2. **Once per new event posted to Gundi**, before `send_events_to_gundi`:
   ```
   Posting Gundi event: er_event_uuid='907a54b9-...' title='Coyote Carcass' provider_metadata={'source_event_url': 'https://gundi-er.pamdas.org/events/907a54b9-...'}
   ```
   Confirms what's actually on the wire to Gundi.

## How to use

After this deploys, trigger a fresh ER event and tail both runners:

**ER runner**:
```
gcloud run services logs read earthranger-actions-runner --project=cdip-dev-78ca --region=us-central1 --limit=50
```

**CMORE runner**:
```
gcloud run services logs read cmore-actions-runner --project=cdip-dev-78ca --region=us-central1 --limit=50
```

Two possible outcomes:

| ER log shows | CMORE log shows | Conclusion |
|---|---|---|
| `provider_metadata={'source_event_url': '...'}` | `provider_metadata=None` | Field is dying between cdip sensors API and cdip-routing → cdip-routing PR #149 isn't actually live in dev |
| `er_ui_root=''` or `provider_metadata` empty | `provider_metadata=None` | ER side never stamped — likely a base_url config issue in the ER integration |
| `provider_metadata={'source_event_url': '...'}` | `provider_metadata={'source_event_url': '...'}` | Field reached cmore; bug elsewhere |

## Tests

107 passing locally (no behavior change, just logging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)