### PR TITLE
Events: use event time for recorded_at; pass serial_number via provider_metadata

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -900,7 +900,9 @@ def transform_events_to_gundi_schema(events, event_type_display_by_slug=None, er
             title = event.get("title") or display_map.get(event_type) or event_type
             if title:
                 transformed_event["title"] = title
-            if recorded_at := event.get("created_at"):
+            # Use the event's own time, not created_at (which is the save
+            # time) — CMORE shows recorded_at as the event's dateOccurred.
+            if recorded_at := event.get("time") or event.get("created_at"):
                 transformed_event["recorded_at"] = recorded_at
             if geometry := event.get("geojson"):
                 transformed_event["geometry"] = geometry
@@ -911,15 +913,20 @@ def transform_events_to_gundi_schema(events, event_type_display_by_slug=None, er
                     "lon": location.get("longitude"),
                     "lat": location.get("latitude")
                 }
-            # Provider-side cross-reference: deep-link back to the ER UI for
-            # this event. Surfaced by downstream destinations (e.g. CMORE
-            # appends it to the event description). Only set when both inputs
-            # are present so we never emit a malformed URL.
+            # Provider-side metadata surfaced by downstream destinations
+            # (e.g. CMORE renders the deep-link as a comment and the serial
+            # number in the event title). Each piece is only added when
+            # available, and Event has no `additional` field, so this is the
+            # channel for passing through provider context like serial_number.
+            provider_metadata = {}
             er_event_id = event.get("id")
             if er_ui_root and er_event_id:
-                transformed_event["provider_metadata"] = {
-                    "source_event_url": f"{er_ui_root}/events/{er_event_id}",
-                }
+                provider_metadata["source_event_url"] = f"{er_ui_root}/events/{er_event_id}"
+            serial_number = event.get("serial_number")
+            if serial_number is not None:
+                provider_metadata["serial_number"] = serial_number
+            if provider_metadata:
+                transformed_event["provider_metadata"] = provider_metadata
             # Save other fields in additional
             transformed_event["additional"] = {
                 key: value for key, value in event.items()

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -1289,3 +1289,44 @@ def test_transform_events_omits_provider_metadata_when_event_id_missing():
         er_ui_root="https://gundi-dev.staging.pamdas.org",
     )
     assert "provider_metadata" not in transformed[0]
+
+
+def test_transform_events_uses_event_time_for_recorded_at():
+    """recorded_at is the event's own ``time``, not ``created_at`` (the save
+    time) — CMORE shows it as the event's dateOccurred."""
+    transformed = transform_events_to_gundi_schema(
+        events=[{
+            "id": "x", "event_type": "wildlife_sighting",
+            "time": "2026-06-10T13:03:25-07:00",
+            "created_at": "2026-06-10T13:04:02-07:00",
+        }],
+    )
+    assert transformed[0]["recorded_at"] == "2026-06-10T13:03:25-07:00"
+
+
+def test_transform_events_recorded_at_falls_back_to_created_at():
+    """No ``time`` → fall back to ``created_at`` (prior behavior)."""
+    transformed = transform_events_to_gundi_schema(
+        events=[{"id": "x", "event_type": "wildlife_sighting", "created_at": "2026-06-10T13:04:02-07:00"}],
+    )
+    assert transformed[0]["recorded_at"] == "2026-06-10T13:04:02-07:00"
+
+
+def test_transform_events_includes_serial_number_in_provider_metadata():
+    """The ER serial_number rides in provider_metadata (Event has no `additional`),
+    alongside the deep-link, for CMORE to render in the title and comment."""
+    transformed = transform_events_to_gundi_schema(
+        events=[{"id": "907a54b9", "event_type": "rhino_carcass", "serial_number": 267}],
+        er_ui_root="https://gundi-dev.staging.pamdas.org",
+    )
+    pm = transformed[0]["provider_metadata"]
+    assert pm["serial_number"] == 267
+    assert pm["source_event_url"] == "https://gundi-dev.staging.pamdas.org/events/907a54b9"
+
+
+def test_transform_events_serial_number_without_ui_root():
+    """serial_number is included even when there's no er_ui_root (no deep-link)."""
+    transformed = transform_events_to_gundi_schema(
+        events=[{"id": "x", "event_type": "rhino_carcass", "serial_number": 5}],
+    )
+    assert transformed[0]["provider_metadata"] == {"serial_number": 5}


### PR DESCRIPTION
Upstream half of two CMORE-runner requests (the data originates here).

## (a) Event timestamp
`recorded_at` was set from `created_at` — the **save** time — so CMORE shows the save time as the event's `dateOccurred`. Now uses the event's own **`time`** (falls back to `created_at` if absent). The CMORE runner already maps `recorded_at → dateOccurred`, so this fixes the displayed time with no CMORE change.

## (b/c) Serial number
The ER `serial_number` previously went into `additional`, which is **dropped for Events** (the Event schema has no `additional` field — same reason the deep-link uses `provider_metadata`). Now `serial_number` is added to **`provider_metadata`** (whenever present, independent of the deep-link URL), so the CMORE runner can render it in the **event title** and the **deep-link comment** (companion PR in gundi-integration-cmore).

## Tests
`pytest app` → **113 passed**, incl. new tests: recorded_at from `time` (+ fallback), serial in provider_metadata (with and without a UI root). Existing deep-link/provider_metadata tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)