### PR TITLE
Request notes from ER events endpoint in pull_events

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -504,7 +504,13 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
         json_filter = json.dumps(event_filter)
         logger.info(f"Extracting events with filter '{event_filter}'...")
 
-        async for event_batch in earth_ranger.get_events(filter=json_filter, batch_size=BATCH_SIZE):
+        # include_notes is required: ER's events-list endpoint omits the notes
+        # array unless explicitly requested, so without this each er_event comes
+        # back without notes and no note update_event is ever emitted (the
+        # ER-note → downstream-comment path silently never fires).
+        async for event_batch in earth_ranger.get_events(
+            filter=json_filter, batch_size=BATCH_SIZE, include_notes=True
+        ):
             for er_event in event_batch:
                 er_event_uuid = er_event.get("id")
                 if not er_event_uuid:

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -461,6 +461,39 @@ async def test_pull_events_event_type_and_category_filter_passed_to_er(
     assert er_filter["event_category"] == ["6b359461-aa53-4116-bf2c-04cc580de4ef"]  # monitoring
 
 
+@pytest.mark.asyncio
+async def test_pull_events_requests_notes_from_er(
+        mocker, mock_gundi_client_v2, mock_state_manager, mock_erclient_class,
+        mock_get_gundi_api_key, mock_gundi_sensors_client_class, er_integration_v2_provider,
+        mock_publish_event, mock_gundi_client_v2_class, mock_config_manager_er_provider
+):
+    """pull_events must pass include_notes to ER's events endpoint.
+
+    ER's events-list endpoint omits the notes array unless include_notes is
+    requested. Without it, er_event["notes"] is always empty, so a note added
+    in ER never produces a {"notes": [...]} update_event and the downstream
+    note → comment path silently never fires. Regression for GUNDI-5386.
+    """
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager_er_provider)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.actions.handlers.state_manager", mock_state_manager)
+    mocker.patch("app.actions.handlers.AsyncERClient", mock_erclient_class)
+    mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class)
+    mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
+
+    await execute_action(
+        integration_id=str(er_integration_v2_provider.id),
+        action_id="pull_events",
+    )
+
+    assert mock_erclient_class.return_value.get_events.called
+    call_kwargs = mock_erclient_class.return_value.get_events.call_args.kwargs
+    assert call_kwargs.get("include_notes") is True
+
+
 @pytest.mark.parametrize(
     "filter_date_field, expected_er_key",
     [


### PR DESCRIPTION
## Problem

A Note added to an event in EarthRanger never appeared as a comment on the corresponding C-more event, even though field changes (e.g. status `new`→`active`) did.

## Root cause

`pull_events` called `get_events(filter=…, batch_size=…)` **without `include_notes`**. ER's events-*list* endpoint omits the `notes` array unless it's explicitly requested, so every fetched `er_event` came back with no notes. `_emit_event_updates` iterates `er_event["notes"]` — which was therefore always empty — so a new Note never emitted a `{"notes": […]}` `update_event`, and downstream destinations (C-more) never received it as a comment.

Field changes still worked because they're derived from fields already present in the list response — which is why a Note's *side-effect* status flip showed up while the note text never did.

## Fix

Pass `include_notes=True` to `get_events` so notes ride along on each fetched event.

## Test

Adds `test_pull_events_requests_notes_from_er`, asserting `pull_events` sends `include_notes=True` to ER. Verified it fails against the prior call signature and passes now. Full actions suite: 92 passing.

## Notes for reviewers

- The first-sight watermark (`handlers.py`) marks pre-existing notes as already-seen, so only notes added *after* an event is first pulled forward — pre-deploy notes won't backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)