### PR TITLE
Set Gundi event source to the ER event_type

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -891,6 +891,10 @@ def transform_events_to_gundi_schema(events, event_type_display_by_slug=None, er
             event_type = event.get("event_type")
             if event_type:
                 transformed_event["event_type"] = event_type
+                # ER events have no per-device source; use the event_type as the
+                # source so Gundi groups them sensibly (external_source_id)
+                # rather than defaulting everything to "default-source".
+                transformed_event["source"] = event_type
             # Prefer the ER event's own title; otherwise fall back to the
             # event-type display name; otherwise the slug; otherwise nothing.
             title = event.get("title") or display_map.get(event_type) or event_type

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -939,6 +939,21 @@ def test_transform_events_no_display_map_arg_matches_prior_behavior():
     assert transformed[0]["title"] == "poacher_sighting_rep"
 
 
+def test_transform_events_sets_source_to_event_type():
+    """ER events have no per-device source, so the event_type is used as the
+    Gundi source (external_source_id) instead of defaulting to 'default-source'."""
+    transformed = transform_events_to_gundi_schema(
+        events=[{"id": "x", "event_type": "rhino_carcass"}],
+    )
+    assert transformed[0]["source"] == "rhino_carcass"
+
+
+def test_transform_events_omits_source_when_event_type_missing():
+    """No event_type → no source set (let downstream default it)."""
+    transformed = transform_events_to_gundi_schema(events=[{"id": "x"}])
+    assert "source" not in transformed[0]
+
+
 @pytest.mark.asyncio
 async def test_fetch_event_type_maps_merges_v1_and_v2(mocker):
     """ER's v1 and v2 event-type endpoints each return only their own version's


### PR DESCRIPTION
## Summary

ER events have no per-device source, so `transform_events_to_gundi_schema` never set a `source` and the cdip Sensors API defaulted `external_source_id` to `default-source` for **every** event. This sets `source = event_type`, so Gundi groups events by type (e.g. `external_source_id = "rhino_carcass"`) instead of collapsing them all under one catch-all source.

Only set when `event_type` is present; otherwise left unset (downstream default unchanged).

## Testing

`pytest app` → **109 passed** (2 new: source set to event_type; source omitted when event_type missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)