### PR TITLE
Add MkDocs technical documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,51 @@
+name: Deploy docs
+
+# Build the MkDocs site and publish it to GitHub Pages.
+# Repo setting required once: Settings → Pages → Build and deployment →
+# Source = "GitHub Actions".
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress run.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - run: pip install -r requirements-docs.txt
+      - run: mkdocs build --strict --site-dir _site
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/actions/auth.md
+++ b/docs/actions/auth.md
@@ -1,0 +1,49 @@
+# `auth`
+
+Validates the configured EarthRanger credentials. This is the action Gundi runs to verify a connection.
+
+`action_auth` — `app/actions/handlers.py`
+
+## Behavior
+
+Authentication supports two methods, selected by `authentication_type`:
+
+- **Token** — calls the ER client's `get_me()` and confirms the returned user is active.
+- **Username / password** — performs an OAuth `login()` against the ER site.
+
+It returns a small result the portal interprets as valid / invalid:
+
+```json
+{ "valid_credentials": true }
+```
+
+```json
+{ "valid_credentials": false, "error": "Invalid credentials" }
+```
+
+## Error cases
+
+The action returns `valid_credentials: false` with a descriptive `error` for each failure mode:
+
+| Condition | `error` |
+|-----------|---------|
+| Missing/invalid ER site URL | `Site URL is empty or invalid: '<url>'` |
+| Token method, no token | `Please provide a token.` |
+| Username/password method, missing either | `Please provide both a username and a password.` |
+| Unknown `authentication_type` | `Please select an valid authentication method.` |
+| ER rejects the credentials | `Invalid credentials` |
+| Other ER client error | the ER client's message |
+| Transport/HTTP error | `HTTP error: <detail>` |
+
+## Configuration — `AuthenticateConfig`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `authentication_type` | enum (`token`, `username_password`) | `token` | Selects which credential fields apply. |
+| `token` | secret string | — | Shown/required when type is `token`. |
+| `username` | string | — | Shown/required when type is `username_password`. |
+| `password` | secret string | — | Shown/required when type is `username_password`. |
+
+The config form uses a conditional JSON schema: choosing `token` shows only the token field; choosing
+`username_password` shows username and password. The ER **base URL** comes from the integration itself,
+not this config.

--- a/docs/actions/index.md
+++ b/docs/actions/index.md
@@ -1,0 +1,17 @@
+# Actions
+
+The runner exposes four actions, all implemented in `app/actions/handlers.py` as `action_*` functions
+with a matching config model in `app/actions/configurations.py`.
+
+| Action | Type | Purpose |
+|--------|------|---------|
+| [`auth`](auth.md) | auth | Validate ER credentials. |
+| [`pull_events`](pull-events.md) | pull | ER events + note/field updates → Gundi events & event updates. |
+| [`pull_observations`](pull-observations.md) | pull | ER subject tracking → Gundi observations. |
+| [`show_permissions`](show-permissions.md) | generic / diagnostic | Show what the account can access and the UUIDs the pull actions need. |
+
+**Typical setup order:** run `auth` to confirm credentials → run `show_permissions` to discover event-type
+/ category slugs and subject-group UUIDs → configure and enable `pull_events` / `pull_observations` with
+those values.
+
+See the [Configuration reference](../configuration.md) for every field of every model in one place.

--- a/docs/actions/pull-events.md
+++ b/docs/actions/pull-events.md
@@ -1,0 +1,45 @@
+# `pull_events`
+
+Pulls events from EarthRanger and forwards them to Gundi — both **new events** and, for events already
+seen, **updates** (new notes and changed fields).
+
+`action_pull_events` — `app/actions/handlers.py`
+
+## What it does
+
+1. **Resolve the time window.** On the first run (or when `force_run_since_start` is set) it starts at
+   `start_datetime`; otherwise it starts at the watermark saved from the last successful run. The window
+   is applied to the ER timestamp named by `filter_date_field` (default `updated_at`). See
+   [State & scheduling](../state-and-scheduling.md).
+2. **Resolve filters.** Configured `event_types` / `event_categories` slugs are resolved to ER UUIDs
+   (ER filters by UUID, not slug). If some slugs don't resolve, it logs a warning; if a configured filter
+   resolves to *nothing*, it **skips the pull without advancing the watermark** so a corrected config can
+   re-pull the same window.
+3. **Fetch events** from the ER events endpoint in batches of 100, with `include_notes=True` so each event
+   carries its notes (without this, note updates never fire — see the note below).
+4. **Per event, decide new vs. update** using per-event state keyed by the ER event UUID:
+      - **Never seen** → transform and POST a new Gundi event, record the returned `gundi_object_id`, and
+        mark all current notes as already-seen (so existing notes aren't bulk-forwarded on first sight).
+      - **Seen before** → if `updated_at` is unchanged, skip; otherwise emit **one Gundi event-update per
+        change** (each new note, and each changed `status` / `priority` / `title`).
+5. **Advance the watermark** to the run's start time once all events are processed.
+
+It returns counts: `events_extracted`, `events_updated`, `updates_emitted`, `events_skipped_unchanged`.
+
+!!! note "`include_notes` is load-bearing"
+    ER's events-*list* endpoint omits the notes array unless `include_notes=true` is requested. The action
+    passes it explicitly; without it, every event arrives note-less and no note update is ever emitted —
+    the ER-note → downstream-comment path silently never fires. See the
+    [data flow](../data-flow.md#notes-and-field-changes-event-updates).
+
+## Configuration — `PullEventsConfig`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `start_datetime` | ISO-8601 string | **required** | First-run window start; ignored after the watermark advances (unless `force_run_since_start`). |
+| `end_datetime` | ISO-8601 string | none | Optional ceiling; sent on every run. Leave empty for ongoing pulls; set only for bounded backfills. |
+| `filter_date_field` | enum: `updated_at` / `created_at` / `event_time` | `updated_at` | Which ER timestamp the window applies to. `updated_at` catches edits and backdated events; `event_time` can silently miss backdated events — use it only for bounded backfills. |
+| `force_run_since_start` | bool | `False` | Reset the watermark for one run. Toggle off after the catch-up, or every run re-pulls from `start_datetime`. |
+| `event_types` | list[str] | `[]` | ER event-type slugs to pull (e.g. `wildlife_sighting_rep`). Empty = no type filter. Find slugs via [`show_permissions`](show-permissions.md). |
+| `event_categories` | list[str] | `[]` | ER event-category slugs. Combined with types using ER's AND semantics. Empty = no category filter. |
+| `run_on_schedule` | bool | `False` | Enable scheduled pulling. Off by default — turn on per connection that should pull events. |

--- a/docs/actions/pull-observations.md
+++ b/docs/actions/pull-observations.md
@@ -1,0 +1,41 @@
+# `pull_observations`
+
+Pulls subject tracking observations (positions over time) from EarthRanger and forwards them to Gundi.
+Designed to backfill large historical windows safely and resumably.
+
+`action_pull_observations` — `app/actions/handlers.py`
+
+## What it does
+
+1. **Acquire a backfill lease.** Because a pull can run longer than its schedule interval, the action takes
+   a Redis lease first; if another run already holds it, this run skips quietly. The lease is released in a
+   `finally` block (and has a TTL as backstop). See
+   [State & scheduling](../state-and-scheduling.md#the-backfill-lease).
+2. **Resolve the time window** from the watermark / `start_datetime` (same semantics as
+   [`pull_events`](pull-events.md)).
+3. **Resolve sources.** The configured `subject_group_ids` are walked recursively (a parent group includes
+   its sub-groups), the member subjects are collected, and their current **source** assignments are
+   resolved (chunked to keep ER URLs short). An empty group list means "no source filter."
+4. **Process the window as `(source × sub-window)` units.** The window is sliced into `subwindow_days`-wide
+   sub-windows; for each source and sub-window it fetches observations (batch size 100), transforms them,
+   and POSTs to Gundi. Progress is committed to a **cursor** after each unit.
+5. **Respect a time budget.** At ~80% of `MAX_ACTION_EXECUTION_TIME` the run saves its cursor and stops.
+   The next scheduled tick resumes from the saved cursor — or, if `continue_immediately` is on, the run
+   re-triggers the next chunk immediately via PubSub (with a runaway guard that stops after 3 consecutive
+   no-progress runs).
+6. **Advance the watermark** only when the entire window is complete.
+
+Observations are transformed with a `source` of `er-src-<source-uuid>` and a `{lon, lat}` location; all
+other ER fields are carried in `additional`. See [Data flow](../data-flow.md#observations).
+
+## Configuration — `PullObservationsConfig`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `start_datetime` | ISO-8601 string | **required** | First-run window start; ignored after the watermark advances (unless `force_run_since_start`). |
+| `end_datetime` | ISO-8601 string | none | Optional ceiling; sent on every run. Clear it after a bounded backfill, or later runs recompute an empty window. |
+| `subject_group_ids` | list[str] | `[]` | ER subject-group UUIDs to include (recursively). Empty = no constraint. Find UUIDs via [`show_permissions`](show-permissions.md). |
+| `subwindow_days` | int | `1` | Backfill granularity: the window is processed in slices this many days wide, committing after each. Smaller = less re-work on resume; larger = less per-slice overhead. |
+| `force_run_since_start` | bool | `False` | Reset the watermark for one run. Toggle off after the catch-up. |
+| `continue_immediately` | bool | `False` | When a run hits its time budget with work left, self-re-trigger the next chunk via PubSub instead of waiting for the next tick. Requires `INTEGRATION_COMMANDS_TOPIC`. |
+| `run_on_schedule` | bool | `False` | Enable scheduled pulling. Off by default. |

--- a/docs/actions/show-permissions.md
+++ b/docs/actions/show-permissions.md
@@ -1,0 +1,37 @@
+# `show_permissions`
+
+A diagnostic action. It introspects what the configured EarthRanger account can see and returns the slugs
+and UUIDs you need to configure the pull actions. It changes nothing.
+
+`action_show_permissions` — `app/actions/handlers.py`
+
+## What it returns
+
+The result renders in the portal as a card with these sections:
+
+| Section | Contents |
+|---------|----------|
+| **User Details** | Full name, username, superuser flag (from ER `/users/me`). |
+| **Global Permissions** | The account's permissions for event categories, event types, events, messages, and observations. |
+| **Event Categories** | Each category, the event types under it, and the account's permissions on it. |
+| **Event Type Slugs** | Flat list — paste into `pull_events`' `event_types`. |
+| **Event Category Slugs** | Flat list — paste into `pull_events`' `event_categories`. |
+| **Subject Groups** | Each group and the subjects within it (and, optionally, its sub-groups). |
+| **Subject Group UUIDs** | Every group UUID, including nested ones — paste into `pull_observations`' `subject_group_ids`. |
+
+The subject-group tree is walked recursively, so nested sub-group UUIDs (which aren't reachable from a flat
+listing) are surfaced too — those are exactly the IDs `pull_observations` needs to filter by a sub-group.
+
+## How operators use it
+
+1. Run it after [`auth`](auth.md) succeeds.
+2. Copy **Event Type Slugs** / **Event Category Slugs** into [`pull_events`](pull-events.md).
+3. Copy **Subject Group UUIDs** into [`pull_observations`](pull-observations.md).
+4. Use **User Details** / **Global Permissions** to diagnose "why am I not seeing X?" (usually a
+   permissions gap on the account).
+
+## Configuration — `ShowPermissionsConfig`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `include_subjects_from_subgroups_in_parent` | bool | `True` | When listing a group's subjects, also include subjects from its sub-groups. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,106 @@
+# Architecture
+
+The runner is a [FastAPI](https://fastapi.tiangolo.com/) service built on the shared
+[Gundi action-runner template](https://github.com/PADAS/gundi-integration-action-runner). Almost all
+EarthRanger-specific logic lives in `app/actions/` — `handlers.py` (the action functions) and
+`configurations.py` (their config models). Everything else is framework code.
+
+## Request flow
+
+Actions are triggered by GCP PubSub messages delivered to the service over HTTP.
+
+```
+GCP PubSub message
+   → POST /                       (app/main.py)
+   → base64-decode the message, parse JSON
+   → execute_action(integration_id, action_id)   (app/services/action_runner.py)
+   → load integration + action config             (config_manager, Redis-cached)
+   → look up the handler by action_id             (app/actions/__init__.py)
+   → parse/validate the config model
+   → run the handler with a timeout
+   → @activity_logger publishes start/complete/error events to PubSub
+```
+
+### HTTP endpoints (`app/main.py`)
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /` | Health check (`{"status": "healthy"}`). |
+| `POST /` | Primary entry point. Decodes a base64 PubSub message and runs the named action. |
+| `POST /push-data` | Push ingestion: runs an action selected by the payload's data type, with `destination_id` taken from the message attributes. |
+| `POST /v1/actions/execute` | Synchronous execution endpoint (`app/routers/actions.py`) used for manual/triggered runs. |
+
+Whether a `POST /` message runs inline or as a background task is governed by
+`PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND` (default off / synchronous).
+
+## Action dispatch
+
+Handlers are discovered automatically at import time. `app/actions/__init__.py` calls
+`discover_actions(module_name="app.actions.handlers", prefix="action_")`, which inspects every
+function named `action_*` and reads its type annotations to build a registry:
+
+```
+action_handlers = { action_id: (handler_func, ConfigModel, DataModel), ... }
+```
+
+`app/services/action_runner.py::execute_action()` then:
+
+1. Loads the integration via `config_manager.get_integration_details()`.
+2. Looks up `action_handlers[action_id]` (or, for push data, matches by data-model name).
+3. Fetches and validates the action's config (`config_model.parse_obj(...)`, plus any `config_overrides`).
+4. Decides whether the run is **manual** or **scheduled** — scheduled pulls that are missing config,
+   fail validation, or have `run_on_schedule` off are skipped quietly rather than erroring.
+5. Runs the handler with a timeout of `MAX_ACTION_EXECUTION_TIME` (default 540 s / 9 min; a 504 is
+   returned on timeout).
+
+## Configuration cache
+
+`app/services/config_manager.py` fetches integration and action config from the Gundi API and caches it
+in Redis (`REDIS_CONFIGS_DB`, default DB 1) under keys like `integration.{id}` and
+`integrationconfig.{id}.{action_id}`. Fetches retry with exponential backoff on HTTP errors.
+
+State (watermarks, per-event records, backfill cursors) is stored separately by
+`IntegrationStateManager` in `REDIS_STATE_DB` (default DB 0). See
+[State & scheduling](state-and-scheduling.md).
+
+## Scheduling
+
+Pull actions can run on a schedule. A schedule is attached either with the `@crontab_schedule("…")`
+decorator on the handler or via `python app/register.py --schedule "action_id:<crontab>"`. Crontab specs
+support the standard five fields plus an optional timezone offset
+(`app/services/action_scheduler.py`).
+
+Note that both pull actions default `run_on_schedule` to **`False`** — this integration is most often
+deployed only as a *destination*, so scheduled pulling is opt-in per connection.
+
+## Self-registration
+
+On startup, if `REGISTER_ON_START` is set, the service registers its integration type with Gundi
+(`app/services/self_registration.py`), publishing each action's JSON schema and marking pull actions as
+periodic. The same logic is runnable from the CLI:
+
+```bash
+python app/register.py --slug earth_ranger --service-url <public-url>
+```
+
+## Activity logging
+
+The `@activity_logger()` decorator on an action publishes **start**, **complete**, and **error** events to
+the `INTEGRATION_EVENTS_TOPIC` PubSub topic; these surface in the Gundi portal's activity feed. Handlers
+also call `log_action_activity(...)` to emit custom INFO/WARNING/ERROR entries (used, for example, when a
+pull is skipped because no configured event types resolved).
+
+## Key environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `GUNDI_API_BASE_URL` | — | Gundi platform API endpoint. |
+| `INTEGRATION_TYPE_SLUG` | — | This integration type's slug — **`earth_ranger`**. |
+| `INTEGRATION_SERVICE_URL` | — | Public URL of this service (for self-registration). |
+| `REGISTER_ON_START` | `False` | Auto-register the integration type on startup. |
+| `REDIS_HOST` / `REDIS_PORT` | `localhost` / `6379` | Redis host for config + state. |
+| `REDIS_STATE_DB` / `REDIS_CONFIGS_DB` | `0` / `1` | Redis DBs for state and config cache. |
+| `INTEGRATION_EVENTS_TOPIC` | `integration-events` | PubSub topic for activity/error events. |
+| `INTEGRATION_COMMANDS_TOPIC` | `{slug}-actions-topic` | PubSub topic used to self-trigger the next backfill chunk. |
+| `MAX_ACTION_EXECUTION_TIME` | `540` | Handler timeout, seconds. |
+| `PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND` | `False` | Process `POST /` messages as background tasks. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,52 @@
+# Configuration reference
+
+Every action's config model lives in `app/actions/configurations.py`. Each is configured per-connection in
+the Gundi portal. This page collects every field in one place; the per-action pages add behavioral context.
+
+## `AuthenticateConfig` — `auth`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `authentication_type` | enum: `token`, `username_password` | `token` | Selects which credential fields apply. |
+| `token` | secret string | — | Used when type is `token`. |
+| `username` | string | — | Used when type is `username_password`. |
+| `password` | secret string | — | Used when type is `username_password`. |
+
+The ER **base URL** comes from the integration record, not this config.
+
+## `ShowPermissionsConfig` — `show_permissions`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `include_subjects_from_subgroups_in_parent` | bool | `True` | Include sub-group subjects when listing a parent group's subjects. |
+
+## `PullEventsConfig` — `pull_events`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `start_datetime` | ISO-8601 string | **required** | First-run window start (applies to `filter_date_field`). Ignored once the watermark advances. |
+| `end_datetime` | ISO-8601 string | none | Optional window ceiling; sent every run. |
+| `filter_date_field` | enum: `updated_at`, `created_at`, `event_time` | `updated_at` | Which ER timestamp the window applies to. |
+| `force_run_since_start` | bool | `False` | Reset the watermark for one run. |
+| `event_types` | list[str] | `[]` | ER event-type slugs. Empty = no filter. |
+| `event_categories` | list[str] | `[]` | ER event-category slugs (AND-combined with types). Empty = no filter. |
+| `run_on_schedule` | bool | `False` | Enable scheduled pulling. |
+
+## `PullObservationsConfig` — `pull_observations`
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `start_datetime` | ISO-8601 string | **required** | First-run window start. Ignored once the watermark advances. |
+| `end_datetime` | ISO-8601 string | none | Optional window ceiling; sent every run. |
+| `subject_group_ids` | list[str] | `[]` | ER subject-group UUIDs (resolved recursively). Empty = no filter. |
+| `subwindow_days` | int | `1` | Backfill slice width in days. |
+| `force_run_since_start` | bool | `False` | Reset the watermark for one run. |
+| `continue_immediately` | bool | `False` | Self-re-trigger the next backfill chunk via PubSub instead of waiting for the next tick. |
+| `run_on_schedule` | bool | `False` | Enable scheduled pulling. |
+
+!!! tip "`run_on_schedule` defaults to off"
+    The base `PullActionConfiguration` defaults `run_on_schedule` to `True`, but both pull actions here
+    override it to `False` — this integration is most often deployed only as a destination, so scheduled
+    pulling is opt-in per connection.
+
+See [State & scheduling](state-and-scheduling.md) for watermark, backfill, and scheduling semantics.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,51 @@
+# Contributing
+
+## Where the code lives
+
+| Path | Purpose |
+|------|---------|
+| `app/actions/handlers.py` | The `action_*` functions — all EarthRanger-specific logic. |
+| `app/actions/configurations.py` | The Pydantic config model for each action. |
+| `app/actions/tests/` | Action tests (and shared fixtures in `conftest.py`). |
+| `app/services/` | Gundi action-runner framework: dispatch, config cache, state, send helpers. |
+
+Everything outside `app/actions/` is framework code shared with the
+[action-runner template](https://github.com/PADAS/gundi-integration-action-runner) — prefer not to fork it.
+
+## Adding a new action
+
+1. **Define a config model** in `app/actions/configurations.py`. Subclass the appropriate base:
+   `AuthActionConfiguration`, `PullActionConfiguration`, `PushActionConfiguration`, or
+   `GenericActionConfiguration`. Use `FieldWithUIOptions(...)` + `UIOptions(...)` for portal field rendering
+   and set `ui_global_options.order` to control field order.
+2. **Write the handler** in `app/actions/handlers.py` named `action_<id>`, annotated so it's
+   auto-discovered:
+   ```python
+   @activity_logger()
+   async def action_my_thing(integration: Integration, action_config: MyThingConfig):
+       ...
+   ```
+   The runner reads the `action_config` annotation to bind the config model; push actions also take
+   `data` and `metadata` parameters.
+3. **Add `@crontab_schedule("…")`** if it should run periodically (pull actions). Remember both existing
+   pull actions default `run_on_schedule` to `False`.
+4. **Talk to EarthRanger** through the ER client; **send to Gundi** through `app/services/gundi.py`
+   (`send_events_to_gundi`, `send_observations_to_gundi`, `update_event_in_gundi`). Keep network calls
+   resilient (the existing send helpers retry with backoff).
+5. **Persist incremental state** through `IntegrationStateManager` if the action is incremental — see
+   [State & scheduling](state-and-scheduling.md) for the watermark/cursor patterns.
+6. **Test it.** Add tests under `app/actions/tests/`, mocking the ER client and Gundi senders (follow the
+   existing tests as a pattern). Run `pytest`.
+
+## Conventions
+
+- **Pydantic** for all data structures (config models, DTOs) — not dataclasses.
+- **Emit one event-update per logical change** (the GUNDI-5386 contract) so each surfaces cleanly
+  downstream. See [Data flow](data-flow.md#notes-and-field-changes-event-updates).
+- **Advance watermarks only after a unit of work is durably forwarded**, so a failure resumes rather than
+  skips.
+
+## Updating these docs
+
+Docs are MkDocs Material under `docs/`. Edit the relevant page, preview with `mkdocs serve`, and confirm
+`mkdocs build --strict` passes (that's what CI runs). Merging to `main` republishes the site.

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -1,0 +1,68 @@
+# Data flow: EarthRanger → Gundi
+
+The pull actions fetch raw ER records and transform them into the Gundi schema before sending. The
+transforms live in `app/actions/handlers.py`; the send functions in `app/services/gundi.py`.
+
+## Events
+
+`transform_events_to_gundi_schema()` maps an ER event to a Gundi event:
+
+| Gundi field | Source |
+|-------------|--------|
+| `title` | ER `title`, falling back to the event-type display name, then the event-type slug. |
+| `event_type` | ER `event_type` slug. |
+| `source` | The `event_type` slug. (ER events have no per-device source; grouping by type avoids defaulting everything to one source.) |
+| `recorded_at` | ER `time`, falling back to `created_at`. |
+| `location` | ER `{longitude, latitude}` → Gundi `{lon, lat}`. |
+| `geometry` | ER `geojson`. |
+| `event_details` | ER `event_details`. |
+| `provider_metadata` | `source_event_url` deep-link + `serial_number` (when available). |
+| `additional` | Any remaining ER fields not mapped above. |
+
+### Deep-link back to ER
+
+`provider_metadata.source_event_url` is built as `{er_ui_root}/events/{er_event_id}`, where `er_ui_root` is
+derived from the integration's base URL. Downstream destinations (e.g. C-more) render it as a click-through
+back to the source ER event. If the base URL can't be parsed, `er_ui_root` is empty and the deep-link is
+simply omitted.
+
+New events are sent with `send_events_to_gundi()` (a batched POST). The Gundi-assigned `object_id` from the
+response is saved in per-event state so later updates can be correlated to the same event.
+
+## Notes and field changes (event updates)
+
+For an event seen on a previous run, `_emit_event_updates()` detects what changed and emits **one Gundi
+event-update per change** (via `update_event_in_gundi()`, a PATCH). Emitting one update per logical change
+means each one surfaces cleanly downstream (e.g. as a separate C-more comment) — this is the GUNDI-5386
+contract.
+
+- **New notes** — each ER note whose ID isn't in `seen_note_ids` is forwarded as
+  `changes = {"notes": [note]}` (preserving author and timestamp), then its ID is recorded as seen.
+- **Field changes** — detected by diffing the cached value against the current one:
+
+  | ER field | Gundi change key |
+  |----------|------------------|
+  | `state` | `status` |
+  | `priority` | `priority` |
+  | `title` | `title` |
+
+  Each changed field emits `changes = {<key>: <new value>}`.
+
+!!! info "Why a note can fail to forward"
+    Notes only enter this path if the event was fetched with `include_notes=true`
+    (see [`pull_events`](actions/pull-events.md)). The note must also be *new* relative to `seen_note_ids` —
+    notes already present when the event was first pulled are marked seen and won't backfill.
+
+## Observations
+
+`transform_observations_to_gundi_schema()` maps an ER observation to a Gundi observation:
+
+| Gundi field | Source |
+|-------------|--------|
+| `source` | `er-src-<ER source UUID>`. |
+| `recorded_at` | ER `recorded_at`. |
+| `location` | ER `{longitude, latitude}` → `{lon, lat}`. |
+| `additional` | Any remaining ER fields. |
+
+Observations are sent with `send_observations_to_gundi()` (a batched POST). All Gundi send functions retry
+with exponential backoff on HTTP errors.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,43 @@
+# EarthRanger Action Runner
+
+A [Gundi v2](https://gundiservice.org) integration that pulls **events** and **subject observations**
+from an [EarthRanger](https://earthranger.com) (ER) site on a schedule and forwards them to Gundi,
+which routes them onward to any configured destinations (for example, a C-more instance).
+
+It is **pull-based**: actions are triggered on a schedule via GCP PubSub, fetch data from the ER API,
+transform it into the Gundi schema, and send it through the Gundi API.
+
+```
+EarthRanger site  →  pull action  →  transform to Gundi schema  →  Gundi API  →  destinations
+```
+
+## The four actions
+
+| Action | What it does |
+|--------|--------------|
+| [`auth`](actions/auth.md) | Validates the configured EarthRanger credentials (token or username/password). |
+| [`pull_events`](actions/pull-events.md) | Pulls ER events — plus their note and field updates — and sends them to Gundi as events and event updates. |
+| [`pull_observations`](actions/pull-observations.md) | Pulls tracking observations for the configured ER subject groups and sends them to Gundi as observations. |
+| [`show_permissions`](actions/show-permissions.md) | Diagnostic. Lists the event categories and subject groups the configured account can access — and the UUIDs the pull actions need. |
+
+## How to read these docs
+
+- **[Architecture](architecture.md)** — the runtime: how a PubSub message becomes an action execution, config caching, scheduling, self-registration.
+- **[Actions](actions/index.md)** — what each action does and every config field it accepts.
+- **[Data flow](data-flow.md)** — how ER events and observations are transformed into the Gundi schema, including the note/field → event-update path.
+- **[State & scheduling](state-and-scheduling.md)** — per-event state, watermarks, and the resumable observation backfill.
+- **[Configuration reference](configuration.md)** — every field of every config model in one table.
+- **[Local development](local-development.md)** — run the service locally and run the tests.
+- **[Contributing](contributing.md)** — how to add a new action.
+
+## Integration type slug
+
+The canonical Gundi integration-type slug for this runner is **`earth_ranger`** (with an underscore).
+It matches `gundi_core.schemas.v1.DestinationTypes.EarthRanger` and the fixtures across `cdip-routing`
+and the gundi-integration repos. Always use `earth_ranger` when setting `INTEGRATION_TYPE_SLUG`, running
+`python app/register.py --slug …`, or referencing this integration type elsewhere — the wrong slug breaks
+registration.
+
+!!! note
+    An `earthranger` type without the underscore existed historically as a registration accident and is
+    being cleaned up. See [PR #13](https://github.com/PADAS/gundi-integration-earthranger/pull/13).

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,46 @@
+# Local development
+
+## Run the tests
+
+```bash
+pytest
+```
+
+Tests use `pytest-asyncio` and `pytest-mock`; all external services (Gundi API, the ER client, PubSub,
+Redis) are mocked via fixtures in `app/conftest.py` and `app/actions/tests/conftest.py`. Action tests live
+in `app/actions/tests/`.
+
+## Run the service locally
+
+The runner is a FastAPI service and can be brought up with Docker Compose against Gundi stage services.
+Full steps are in [`local/LOCAL_DEVELOPMENT.md`](https://github.com/PADAS/gundi-integration-earthranger/blob/main/local/LOCAL_DEVELOPMENT.md);
+in short:
+
+1. In `local/`, copy `.env.local.example` to `.env.local` and set `KEYCLOAK_CLIENT_SECRET` to a stage
+   secret (ask the Gundi team).
+2. Compile `requirements.txt` if you've changed any `*.in` files (otherwise the image may miss deps).
+3. `docker compose up --build`.
+
+The browsable API is then at <http://localhost:8080/docs>.
+
+## Dependencies
+
+Runtime/dev dependencies are compiled from the `*.in` files:
+
+```bash
+pip-compile --output-file=requirements.txt requirements-base.in requirements-dev.in requirements.in
+```
+
+Documentation dependencies are separate, in `requirements-docs.txt` (`mkdocs` + `mkdocs-material`).
+
+## Working on these docs
+
+```bash
+pip install -r requirements-docs.txt
+mkdocs serve            # live-reload preview at http://127.0.0.1:8000
+mkdocs build --strict   # what CI runs; fails on broken links/nav
+```
+
+The docs site is published to GitHub Pages automatically on push to `main` (see
+[`.github/workflows/docs.yml`](https://github.com/PADAS/gundi-integration-earthranger/blob/main/.github/workflows/docs.yml)).
+Brainstorming specs under `docs/superpowers/` are excluded from the published site.

--- a/docs/state-and-scheduling.md
+++ b/docs/state-and-scheduling.md
@@ -1,0 +1,96 @@
+# State & scheduling
+
+Both pull actions are incremental: each run only fetches what's new since the last one. They achieve this
+with state stored in Redis by `IntegrationStateManager` (`app/services/state.py`).
+
+## The state store
+
+State is JSON, stored in `REDIS_STATE_DB` (default DB 0) under keys of the form:
+
+```
+integration_state.{integration_id}.{action_id}.{source_id}
+```
+
+`source_id` defaults to `"no-source"` when a single record covers the whole action. The API is small:
+`get_state` (returns `{}` on miss), `set_state`, `delete_state`, and `set_if_absent` — an atomic
+set-with-TTL used for the backfill lease. All calls retry on transient Redis errors.
+
+## Watermarks
+
+Each pull action tracks a `last_execution` watermark:
+
+| Situation | `last_execution` | Window start used |
+|-----------|------------------|-------------------|
+| First run | absent | `start_datetime` from config |
+| Subsequent run | present | `last_execution` |
+| Catch-up (`force_run_since_start = True`) | present | `start_datetime` (reset for one run) |
+
+`force_run_since_start` resets the watermark for a single run — **toggle it off afterward**, or every run
+re-pulls from `start_datetime`. `end_datetime`, when set, is sent on every run; clear it after a bounded
+backfill so later runs don't recompute an empty window.
+
+For `pull_events`, the watermark is compared against the ER timestamp chosen by `filter_date_field`
+(default `updated_at`, which catches edits and backdated events).
+
+## Per-event state (`pull_events`)
+
+`pull_events` keeps one record per ER event, keyed by the **ER event UUID**:
+
+| Field | Purpose |
+|-------|---------|
+| `gundi_object_id` | The Gundi ID returned when the event was first posted — used to correlate later updates. |
+| `updated_at` | Cached ER `updated_at`; if unchanged on the next sight, the event is skipped. |
+| `state`, `priority`, `title` | Cached values, diffed to detect field changes. |
+| `seen_note_ids` | IDs of notes already forwarded, so only *new* notes emit updates. |
+
+On first sight, all existing notes are recorded as seen (no bulk-forward). See
+[Data flow](data-flow.md#notes-and-field-changes-event-updates).
+
+## The resumable observation backfill
+
+`pull_observations` is built to backfill large windows across many runs without dropping or duplicating
+data. It stores a **cursor** under its state alongside `last_execution`:
+
+```python
+{
+  "start": ..., "end": ...,          # the overall window
+  "subwindow_days": ...,             # slice width
+  "sources": [...],                  # sorted source UUIDs ([None] = no filter)
+  "window_index": ..., "source_index": ...,  # progress within the (sub-window × source) grid
+  "no_progress_count": ...,          # runaway guard for continue_immediately
+  "units_failed": ...,
+}
+```
+
+The window is sliced into deterministic, half-open `[start, end)` sub-windows (`_iter_subwindows`), and the
+action walks the `(sub-window × source)` grid, committing the cursor after each unit. Because the source
+list is sorted and the slicing is deterministic, a resumed run regenerates the exact same unit sequence and
+continues by index.
+
+The watermark (`last_execution`) is **advanced only when the whole window completes** — so a run that fails
+or times out mid-backfill leaves the watermark untouched and the next run resumes from the cursor.
+
+### Time budget and continuation
+
+At ~80% of `MAX_ACTION_EXECUTION_TIME`, the run saves its cursor and stops. Continuation is either:
+
+- **Scheduler-driven** (default) — the next scheduled tick picks up the cursor, or
+- **Immediate** (`continue_immediately = True`) — the run re-triggers the next chunk via the
+  `INTEGRATION_COMMANDS_TOPIC` PubSub topic. A runaway guard stops self-re-triggering after 3 consecutive
+  runs that make no progress.
+
+### The backfill lease
+
+Because a backfill can outlast its schedule interval, two runs could otherwise overlap and race on the
+cursor (causing duplicate sends). Before working, the action takes a lease via `set_if_absent` with a TTL of
+`MAX_ACTION_EXECUTION_TIME + 30s`. If the lease is already held, the run skips quietly. The lease is released
+in a `finally` block, with the TTL as a backstop. Lease acquisition **fails open** — if Redis is briefly
+unavailable, the run proceeds rather than crash (a rare duplicate is cheaper than a stall).
+
+## Scheduling and `run_on_schedule`
+
+Schedules are attached with `@crontab_schedule("…")` or `register.py --schedule`. But both pull actions
+default `run_on_schedule` to **`False`**: a scheduled tick for a pull action whose config has
+`run_on_schedule` off (or missing/invalid config) is **skipped quietly**, not errored. This integration is
+most often deployed only as a *destination*, so pulling is opt-in per connection. Manual runs always
+execute regardless.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,58 @@
+site_name: EarthRanger Action Runner
+site_description: A Gundi v2 integration that pulls events and observations from EarthRanger and forwards them to Gundi.
+repo_url: https://github.com/PADAS/gundi-integration-earthranger
+repo_name: PADAS/gundi-integration-earthranger
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - content.code.copy
+    - toc.follow
+    - search.suggest
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: green
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: green
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+markdown_extensions:
+  - admonition
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+
+# Brainstorming specs live under docs/superpowers/ — keep them out of the site.
+exclude_docs: |
+  superpowers/
+
+nav:
+  - Home: index.md
+  - Architecture: architecture.md
+  - Actions:
+      - Overview: actions/index.md
+      - auth: actions/auth.md
+      - pull_events: actions/pull-events.md
+      - pull_observations: actions/pull-observations.md
+      - show_permissions: actions/show-permissions.md
+  - Data flow: data-flow.md
+  - State & scheduling: state-and-scheduling.md
+  - Configuration reference: configuration.md
+  - Local development: local-development.md
+  - Contributing: contributing.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+mkdocs~=1.6
+mkdocs-material~=9.5


### PR DESCRIPTION
## What

Adds a [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) documentation site for the EarthRanger action runner — the deeper technical layer the new README (#32) points to.

Content is sourced from the code, not aspirational:

- **Architecture** — runtime/request flow (PubSub → `POST /` → `execute_action`), action dispatch, config cache, scheduling, self-registration, key env vars
- **Actions** — a page each for `auth`, `pull_events`, `pull_observations`, `show_permissions`, with behavior + every config field
- **Data flow** — ER → Gundi transforms for events and observations, plus the note/field → event-update path (the GUNDI-5386 contract)
- **State & scheduling** — watermarks, per-event state, the resumable observation backfill (cursor, sub-windows, lease, time budget / `continue_immediately`)
- **Configuration reference** — every field of every model in one table
- **Local development** and **Contributing** (how to add an action)

## Tooling & deploy

- `mkdocs.yml` — Material theme, explicit `nav`; `exclude_docs` keeps `docs/superpowers/` (brainstorming specs) out of the published site
- `requirements-docs.txt` — `mkdocs` + `mkdocs-material`
- `.github/workflows/docs.yml` — builds with `mkdocs build --strict` and deploys to **GitHub Pages** on push to `main` (paths-filtered to docs)

## One repo setting required

For the deploy to publish, enable Pages once: **Settings → Pages → Build and deployment → Source = "GitHub Actions"**. Until then the build job still runs (and `--strict` gates broken links), it just won't publish.

## Verification

`mkdocs build --strict` passes locally (no broken links/nav). Docs-only; no application code touched.

Relates to #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)