### PR TITLE
Time-accurate source naming for ER observations

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -20,6 +20,7 @@ from app.services.utils import find_config_for_action
 from app.services.state import IntegrationStateManager
 from .configurations import AuthenticateConfig, EventFilterDateField, PullObservationsConfig, PullEventsConfig, \
     ERAuthenticationType, ShowPermissionsConfig
+from .source_profiles import SourceProfileResolver
 from ..services.activity_logger import activity_logger, log_action_activity
 from ..services.gundi import send_events_to_gundi, send_observations_to_gundi, update_event_in_gundi
 from ..services.action_scheduler import trigger_action
@@ -641,6 +642,10 @@ async def action_pull_observations(integration: Integration, action_config: Pull
                 log_level=logging.INFO,
             )
         try:
+            # One resolver per run: lazily fetches + caches per-source profiles
+            # (manufacturer_id, subject assignment history) so observations are
+            # labelled with the device's natural id and time-correct subject name.
+            resolver = SourceProfileResolver(earth_ranger, integration_id=integration_id)
             state = await state_manager.get_state(
                 integration_id=integration_id, action_id="pull_observations"
             )
@@ -752,7 +757,7 @@ async def action_pull_observations(integration: Integration, action_config: Pull
                     try:
                         total_observations += await _pull_source_window(
                             earth_ranger, source, w_start, w_end,
-                            integration_id=integration_id,
+                            integration_id=integration_id, resolver=resolver,
                         )
                     except Exception as e:
                         # Don't wedge the backfill on one bad unit: log loudly and
@@ -986,20 +991,28 @@ async def _save_backfill_cursor(integration_id, *, last_execution, cursor):
     )
 
 
-async def _pull_source_window(er_client, source, start, end, *, integration_id):
+async def _pull_source_window(er_client, source, start, end, *, integration_id, resolver=None):
     """Drain one (source × sub-window) unit and forward to Gundi.
 
     ``source=None`` means no source filter (whole instance for the window).
     Returns the number of observations forwarded. ER filters server-side, so no
     client-side source filtering is needed. ``er_client`` must already be an
     entered/open client session (call within ``async with er_client``).
+
+    When ``resolver`` is given, each batch's source UUIDs are prefetched (so the
+    resolver caches per-source profiles) and passed into the transform to enrich
+    observations with ``manufacturer_id``/``source_name``/``subject_type``.
     """
     params = {"start": start, "end": end, "batch_size": BATCH_SIZE}
     if source is not None:
         params["source_id"] = source
     sent = 0
     async for observation_batch in er_client.get_observations(**params):
-        transformed = transform_observations_to_gundi_schema(observations=observation_batch)
+        if resolver is not None:
+            await resolver.ensure({o.get("source") for o in observation_batch if o.get("source")})
+        transformed = transform_observations_to_gundi_schema(
+            observations=observation_batch, resolver=resolver
+        )
         if not transformed:
             continue
         logger.info(f"Sending {len(transformed)} observations to Gundi...")

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1311,8 +1311,8 @@ def transform_observations_to_gundi_schema(observations, resolver=None):
             source_uuid = observation.get("source")
             if source_uuid:
                 if resolver is not None:
-                    from datetime import datetime
-                    when = datetime.fromisoformat(recorded_at) if recorded_at else None
+                    recorded_at_norm = recorded_at.replace("Z", "+00:00") if recorded_at else None
+                    when = datetime.datetime.fromisoformat(recorded_at_norm) if recorded_at_norm else None
                     resolved = resolver.resolve(source_uuid, when)
                     transformed_observation["source"] = resolved.external_source_id
                     if resolved.source_name:
@@ -1330,7 +1330,7 @@ def transform_observations_to_gundi_schema(observations, resolver=None):
             # ER source UUID for traceability/reconciliation after the identity change.
             additional = {
                 key: value for key, value in observation.items()
-                if key not in transformed_observation.keys() and key != "source"
+                if key not in transformed_observation.keys() and key not in ("source", "er_source_id")
             }
             if source_uuid:
                 additional["er_source_id"] = source_uuid

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1300,30 +1300,45 @@ def transform_events_to_gundi_schema(events, event_type_display_by_slug=None, er
     return transformed_data
 
 
-def transform_observations_to_gundi_schema(observations):
+def transform_observations_to_gundi_schema(observations, resolver=None):
     transformed_data = []
     for observation in observations:
         try:
             transformed_observation = {}
-            # Set base fields
-            if recorded_at := observation.get("recorded_at"):
+            recorded_at = observation.get("recorded_at")
+            if recorded_at:
                 transformed_observation["recorded_at"] = recorded_at
-            if source := observation.get("source"):
-                transformed_observation["source"] = f"er-src-{source}"
+            source_uuid = observation.get("source")
+            if source_uuid:
+                if resolver is not None:
+                    from datetime import datetime
+                    when = datetime.fromisoformat(recorded_at) if recorded_at else None
+                    resolved = resolver.resolve(source_uuid, when)
+                    transformed_observation["source"] = resolved.external_source_id
+                    if resolved.source_name:
+                        transformed_observation["source_name"] = resolved.source_name
+                    if resolved.subject_type:
+                        transformed_observation["subject_type"] = resolved.subject_type
+                else:
+                    transformed_observation["source"] = f"er-src-{source_uuid}"
             if location := observation.get("location"):
                 transformed_observation["location"] = {
                     "lon": location.get("longitude"),
-                    "lat": location.get("latitude")
+                    "lat": location.get("latitude"),
                 }
-            # Save others fields in additional
-            transformed_observation["additional"] = {
+            # Everything not already mapped goes to additional; preserve the raw
+            # ER source UUID for traceability/reconciliation after the identity change.
+            additional = {
                 key: value for key, value in observation.items()
-                if key not in transformed_observation.keys()
+                if key not in transformed_observation.keys() and key != "source"
             }
+            if source_uuid:
+                additional["er_source_id"] = source_uuid
+            transformed_observation["additional"] = additional
         except Exception as e:
             logger.error(
                 f"Error transforming observation {observation}: {e}",
-                extra={"attention_needed": True}
+                extra={"attention_needed": True},
             )
             continue
         else:

--- a/app/actions/source_profiles.py
+++ b/app/actions/source_profiles.py
@@ -37,6 +37,8 @@ class Assignment(BaseModel):
 
     def covers(self, when: datetime) -> bool:
         when = _ensure_utc(when)
+        if when is None:
+            return False
         lower = _ensure_utc(self.lower)
         upper = _ensure_utc(self.upper)
         if when < lower:

--- a/app/actions/source_profiles.py
+++ b/app/actions/source_profiles.py
@@ -37,6 +37,17 @@ class ResolvedSource(BaseModel):
     subject_type: Optional[str] = None
 
 
+def _chunked(seq, size):
+    seq = list(seq)
+    for i in range(0, len(seq), size):
+        yield seq[i:i + size]
+
+
+def _parse_dt(value):
+    from datetime import datetime
+    return datetime.fromisoformat(value) if value else None
+
+
 def resolve_source(profile: Optional[SourceProfile], source_uuid: str, recorded_at: datetime) -> ResolvedSource:
     """Pure: map a source UUID + observation time to its Gundi identifiers.
 
@@ -55,3 +66,80 @@ def resolve_source(profile: Optional[SourceProfile], source_uuid: str, recorded_
         source_name=chosen.subject_name if chosen else None,
         subject_type=chosen.subject_type if chosen else None,
     )
+
+
+class SourceProfileResolver:
+    """Per-run resolver: source UUID -> SourceProfile, fetched lazily and cached.
+
+    Covers both pull paths because it keys off the source UUIDs that actually
+    appear in observations. Enrichment failures degrade to a UUID fallback and
+    are never allowed to fail the pull.
+    """
+
+    def __init__(self, er_client, *, integration_id=None):
+        self._er = er_client
+        self._integration_id = integration_id
+        self._cache = {}
+
+    async def ensure(self, source_uuids: Iterable[str]) -> None:
+        missing = sorted({u for u in source_uuids if u and u not in self._cache})
+        if not missing:
+            return
+        try:
+            ranges_by_source = await self._fetch_ranges(missing)
+        except Exception as e:
+            logger.warning(
+                "Source assignments fetch failed for %s sources (%s); using UUID fallback for all.",
+                len(missing), e, extra={"attention_needed": True},
+            )
+            for uuid in missing:
+                self._cache[uuid] = SourceProfile()
+            return
+        for uuid in missing:
+            try:
+                self._cache[uuid] = await self._build_profile(uuid, ranges_by_source.get(uuid, []))
+            except Exception as e:
+                logger.warning(
+                    "Source profile fetch failed for %s (%s); using UUID fallback.",
+                    uuid, e, extra={"attention_needed": True},
+                )
+                self._cache[uuid] = SourceProfile()
+
+    def resolve(self, source_uuid, recorded_at) -> ResolvedSource:
+        return resolve_source(self._cache.get(source_uuid), source_uuid, recorded_at)
+
+    async def _fetch_ranges(self, source_uuids):
+        """source UUID -> list of (lower, upper, subject_uuid) from /subjectsources."""
+        out = {}
+        for chunk in _chunked(source_uuids, SOURCE_ID_CHUNK_SIZE):
+            try:
+                raw = await self._er.get_source_assignments(source_ids=list(chunk))
+            except Exception:
+                raise  # handled per-source by ensure() fallback below
+            records = raw.get("results", []) if isinstance(raw, dict) else raw
+            for rec in records or []:
+                src = rec.get("source")
+                rng = rec.get("assigned_range") or {}
+                if not src:
+                    continue
+                out.setdefault(src, []).append(
+                    (_parse_dt(rng.get("lower")), _parse_dt(rng.get("upper")), rec.get("subject"))
+                )
+        return out
+
+    async def _build_profile(self, source_uuid, ranges):
+        detail = await self._er.get_source_by_manufacturer_id(source_uuid)  # source/{uuid}/
+        manufacturer_id = (detail or {}).get("manufacturer_id")
+        subjects = await self._er.get_source_subjects(source_uuid)
+        subj_by_id = {s.get("id"): s for s in (subjects or [])}
+        assignments = []
+        for lower, upper, subject_uuid in ranges:
+            if lower is None:
+                continue
+            s = subj_by_id.get(subject_uuid, {})
+            assignments.append(Assignment(
+                lower=lower, upper=upper,
+                subject_name=s.get("name"),
+                subject_type=s.get("subject_type"),
+            ))
+        return SourceProfile(manufacturer_id=manufacturer_id, assignments=assignments)

--- a/app/actions/source_profiles.py
+++ b/app/actions/source_profiles.py
@@ -26,7 +26,14 @@ def _ensure_utc(dt: Optional[datetime]) -> Optional[datetime]:
 
 
 def _parse_dt(value):
-    return _ensure_utc(datetime.fromisoformat(value)) if value else None
+    if not value:
+        return None
+    # ER serializes assigned_range bounds with a trailing 'Z'
+    # (e.g. "9999-12-31T23:59:59.999999Z"), which datetime.fromisoformat
+    # rejects on Python 3.10. Normalize to a +00:00 offset before parsing.
+    if isinstance(value, str) and value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return _ensure_utc(datetime.fromisoformat(value))
 
 
 class Assignment(BaseModel):

--- a/app/actions/source_profiles.py
+++ b/app/actions/source_profiles.py
@@ -1,0 +1,37 @@
+# app/actions/source_profiles.py
+import logging
+from datetime import datetime
+from typing import Iterable, List, Optional
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+# ER's /subjectsources accepts a comma-joined list of source UUIDs; keep chunks
+# small so the query string can't 414 and the (single-page) response isn't truncated.
+SOURCE_ID_CHUNK_SIZE = 25
+
+
+class Assignment(BaseModel):
+    lower: datetime
+    upper: Optional[datetime] = None  # None = still assigned (open-ended)
+    subject_name: Optional[str] = None
+    subject_type: Optional[str] = None
+
+    def covers(self, when: datetime) -> bool:
+        if when < self.lower:
+            return False
+        if self.upper is not None and when >= self.upper:  # half-open [lower, upper)
+            return False
+        return True
+
+
+class SourceProfile(BaseModel):
+    manufacturer_id: Optional[str] = None
+    assignments: List[Assignment] = []
+
+
+class ResolvedSource(BaseModel):
+    external_source_id: str
+    source_name: Optional[str] = None
+    subject_type: Optional[str] = None

--- a/app/actions/source_profiles.py
+++ b/app/actions/source_profiles.py
@@ -35,3 +35,23 @@ class ResolvedSource(BaseModel):
     external_source_id: str
     source_name: Optional[str] = None
     subject_type: Optional[str] = None
+
+
+def resolve_source(profile: Optional[SourceProfile], source_uuid: str, recorded_at: datetime) -> ResolvedSource:
+    """Pure: map a source UUID + observation time to its Gundi identifiers.
+
+    external_source_id = manufacturer_id, falling back to er-src-{uuid}. The
+    subject name/type come from the assignment whose half-open [lower, upper)
+    range contains recorded_at; on overlap the latest-starting assignment wins.
+    """
+    fallback = f"er-src-{source_uuid}"
+    if profile is None:
+        return ResolvedSource(external_source_id=fallback)
+    external = profile.manufacturer_id or fallback
+    covering = [a for a in profile.assignments if a.covers(recorded_at)]
+    chosen = max(covering, key=lambda a: a.lower) if covering else None
+    return ResolvedSource(
+        external_source_id=external,
+        source_name=chosen.subject_name if chosen else None,
+        subject_type=chosen.subject_type if chosen else None,
+    )

--- a/app/actions/source_profiles.py
+++ b/app/actions/source_profiles.py
@@ -1,6 +1,6 @@
 # app/actions/source_profiles.py
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Iterable, List, Optional
 
 from pydantic import BaseModel
@@ -12,6 +12,23 @@ logger = logging.getLogger(__name__)
 SOURCE_ID_CHUNK_SIZE = 25
 
 
+def _ensure_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    """Return dt normalised to UTC-aware, or None if dt is None.
+
+    If dt has no tzinfo, attach UTC (ER sometimes returns offset-less ISO strings).
+    Otherwise convert to UTC so comparisons are always tz-homogeneous.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _parse_dt(value):
+    return _ensure_utc(datetime.fromisoformat(value)) if value else None
+
+
 class Assignment(BaseModel):
     lower: datetime
     upper: Optional[datetime] = None  # None = still assigned (open-ended)
@@ -19,9 +36,12 @@ class Assignment(BaseModel):
     subject_type: Optional[str] = None
 
     def covers(self, when: datetime) -> bool:
-        if when < self.lower:
+        when = _ensure_utc(when)
+        lower = _ensure_utc(self.lower)
+        upper = _ensure_utc(self.upper)
+        if when < lower:
             return False
-        if self.upper is not None and when >= self.upper:  # half-open [lower, upper)
+        if upper is not None and when >= upper:  # half-open [lower, upper)
             return False
         return True
 
@@ -43,11 +63,6 @@ def _chunked(seq, size):
         yield seq[i:i + size]
 
 
-def _parse_dt(value):
-    from datetime import datetime
-    return datetime.fromisoformat(value) if value else None
-
-
 def resolve_source(profile: Optional[SourceProfile], source_uuid: str, recorded_at: datetime) -> ResolvedSource:
     """Pure: map a source UUID + observation time to its Gundi identifiers.
 
@@ -60,7 +75,7 @@ def resolve_source(profile: Optional[SourceProfile], source_uuid: str, recorded_
         return ResolvedSource(external_source_id=fallback)
     external = profile.manufacturer_id or fallback
     covering = [a for a in profile.assignments if a.covers(recorded_at)]
-    chosen = max(covering, key=lambda a: a.lower) if covering else None
+    chosen = max(covering, key=lambda a: _ensure_utc(a.lower)) if covering else None
     return ResolvedSource(
         external_source_id=external,
         source_name=chosen.subject_name if chosen else None,
@@ -85,16 +100,9 @@ class SourceProfileResolver:
         missing = sorted({u for u in source_uuids if u and u not in self._cache})
         if not missing:
             return
-        try:
-            ranges_by_source = await self._fetch_ranges(missing)
-        except Exception as e:
-            logger.warning(
-                "Source assignments fetch failed for %s sources (%s); using UUID fallback for all.",
-                len(missing), e, extra={"attention_needed": True},
-            )
-            for uuid in missing:
-                self._cache[uuid] = SourceProfile()
-            return
+        # _fetch_ranges is now per-chunk resilient and never raises; always returns
+        # whatever it managed to collect before any failing chunk.
+        ranges_by_source = await self._fetch_ranges(missing)
         for uuid in missing:
             try:
                 self._cache[uuid] = await self._build_profile(uuid, ranges_by_source.get(uuid, []))
@@ -109,14 +117,36 @@ class SourceProfileResolver:
         return resolve_source(self._cache.get(source_uuid), source_uuid, recorded_at)
 
     async def _fetch_ranges(self, source_uuids):
-        """source UUID -> list of (lower, upper, subject_uuid) from /subjectsources."""
+        """source UUID -> list of (lower, upper, subject_uuid) from /subjectsources.
+
+        Chunks the request to keep URLs short. Per-chunk failures are logged and
+        skipped; successfully collected chunks are always returned. The fallback
+        to an empty SourceProfile() happens in ensure() for sources whose UUID
+        is absent from the returned dict.
+        """
         out = {}
         for chunk in _chunked(source_uuids, SOURCE_ID_CHUNK_SIZE):
             try:
                 raw = await self._er.get_source_assignments(source_ids=list(chunk))
-            except Exception:
-                raise  # handled per-source by ensure() fallback below
-            records = raw.get("results", []) if isinstance(raw, dict) else raw
+            except Exception as e:
+                logger.warning(
+                    "Source assignments chunk fetch failed for %d sources (%s); "
+                    "skipping chunk, already-collected results are preserved.",
+                    len(chunk), e, extra={"attention_needed": True},
+                )
+                continue
+            if isinstance(raw, dict):
+                if raw.get("next"):
+                    logger.warning(
+                        "subjectsources chunk returned a paginated 'next' "
+                        "(count=%s, chunk_size=%d) — sources may be dropped; "
+                        "lower SOURCE_ID_CHUNK_SIZE.",
+                        raw.get("count"), len(chunk),
+                        extra={"attention_needed": True},
+                    )
+                records = raw.get("results", [])
+            else:
+                records = raw
             for rec in records or []:
                 src = rec.get("source")
                 rng = rec.get("assigned_range") or {}
@@ -128,7 +158,10 @@ class SourceProfileResolver:
         return out
 
     async def _build_profile(self, source_uuid, ranges):
-        detail = await self._er.get_source_by_manufacturer_id(source_uuid)  # source/{uuid}/
+        # ER's get_source_by_manufacturer_id GETs /source/{id}/ — despite the method
+        # name it resolves by source PK (UUID), not manufacturer_id. No clearer method
+        # exists on AsyncERClient; see: dir(erclient.AsyncERClient) → no get_source/get_source_by_id.
+        detail = await self._er.get_source_by_manufacturer_id(source_uuid)
         manufacturer_id = (detail or {}).get("manufacturer_id")
         subjects = await self._er.get_source_subjects(source_uuid)
         subj_by_id = {s.get("id"): s for s in (subjects or [])}

--- a/app/actions/tests/fixtures/subjectsources_sample.json
+++ b/app/actions/tests/fixtures/subjectsources_sample.json
@@ -1,0 +1,44 @@
+{
+  "_note": "Captured from stage ER (gundi-dev.staging.pamdas.org) via dev/spike_source_profile.py on 2026-06-16. Confirms the live shapes SourceProfileResolver depends on: source detail carries manufacturer_id; assignments come back as a paginated {results:[...]} dict with Z-suffixed assigned_range bounds and a 'bounds' inclusivity flag; source/{id}/subjects is a plain list with name/subject_type.",
+  "source_uuid": "6ab62baf-44a3-441f-94c5-c8778b62f4e0",
+  "source_detail": {
+    "id": "6ab62baf-44a3-441f-94c5-c8778b62f4e0",
+    "source_type": null,
+    "manufacturer_id": "2356469",
+    "model_name": "generic:gundi_tracpoint_9d7720a0-881e-4f2e-bb21-5a7e3d29b807",
+    "additional": {},
+    "provider": "gundi_tracpoint_9d7720a0-881e-4f2e-bb21-5a7e3d29b807",
+    "content_type": "observations.source"
+  },
+  "assignments": {
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+      {
+        "id": "30214ab2-d37b-4569-9026-60f9fad34217",
+        "assigned_range": {
+          "lower": "0001-01-01T00:00:00Z",
+          "upper": "9999-12-31T23:59:59.999999Z",
+          "bounds": "[)"
+        },
+        "source": "6ab62baf-44a3-441f-94c5-c8778b62f4e0",
+        "subject": "75f26e4d-4120-4b20-8b67-de377b0c72d4",
+        "additional": {},
+        "location": null
+      }
+    ]
+  },
+  "subjects": [
+    {
+      "content_type": "observations.subject",
+      "id": "75f26e4d-4120-4b20-8b67-de377b0c72d4",
+      "name": "South Sudan JTEBB71J-104001956",
+      "subject_type": "vehicle",
+      "subject_subtype": "truck",
+      "common_name": null,
+      "additional": {},
+      "is_active": true
+    }
+  ]
+}

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -2211,3 +2211,37 @@ def test_transform_observation_enriches_with_z_timestamp():
     assert len(out) == 1, "Observation with Z-suffix timestamp must not be dropped"
     assert out[0]["source"] == "SERIAL-Z"
     assert out[0]["source_name"] == "Zeta"
+
+
+@pytest.mark.asyncio
+async def test_pull_source_window_enriches_via_resolver(mocker):
+    from app.actions.tests.conftest import AsyncIterator
+    from app.actions import handlers
+
+    er = mocker.MagicMock()
+    er.get_observations.return_value = AsyncIterator([[
+        {"source": "src-1", "recorded_at": "2026-06-01T00:00:00+00:00",
+         "location": {"longitude": 1.0, "latitude": 2.0}},
+    ]])
+    sent = {}
+
+    async def fake_send(observations, integration_id):
+        sent["observations"] = observations
+        return {}
+
+    mocker.patch.object(handlers, "send_observations_to_gundi", side_effect=fake_send)
+
+    resolver = mocker.MagicMock()
+    from app.actions.source_profiles import ResolvedSource
+    resolver.ensure = mocker.AsyncMock()
+    resolver.resolve.return_value = ResolvedSource(
+        external_source_id="SERIAL-9", source_name="Tau", subject_type="elephant")
+
+    count = await handlers._pull_source_window(
+        er, "src-1", "2026-06-01T00:00:00+00:00", "2026-06-02T00:00:00+00:00",
+        integration_id="int-1", resolver=resolver,
+    )
+    assert count == 1
+    resolver.ensure.assert_awaited()                       # sources prefetched
+    assert sent["observations"][0]["source"] == "SERIAL-9"
+    assert sent["observations"][0]["source_name"] == "Tau"

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -2195,3 +2195,19 @@ def test_transform_observation_without_resolver_keeps_legacy_fallback():
     out = transform_observations_to_gundi_schema(obs)
     assert out[0]["source"] == "er-src-src-1"
     assert "source_name" not in out[0]
+    assert out[0]["additional"]["er_source_id"] == "src-1"
+
+
+def test_transform_observation_enriches_with_z_timestamp():
+    prof = SourceProfile(manufacturer_id="SERIAL-Z", assignments=[
+        Assignment(lower=datetime(2026,1,1,tzinfo=timezone.utc), upper=None, subject_name="Zeta", subject_type="lion"),
+    ])
+    obs = [{
+        "source": "src-z",
+        "recorded_at": "2026-06-01T00:00:00Z",
+        "location": {"longitude": 10.0, "latitude": -1.0},
+    }]
+    out = transform_observations_to_gundi_schema(obs, resolver=_StaticResolver(prof))
+    assert len(out) == 1, "Observation with Z-suffix timestamp must not be dropped"
+    assert out[0]["source"] == "SERIAL-Z"
+    assert out[0]["source_name"] == "Zeta"

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -2242,6 +2242,7 @@ async def test_pull_source_window_enriches_via_resolver(mocker):
         integration_id="int-1", resolver=resolver,
     )
     assert count == 1
-    resolver.ensure.assert_awaited()                       # sources prefetched
+    resolver.ensure.assert_awaited_once_with({"src-1"})    # exact source-UUID set computed correctly
     assert sent["observations"][0]["source"] == "SERIAL-9"
     assert sent["observations"][0]["source_name"] == "Tau"
+    assert sent["observations"][0]["subject_type"] == "elephant"

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -2153,3 +2153,45 @@ async def test_pull_observations_resume_round_trip_completes(
     assert "backfill" not in final
     # Correct resume processes each of the 3 windows exactly once (no re-processing).
     assert mock_erclient_class.return_value.get_observations.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Task 5: transform_observations_to_gundi_schema — resolver enrichment
+# ---------------------------------------------------------------------------
+from datetime import datetime, timezone
+from app.actions.handlers import transform_observations_to_gundi_schema
+from app.actions.source_profiles import SourceProfile, Assignment, SourceProfileResolver
+
+
+class _StaticResolver:
+    def __init__(self, profile):
+        self._p = profile
+    def resolve(self, source_uuid, recorded_at):
+        from app.actions.source_profiles import resolve_source
+        return resolve_source(self._p, source_uuid, recorded_at)
+
+
+def test_transform_observation_enriches_with_profile():
+    prof = SourceProfile(manufacturer_id="SERIAL-9", assignments=[
+        Assignment(lower=datetime(2026,1,1,tzinfo=timezone.utc), upper=None, subject_name="Tau", subject_type="elephant"),
+    ])
+    obs = [{
+        "source": "src-1",
+        "recorded_at": "2026-06-01T00:00:00+00:00",
+        "location": {"longitude": -72.7, "latitude": -51.7},
+        "speed_kmph": 4,
+    }]
+    out = transform_observations_to_gundi_schema(obs, resolver=_StaticResolver(prof))
+    assert out[0]["source"] == "SERIAL-9"
+    assert out[0]["source_name"] == "Tau"
+    assert out[0]["subject_type"] == "elephant"
+    assert out[0]["location"] == {"lon": -72.7, "lat": -51.7}
+    assert out[0]["additional"]["er_source_id"] == "src-1"
+    assert out[0]["additional"]["speed_kmph"] == 4
+
+
+def test_transform_observation_without_resolver_keeps_legacy_fallback():
+    obs = [{"source": "src-1", "recorded_at": "2026-06-01T00:00:00+00:00"}]
+    out = transform_observations_to_gundi_schema(obs)
+    assert out[0]["source"] == "er-src-src-1"
+    assert "source_name" not in out[0]

--- a/app/actions/tests/test_source_profiles.py
+++ b/app/actions/tests/test_source_profiles.py
@@ -1,0 +1,20 @@
+# app/actions/tests/test_source_profiles.py
+from datetime import datetime, timezone
+from app.actions.source_profiles import Assignment, SourceProfile, ResolvedSource
+
+
+def _dt(s):
+    return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+
+def test_assignment_covers_open_ended():
+    a = Assignment(lower=_dt("2026-01-01T00:00:00"), upper=None, subject_name="Tau", subject_type="elephant")
+    assert a.covers(_dt("2026-06-01T00:00:00")) is True
+    assert a.covers(_dt("2025-12-31T23:59:59")) is False
+
+
+def test_assignment_covers_closed_range_half_open():
+    a = Assignment(lower=_dt("2026-01-01T00:00:00"), upper=_dt("2026-02-01T00:00:00"))
+    assert a.covers(_dt("2026-01-15T00:00:00")) is True
+    assert a.covers(_dt("2026-02-01T00:00:00")) is False  # upper exclusive
+    assert a.covers(_dt("2025-12-31T00:00:00")) is False

--- a/app/actions/tests/test_source_profiles.py
+++ b/app/actions/tests/test_source_profiles.py
@@ -65,3 +65,48 @@ def test_resolve_overlapping_picks_latest_starting():
     ])
     r = resolve_source(p, "abc-123", _dt("2026-06-01T00:00:00"))
     assert r.source_name == "New"
+
+
+import pytest
+from app.actions.source_profiles import SourceProfileResolver
+
+
+class _FakeER:
+    def __init__(self):
+        self.assignment_calls = []
+        self.source_detail_calls = []
+    async def get_source_assignments(self, subject_ids=None, source_ids=None):
+        self.assignment_calls.append(tuple(source_ids or []))
+        return [{
+            "assigned_range": {"lower": "2026-01-01T00:00:00+00:00", "upper": None},
+            "source": "src-1", "subject": "subj-1",
+        }]
+    async def get_source_subjects(self, source_id):
+        return [{"id": "subj-1", "name": "Tau", "subject_type": "elephant"}]
+    async def get_source_by_manufacturer_id(self, source_id):  # source/{uuid}/
+        self.source_detail_calls.append(source_id)
+        return {"id": "src-1", "manufacturer_id": "SERIAL-9"}
+
+
+@pytest.mark.asyncio
+async def test_resolver_builds_profile_and_caches():
+    er = _FakeER()
+    r = SourceProfileResolver(er)
+    await r.ensure(["src-1"])
+    await r.ensure(["src-1"])  # second call must hit cache, not refetch
+    assert er.source_detail_calls == ["src-1"]            # fetched once
+    assert er.assignment_calls == [("src-1",)]            # fetched once
+    res = r.resolve("src-1", _dt("2026-06-01T00:00:00"))
+    assert res.external_source_id == "SERIAL-9"
+    assert res.source_name == "Tau" and res.subject_type == "elephant"
+
+
+@pytest.mark.asyncio
+async def test_resolver_fetch_error_falls_back(mocker):
+    er = _FakeER()
+    mocker.patch.object(er, "get_source_assignments", side_effect=RuntimeError("boom"))
+    r = SourceProfileResolver(er)
+    await r.ensure(["src-1"])
+    res = r.resolve("src-1", _dt("2026-06-01T00:00:00"))
+    assert res.external_source_id == "er-src-src-1"       # fallback, never raises
+    assert res.source_name is None

--- a/app/actions/tests/test_source_profiles.py
+++ b/app/actions/tests/test_source_profiles.py
@@ -18,3 +18,50 @@ def test_assignment_covers_closed_range_half_open():
     assert a.covers(_dt("2026-01-15T00:00:00")) is True
     assert a.covers(_dt("2026-02-01T00:00:00")) is False  # upper exclusive
     assert a.covers(_dt("2025-12-31T00:00:00")) is False
+
+
+from app.actions.source_profiles import resolve_source
+
+
+def test_resolve_no_profile_falls_back_to_uuid():
+    r = resolve_source(None, "abc-123", _dt("2026-06-01T00:00:00"))
+    assert r.external_source_id == "er-src-abc-123"
+    assert r.source_name is None and r.subject_type is None
+
+
+def test_resolve_missing_manufacturer_id_falls_back_to_uuid():
+    p = SourceProfile(manufacturer_id=None, assignments=[
+        Assignment(lower=_dt("2026-01-01T00:00:00"), upper=None, subject_name="Tau", subject_type="elephant"),
+    ])
+    r = resolve_source(p, "abc-123", _dt("2026-06-01T00:00:00"))
+    assert r.external_source_id == "er-src-abc-123"
+    assert r.source_name == "Tau" and r.subject_type == "elephant"
+
+
+def test_resolve_uses_manufacturer_id_and_time_correct_subject():
+    p = SourceProfile(manufacturer_id="SERIAL-9", assignments=[
+        Assignment(lower=_dt("2026-01-01T00:00:00"), upper=_dt("2026-03-01T00:00:00"), subject_name="Tau", subject_type="elephant"),
+        Assignment(lower=_dt("2026-03-01T00:00:00"), upper=None, subject_name="Habi", subject_type="elephant"),
+    ])
+    early = resolve_source(p, "abc-123", _dt("2026-02-01T00:00:00"))
+    late = resolve_source(p, "abc-123", _dt("2026-06-01T00:00:00"))
+    assert early.external_source_id == "SERIAL-9" and early.source_name == "Tau"
+    assert late.source_name == "Habi"
+
+
+def test_resolve_no_covering_assignment_omits_name():
+    p = SourceProfile(manufacturer_id="SERIAL-9", assignments=[
+        Assignment(lower=_dt("2026-03-01T00:00:00"), upper=None, subject_name="Habi"),
+    ])
+    r = resolve_source(p, "abc-123", _dt("2026-01-01T00:00:00"))
+    assert r.external_source_id == "SERIAL-9"
+    assert r.source_name is None and r.subject_type is None
+
+
+def test_resolve_overlapping_picks_latest_starting():
+    p = SourceProfile(manufacturer_id="S", assignments=[
+        Assignment(lower=_dt("2026-01-01T00:00:00"), upper=None, subject_name="Old"),
+        Assignment(lower=_dt("2026-02-01T00:00:00"), upper=None, subject_name="New"),
+    ])
+    r = resolve_source(p, "abc-123", _dt("2026-06-01T00:00:00"))
+    assert r.source_name == "New"

--- a/app/actions/tests/test_source_profiles.py
+++ b/app/actions/tests/test_source_profiles.py
@@ -334,3 +334,47 @@ async def test_fetch_ranges_per_chunk_resilience(mocker):
     # Sources from the second (failed) chunk: _build_profile raises → UUID fallback
     res_last = r.resolve(f"src-{SOURCE_ID_CHUNK_SIZE}", _dt("2026-06-01T00:00:00"))
     assert res_last.external_source_id == f"er-src-src-{SOURCE_ID_CHUNK_SIZE}"
+
+
+@pytest.mark.asyncio
+async def test_resolver_handles_real_er_shapes_with_z_timestamps(mocker):
+    """Regression for the live shapes captured from stage ER.
+
+    ER serializes assigned_range bounds with a 'Z' suffix
+    (e.g. "9999-12-31T23:59:59.999999Z") and returns assignments as a
+    paginated {"results": [...]} dict. The resolver must parse those ranges
+    (not silently drop them on a fromisoformat error), so source_name /
+    subject_type populate alongside manufacturer_id.
+    """
+    er = mocker.MagicMock()
+    er.get_source_by_manufacturer_id = mocker.AsyncMock(
+        return_value={"id": "src-1", "manufacturer_id": "2356469"}
+    )
+    er.get_source_assignments = mocker.AsyncMock(
+        return_value={
+            "count": 1, "next": None, "previous": None,
+            "results": [{
+                "assigned_range": {
+                    "lower": "0001-01-01T00:00:00Z",
+                    "upper": "9999-12-31T23:59:59.999999Z",
+                    "bounds": "[)",
+                },
+                "source": "src-1", "subject": "subj-1",
+            }],
+        }
+    )
+    er.get_source_subjects = mocker.AsyncMock(
+        return_value=[{
+            "id": "subj-1",
+            "name": "South Sudan JTEBB71J-104001956",
+            "subject_type": "vehicle",
+        }]
+    )
+
+    r = SourceProfileResolver(er)
+    await r.ensure(["src-1"])
+    res = r.resolve("src-1", _dt("2026-06-01T00:00:00"))
+
+    assert res.external_source_id == "2356469"
+    assert res.source_name == "South Sudan JTEBB71J-104001956"
+    assert res.subject_type == "vehicle"

--- a/app/actions/tests/test_source_profiles.py
+++ b/app/actions/tests/test_source_profiles.py
@@ -7,6 +7,11 @@ def _dt(s):
     return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
 
 
+def _naive(s):
+    """Return a timezone-naive datetime (no tzinfo)."""
+    return datetime.fromisoformat(s)
+
+
 def test_assignment_covers_open_ended():
     a = Assignment(lower=_dt("2026-01-01T00:00:00"), upper=None, subject_name="Tau", subject_type="elephant")
     assert a.covers(_dt("2026-06-01T00:00:00")) is True
@@ -18,6 +23,38 @@ def test_assignment_covers_closed_range_half_open():
     assert a.covers(_dt("2026-01-15T00:00:00")) is True
     assert a.covers(_dt("2026-02-01T00:00:00")) is False  # upper exclusive
     assert a.covers(_dt("2025-12-31T00:00:00")) is False
+
+
+# --- timezone-naive vs aware comparison tests ---
+
+def test_assignment_covers_naive_recorded_at_against_aware_bounds():
+    """Naive recorded_at must NOT raise TypeError against an aware lower/upper."""
+    a = Assignment(
+        lower=_dt("2026-01-01T00:00:00"),
+        upper=_dt("2026-06-01T00:00:00"),
+        subject_name="Tau",
+        subject_type="elephant",
+    )
+    # naive datetime inside the range -> True
+    assert a.covers(_naive("2026-03-01T00:00:00")) is True
+    # naive datetime before lower -> False
+    assert a.covers(_naive("2025-12-31T00:00:00")) is False
+    # naive datetime at upper (exclusive) -> False
+    assert a.covers(_naive("2026-06-01T00:00:00")) is False
+
+
+def test_assignment_covers_naive_lower_against_aware_recorded_at():
+    """Aware recorded_at must NOT raise TypeError when lower/upper are naive (legacy data)."""
+    # lower stored as naive (simulate ER returning offset-less ISO string)
+    a = Assignment(
+        lower=_naive("2026-01-01T00:00:00"),
+        upper=_naive("2026-06-01T00:00:00"),
+        subject_name="Tau",
+    )
+    # aware recorded_at inside the range -> True
+    assert a.covers(_dt("2026-03-01T00:00:00")) is True
+    # aware recorded_at before lower -> False
+    assert a.covers(_dt("2025-12-01T00:00:00")) is False
 
 
 from app.actions.source_profiles import resolve_source
@@ -103,10 +140,182 @@ async def test_resolver_builds_profile_and_caches():
 
 @pytest.mark.asyncio
 async def test_resolver_fetch_error_falls_back(mocker):
+    """A get_source_assignments failure is now per-chunk: ensure() never raises.
+    _fetch_ranges skips the failing chunk and returns empty ranges.
+    _build_profile still runs; if that also fails we get the UUID fallback.
+    Here we patch both so we confirm the pull never raises."""
     er = _FakeER()
     mocker.patch.object(er, "get_source_assignments", side_effect=RuntimeError("boom"))
+    mocker.patch.object(er, "get_source_by_manufacturer_id", side_effect=RuntimeError("also boom"))
     r = SourceProfileResolver(er)
     await r.ensure(["src-1"])
     res = r.resolve("src-1", _dt("2026-06-01T00:00:00"))
     assert res.external_source_id == "er-src-src-1"       # fallback, never raises
     assert res.source_name is None
+
+
+# --- new test: ensure caches sources independently ---
+
+@pytest.mark.asyncio
+async def test_ensure_caches_sources_independently(mocker):
+    """ensure(["src-1","src-2"]) caches both; a _build_profile failure for one does not
+    corrupt or evict the other."""
+    er = _FakeER()
+
+    # _fetch_ranges returns data for both sources
+    async def fake_assignments(subject_ids=None, source_ids=None):
+        er.assignment_calls.append(tuple(source_ids or []))
+        return [
+            {
+                "assigned_range": {"lower": "2026-01-01T00:00:00+00:00", "upper": None},
+                "source": "src-1", "subject": "subj-1",
+            },
+            {
+                "assigned_range": {"lower": "2026-02-01T00:00:00+00:00", "upper": None},
+                "source": "src-2", "subject": "subj-2",
+            },
+        ]
+
+    mocker.patch.object(er, "get_source_assignments", side_effect=fake_assignments)
+
+    # _build_profile for src-2 raises; src-1 succeeds
+    original_get_source_by_manufacturer_id = er.get_source_by_manufacturer_id
+
+    async def failing_detail(source_id):
+        if source_id == "src-2":
+            raise RuntimeError("detail fetch failed for src-2")
+        return await original_get_source_by_manufacturer_id(source_id)
+
+    mocker.patch.object(er, "get_source_by_manufacturer_id", side_effect=failing_detail)
+
+    r = SourceProfileResolver(er)
+    await r.ensure(["src-1", "src-2"])
+
+    # src-1 should have a real profile with SERIAL-9
+    res1 = r.resolve("src-1", _dt("2026-06-01T00:00:00"))
+    assert res1.external_source_id == "SERIAL-9"
+    assert res1.source_name == "Tau"
+
+    # src-2 should have fallen back gracefully (empty SourceProfile)
+    res2 = r.resolve("src-2", _dt("2026-06-01T00:00:00"))
+    assert res2.external_source_id == "er-src-src-2"
+    assert res2.source_name is None
+
+
+# --- new test: chunking into multiple get_source_assignments calls ---
+
+@pytest.mark.asyncio
+async def test_ensure_chunks_large_source_list(mocker):
+    """Passing >25 source UUIDs results in TWO get_source_assignments calls."""
+    from app.actions.source_profiles import SOURCE_ID_CHUNK_SIZE
+
+    er = _FakeER()
+    # Return empty results (no assignments) — we only care about call count/chunking
+    async def empty_assignments(subject_ids=None, source_ids=None):
+        er.assignment_calls.append(tuple(source_ids or []))
+        return []
+
+    mocker.patch.object(er, "get_source_assignments", side_effect=empty_assignments)
+    mocker.patch.object(er, "get_source_by_manufacturer_id", return_value={"manufacturer_id": None})
+    mocker.patch.object(er, "get_source_subjects", return_value=[])
+
+    # Create SOURCE_ID_CHUNK_SIZE + 1 sources so we get 2 chunks
+    source_uuids = [f"src-{i}" for i in range(SOURCE_ID_CHUNK_SIZE + 1)]
+
+    r = SourceProfileResolver(er)
+    await r.ensure(source_uuids)
+
+    # Should have made exactly 2 get_source_assignments calls
+    assert len(er.assignment_calls) == 2
+    # First chunk should have SOURCE_ID_CHUNK_SIZE elements
+    assert len(er.assignment_calls[0]) == SOURCE_ID_CHUNK_SIZE
+    # Second chunk should have the remainder
+    assert len(er.assignment_calls[1]) == 1
+    # All sources should be cached
+    for uuid in source_uuids:
+        assert uuid in r._cache
+
+
+# --- new test: _fetch_ranges warns on paginated 'next' ---
+
+@pytest.mark.asyncio
+async def test_fetch_ranges_warns_on_pagination(mocker):
+    """When a chunk response dict carries a truthy 'next', a warning is logged."""
+    er = _FakeER()
+
+    async def paginated_response(subject_ids=None, source_ids=None):
+        return {
+            "results": [
+                {
+                    "assigned_range": {"lower": "2026-01-01T00:00:00+00:00", "upper": None},
+                    "source": "src-1", "subject": "subj-1",
+                }
+            ],
+            "next": "http://example.com/api/v1.0/subjectsources/?page=2",
+            "count": 50,
+        }
+
+    mocker.patch.object(er, "get_source_assignments", side_effect=paginated_response)
+    mock_warning = mocker.patch("app.actions.source_profiles.logger.warning")
+
+    r = SourceProfileResolver(er)
+    await r.ensure(["src-1"])
+
+    # At least one warning call should mention pagination / 'next'
+    warning_texts = [str(call) for call in mock_warning.call_args_list]
+    assert any("next" in t.lower() or "pagina" in t.lower() for t in warning_texts), (
+        f"Expected pagination warning, got: {warning_texts}"
+    )
+
+
+# --- new test: per-chunk resilience in _fetch_ranges ---
+
+@pytest.mark.asyncio
+async def test_fetch_ranges_per_chunk_resilience(mocker):
+    """A failing chunk in _fetch_ranges must not discard results from successful chunks.
+    The pull must not raise out of ensure()."""
+    from app.actions.source_profiles import SOURCE_ID_CHUNK_SIZE
+
+    er = _FakeER()
+    call_count = 0
+
+    async def sometimes_fails(subject_ids=None, source_ids=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First chunk succeeds
+            return [
+                {
+                    "assigned_range": {"lower": "2026-01-01T00:00:00+00:00", "upper": None},
+                    "source": "src-0", "subject": "subj-1",
+                }
+            ]
+        else:
+            # Second chunk fails
+            raise RuntimeError("network error on chunk 2")
+
+    mocker.patch.object(er, "get_source_assignments", side_effect=sometimes_fails)
+
+    # get_source_by_manufacturer_id only returns MFRID-0 for src-0;
+    # all others raise so they fall through to the UUID fallback.
+    async def discriminating_detail(source_id):
+        if source_id == "src-0":
+            return {"manufacturer_id": "MFRID-0"}
+        raise RuntimeError(f"detail unavailable for {source_id}")
+
+    mocker.patch.object(er, "get_source_by_manufacturer_id", side_effect=discriminating_detail)
+    mocker.patch.object(er, "get_source_subjects", return_value=[{"id": "subj-1", "name": "Tau", "subject_type": "elephant"}])
+
+    source_uuids = [f"src-{i}" for i in range(SOURCE_ID_CHUNK_SIZE + 1)]
+
+    r = SourceProfileResolver(er)
+    # Must NOT raise
+    await r.ensure(source_uuids)
+
+    # src-0 (in first chunk) should have assignment data from the successful chunk
+    res0 = r.resolve("src-0", _dt("2026-06-01T00:00:00"))
+    assert res0.external_source_id == "MFRID-0"
+
+    # Sources from the second (failed) chunk: _build_profile raises → UUID fallback
+    res_last = r.resolve(f"src-{SOURCE_ID_CHUNK_SIZE}", _dt("2026-06-01T00:00:00"))
+    assert res_last.external_source_id == f"er-src-src-{SOURCE_ID_CHUNK_SIZE}"

--- a/app/actions/tests/test_source_profiles.py
+++ b/app/actions/tests/test_source_profiles.py
@@ -104,6 +104,21 @@ def test_resolve_overlapping_picks_latest_starting():
     assert r.source_name == "New"
 
 
+def test_assignment_covers_none_when():
+    """Assignment.covers(None) must return False, never raise TypeError."""
+    a = Assignment(lower=_dt("2026-01-01T00:00:00"), upper=None, subject_name="X")
+    assert a.covers(None) is False
+
+
+def test_resolve_source_none_recorded_at():
+    """resolve_source with recorded_at=None: identity resolved, no subject, no exception."""
+    p = SourceProfile(manufacturer_id="S", assignments=[
+        Assignment(lower=_dt("2026-01-01T00:00:00"), upper=None, subject_name="Tau", subject_type="elephant"),
+    ])
+    r = resolve_source(p, "src-1", None)
+    assert r == ResolvedSource(external_source_id="S", source_name=None, subject_type=None)
+
+
 import pytest
 from app.actions.source_profiles import SourceProfileResolver
 

--- a/dev/spike_source_profile.py
+++ b/dev/spike_source_profile.py
@@ -1,0 +1,80 @@
+"""Spike: confirm the ER responses the SourceProfileResolver depends on.
+
+Runs the three EarthRanger calls the resolver makes for one source UUID and
+prints the JSON, so you can eyeball:
+
+  * source detail        -> does it carry a populated `manufacturer_id`?
+  * subjectsources        -> `assigned_range` shape + are HISTORICAL ranges returned?
+  * source/{id}/subjects  -> subject `name` / `subject_type` for the join
+
+The API *shapes* are already confirmed from the `das` serializers/viewsets
+(see docs/superpowers/specs/2026-06-16-er-observation-source-naming-design.md);
+this validates the live DATA for a real deployment and produces a fixture.
+
+Usage:
+    export ER_HOST=gundi-er.stage.pamdas.org     # hostname only, no scheme/path
+    export ER_TOKEN=<an ER API token>
+    export SOURCE_UUID=<a source UUID that has at least one subject assignment>
+    # optional: export OUT=app/actions/tests/fixtures/subjectsources_sample.json
+    python dev/spike_source_profile.py
+"""
+import asyncio
+import json
+import os
+
+from erclient import AsyncERClient
+
+
+async def main():
+    host = os.environ["ER_HOST"]
+    token = os.environ["ER_TOKEN"]
+    source_uuid = os.environ["SOURCE_UUID"]
+
+    client = AsyncERClient(
+        service_root=f"https://{host}/api/v1.0",
+        token=token,
+        token_url=f"https://{host}/oauth2/token",
+        client_id="das_web_client",
+    )
+
+    async with client as er:
+        # 1) Source detail by UUID -> manufacturer_id. erclient.get_source_by_manufacturer_id
+        #    GETs source/{identifier}/, which ER resolves by PK when given a UUID
+        #    (das SourceView._resolve_identifier).
+        source_detail = await er.get_source_by_manufacturer_id(source_uuid)
+        # 2) Assignment history (ranges + subject UUIDs), filtered by source.
+        assignments = await er.get_source_assignments(source_ids=[source_uuid])
+        # 3) Subjects ever linked to the source (for the subject UUID -> name/type join).
+        subjects = await er.get_source_subjects(source_uuid)
+
+    result = {
+        "source_uuid": source_uuid,
+        "source_detail": source_detail,
+        "assignments": assignments,
+        "subjects": subjects,
+    }
+    print(json.dumps(result, indent=2, default=str))
+
+    # Quick assertions to surface the answers without reading the full dump.
+    mfg = (source_detail or {}).get("manufacturer_id") if isinstance(source_detail, dict) else None
+    print("\n--- spike summary ---")
+    print(f"manufacturer_id populated: {bool(mfg)} ({mfg!r})")
+    recs = assignments.get("results", assignments) if isinstance(assignments, dict) else assignments
+    print(f"assignment rows returned: {len(recs) if recs else 0}")
+    if recs:
+        print(f"first assigned_range: {recs[0].get('assigned_range')!r}")
+        print(f"paginated 'next' present (rows may be truncated): "
+              f"{bool(assignments.get('next')) if isinstance(assignments, dict) else False}")
+    subj = subjects.get("results", subjects) if isinstance(subjects, dict) else subjects
+    if subj:
+        print(f"subject sample: name={subj[0].get('name')!r} subject_type={subj[0].get('subject_type')!r}")
+
+    out = os.environ.get("OUT")
+    if out:
+        with open(out, "w") as f:
+            json.dump(result, f, indent=2, default=str)
+        print(f"\nwrote fixture: {out}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/actions/pull-observations.md
+++ b/docs/actions/pull-observations.md
@@ -25,8 +25,7 @@ Designed to backfill large historical windows safely and resumably.
    no-progress runs).
 6. **Advance the watermark** only when the entire window is complete.
 
-Observations are transformed with a `source` of `er-src-<source-uuid>` and a `{lon, lat}` location; all
-other ER fields are carried in `additional`. See [Data flow](../data-flow.md#observations).
+Observations are transformed with `external_source_id = manufacturer_id` (falling back to `er-src-{uuid}`), `source_name = time-accurate Subject.name`, and `subject_type`; location is mapped to `{lon, lat}`; and all other ER fields are carried in `additional`. See [Data flow](../data-flow.md#observations).
 
 ## Configuration — `PullObservationsConfig`
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -59,10 +59,15 @@ contract.
 
 | Gundi field | Source |
 |-------------|--------|
-| `source` | `er-src-<ER source UUID>`. |
+| `source` (external_source_id) | `Source.manufacturer_id`, falling back to `er-src-<ER source UUID>` when absent. |
+| `source_name` | `Subject.name` for the subject assigned at the observation's `recorded_at` (time-accurate via `assigned_range`). |
+| `subject_type` | the assigned subject's type. |
 | `recorded_at` | ER `recorded_at`. |
 | `location` | ER `{longitude, latitude}` → `{lon, lat}`. |
-| `additional` | Any remaining ER fields. |
+| `additional.er_source_id` | the raw ER source UUID, preserved for traceability. |
+| `additional` | remaining ER fields. |
+
+Enrichment is best-effort — if the device or subject can't be resolved, the observation still sends under `er-src-<uuid>` with no name.
 
 Observations are sent with `send_observations_to_gundi()` (a batched POST). All Gundi send functions retry
 with exponential backoff on HTTP errors.

--- a/docs/superpowers/plans/2026-06-16-er-observation-source-naming.md
+++ b/docs/superpowers/plans/2026-06-16-er-observation-source-naming.md
@@ -1,0 +1,690 @@
+# Time-Accurate Source Naming for ER Observations — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the meaningless `er-src-{uuid}` source identifier on pulled ER observations with the device's natural `manufacturer_id` (`external_source_id`), the time-correct `Subject.name` (`source_name`), and `subject_type`.
+
+**Architecture:** A new per-run `SourceProfileResolver` (in `app/actions/source_profiles.py`) lazily fetches and caches, per ER source UUID, the device `manufacturer_id` and the full subject-assignment history (`assigned_range` + subject name/type). `transform_observations_to_gundi_schema` consults it to label each observation with the subject assigned at that observation's `recorded_at`. Pure range-matching logic is separated from I/O so it is unit-testable without mocks.
+
+**Tech Stack:** Python 3.10, Pydantic v1 (matches `gundi_core`), `pytest` + `pytest-asyncio` + `pytest-mock`, the async `erclient`.
+
+---
+
+## Spec
+
+Implements `docs/superpowers/specs/2026-06-16-er-observation-source-naming-design.md`. Read it first.
+
+## Confirmed ER data shapes (from `das` serializers + `erclient`)
+
+- `get_source_assignments(source_ids=[...])` → `GET /subjectsources?sources=uuid1,uuid2` → list of
+  `{"id", "assigned_range": {"lower": iso, "upper": iso|null}, "source": "<uuid>", "subject": "<uuid>", ...}`.
+- `get_source_subjects(source_id)` → `GET source/{id}/subjects` → list of subject dicts with `{"id", "name", "subject_type", "subject_subtype", ...}`.
+- Source `manufacturer_id` lives on the source detail (`SourceSerializer`: `{"id", "manufacturer_id", ...}`), fetched via `GET source/{uuid}/` (the `erclient.get_source_by_manufacturer_id` method hits this path; ER resolves it by PK or manufacturer_id).
+
+## File structure
+
+- **Create** `app/actions/source_profiles.py` — `Assignment`, `SourceProfile`, `ResolvedSource` (Pydantic), the pure `resolve_source(...)` helper, and `SourceProfileResolver` (I/O). Self-contained; keeps the already-large `handlers.py` from growing.
+- **Create** `app/actions/tests/test_source_profiles.py` — unit tests for the models, `resolve_source`, and the resolver (mocked `erclient`).
+- **Modify** `app/actions/handlers.py` — `transform_observations_to_gundi_schema` signature/body; `_pull_source_window` to build+thread the resolver; `action_pull_observations` to construct one resolver per run.
+- **Modify** `app/actions/tests/test_actions.py` — transform tests + a `pull_observations` wiring test.
+- **Modify** `docs/actions/pull-observations.md` and `docs/data-flow.md` — document the new fields.
+
+---
+
+## Task 1: Spike — confirm fetch shapes against stage ER, capture fixtures
+
+**Files:**
+- Create: `app/actions/tests/fixtures/subjectsources_sample.json` (recorded real responses)
+
+- [ ] **Step 1: Capture real responses from stage ER**
+
+Using stage credentials (see `local/.env.local`), in a Python REPL or scratch script, call against a source UUID that has at least one subject assignment:
+
+```python
+import asyncio
+from erclient import AsyncERClient
+async def main():
+    c = AsyncERClient(service_root=..., token=..., ...)
+    async with c as er:
+        print("ASSIGNMENTS:", await er.get_source_assignments(source_ids=["<src-uuid>"]))
+        print("SUBJECTS:", await er.get_source_subjects("<src-uuid>"))
+        print("SOURCE:", await er.get_source_by_manufacturer_id("<src-uuid>"))  # source/{uuid}/
+asyncio.run(main())
+```
+
+- [ ] **Step 2: Confirm and record these facts** (write them into the spec's "implementation spike" note and save the JSON to the fixture file):
+  - `assigned_range` exact keys and ISO format; whether `upper` is `null` for an open (current) assignment.
+  - Whether `get_source_assignments` returns **historical** (past) assignments, not just current.
+  - Whether `get_source_subjects` includes subjects from **past** assignments or only currently-linked ones (affects whether we can name a historically-assigned-but-now-unlinked subject).
+  - The exact key for source `manufacturer_id` in the source-detail response.
+
+- [ ] **Step 3: Commit the fixture**
+
+```bash
+git add app/actions/tests/fixtures/subjectsources_sample.json
+git commit -m "test: capture ER subjectsources/source/subjects fixtures for source-naming"
+```
+
+> If Step 2 reveals `get_source_assignments` does NOT return historical ranges, stop and revisit the spec with the user — time-accuracy would need a different endpoint.
+
+---
+
+## Task 2: Data models
+
+**Files:**
+- Create: `app/actions/source_profiles.py`
+- Test: `app/actions/tests/test_source_profiles.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# app/actions/tests/test_source_profiles.py
+from datetime import datetime, timezone
+from app.actions.source_profiles import Assignment, SourceProfile, ResolvedSource
+
+
+def _dt(s):
+    return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+
+def test_assignment_covers_open_ended():
+    a = Assignment(lower=_dt("2026-01-01T00:00:00"), upper=None, subject_name="Tau", subject_type="elephant")
+    assert a.covers(_dt("2026-06-01T00:00:00")) is True
+    assert a.covers(_dt("2025-12-31T23:59:59")) is False
+
+
+def test_assignment_covers_closed_range_half_open():
+    a = Assignment(lower=_dt("2026-01-01T00:00:00"), upper=_dt("2026-02-01T00:00:00"))
+    assert a.covers(_dt("2026-01-15T00:00:00")) is True
+    assert a.covers(_dt("2026-02-01T00:00:00")) is False  # upper exclusive
+    assert a.covers(_dt("2025-12-31T00:00:00")) is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest app/actions/tests/test_source_profiles.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.actions.source_profiles'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/actions/source_profiles.py
+import logging
+from datetime import datetime
+from typing import Iterable, List, Optional
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+# ER's /subjectsources accepts a comma-joined list of source UUIDs; keep chunks
+# small so the query string can't 414 and the (single-page) response isn't truncated.
+SOURCE_ID_CHUNK_SIZE = 25
+
+
+class Assignment(BaseModel):
+    lower: datetime
+    upper: Optional[datetime] = None  # None = still assigned (open-ended)
+    subject_name: Optional[str] = None
+    subject_type: Optional[str] = None
+
+    def covers(self, when: datetime) -> bool:
+        if when < self.lower:
+            return False
+        if self.upper is not None and when >= self.upper:  # half-open [lower, upper)
+            return False
+        return True
+
+
+class SourceProfile(BaseModel):
+    manufacturer_id: Optional[str] = None
+    assignments: List[Assignment] = []
+
+
+class ResolvedSource(BaseModel):
+    external_source_id: str
+    source_name: Optional[str] = None
+    subject_type: Optional[str] = None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest app/actions/tests/test_source_profiles.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/source_profiles.py app/actions/tests/test_source_profiles.py
+git commit -m "feat: add source-profile data models for ER observation naming"
+```
+
+---
+
+## Task 3: Pure `resolve_source` range-matching
+
+**Files:**
+- Modify: `app/actions/source_profiles.py`
+- Test: `app/actions/tests/test_source_profiles.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to app/actions/tests/test_source_profiles.py
+from app.actions.source_profiles import resolve_source
+
+
+def test_resolve_no_profile_falls_back_to_uuid():
+    r = resolve_source(None, "abc-123", _dt("2026-06-01T00:00:00"))
+    assert r.external_source_id == "er-src-abc-123"
+    assert r.source_name is None and r.subject_type is None
+
+
+def test_resolve_missing_manufacturer_id_falls_back_to_uuid():
+    p = SourceProfile(manufacturer_id=None, assignments=[
+        Assignment(lower=_dt("2026-01-01T00:00:00"), upper=None, subject_name="Tau", subject_type="elephant"),
+    ])
+    r = resolve_source(p, "abc-123", _dt("2026-06-01T00:00:00"))
+    assert r.external_source_id == "er-src-abc-123"
+    assert r.source_name == "Tau" and r.subject_type == "elephant"
+
+
+def test_resolve_uses_manufacturer_id_and_time_correct_subject():
+    p = SourceProfile(manufacturer_id="SERIAL-9", assignments=[
+        Assignment(lower=_dt("2026-01-01T00:00:00"), upper=_dt("2026-03-01T00:00:00"), subject_name="Tau", subject_type="elephant"),
+        Assignment(lower=_dt("2026-03-01T00:00:00"), upper=None, subject_name="Habi", subject_type="elephant"),
+    ])
+    early = resolve_source(p, "abc-123", _dt("2026-02-01T00:00:00"))
+    late = resolve_source(p, "abc-123", _dt("2026-06-01T00:00:00"))
+    assert early.external_source_id == "SERIAL-9" and early.source_name == "Tau"
+    assert late.source_name == "Habi"
+
+
+def test_resolve_no_covering_assignment_omits_name():
+    p = SourceProfile(manufacturer_id="SERIAL-9", assignments=[
+        Assignment(lower=_dt("2026-03-01T00:00:00"), upper=None, subject_name="Habi"),
+    ])
+    r = resolve_source(p, "abc-123", _dt("2026-01-01T00:00:00"))
+    assert r.external_source_id == "SERIAL-9"
+    assert r.source_name is None and r.subject_type is None
+
+
+def test_resolve_overlapping_picks_latest_starting():
+    p = SourceProfile(manufacturer_id="S", assignments=[
+        Assignment(lower=_dt("2026-01-01T00:00:00"), upper=None, subject_name="Old"),
+        Assignment(lower=_dt("2026-02-01T00:00:00"), upper=None, subject_name="New"),
+    ])
+    r = resolve_source(p, "abc-123", _dt("2026-06-01T00:00:00"))
+    assert r.source_name == "New"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest app/actions/tests/test_source_profiles.py -k resolve -v`
+Expected: FAIL — `ImportError: cannot import name 'resolve_source'`
+
+- [ ] **Step 3: Implement**
+
+```python
+# append to app/actions/source_profiles.py
+def resolve_source(profile: Optional[SourceProfile], source_uuid: str, recorded_at: datetime) -> ResolvedSource:
+    """Pure: map a source UUID + observation time to its Gundi identifiers.
+
+    external_source_id = manufacturer_id, falling back to er-src-{uuid}. The
+    subject name/type come from the assignment whose half-open [lower, upper)
+    range contains recorded_at; on overlap the latest-starting assignment wins.
+    """
+    fallback = f"er-src-{source_uuid}"
+    if profile is None:
+        return ResolvedSource(external_source_id=fallback)
+    external = profile.manufacturer_id or fallback
+    covering = [a for a in profile.assignments if a.covers(recorded_at)]
+    chosen = max(covering, key=lambda a: a.lower) if covering else None
+    return ResolvedSource(
+        external_source_id=external,
+        source_name=chosen.subject_name if chosen else None,
+        subject_type=chosen.subject_type if chosen else None,
+    )
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest app/actions/tests/test_source_profiles.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/source_profiles.py app/actions/tests/test_source_profiles.py
+git commit -m "feat: add time-accurate resolve_source range matching"
+```
+
+---
+
+## Task 4: `SourceProfileResolver` — fetch + cache
+
+**Files:**
+- Modify: `app/actions/source_profiles.py`
+- Test: `app/actions/tests/test_source_profiles.py`
+
+- [ ] **Step 1: Write the failing test** (mock the erclient; assignment ranges joined to subject detail + manufacturer_id)
+
+```python
+# append to app/actions/tests/test_source_profiles.py
+import pytest
+from app.actions.source_profiles import SourceProfileResolver
+
+
+class _FakeER:
+    def __init__(self):
+        self.assignment_calls = []
+        self.source_detail_calls = []
+    async def get_source_assignments(self, subject_ids=None, source_ids=None):
+        self.assignment_calls.append(tuple(source_ids or []))
+        return [{
+            "assigned_range": {"lower": "2026-01-01T00:00:00+00:00", "upper": None},
+            "source": "src-1", "subject": "subj-1",
+        }]
+    async def get_source_subjects(self, source_id):
+        return [{"id": "subj-1", "name": "Tau", "subject_type": "elephant"}]
+    async def get_source_by_manufacturer_id(self, source_id):  # source/{uuid}/
+        self.source_detail_calls.append(source_id)
+        return {"id": "src-1", "manufacturer_id": "SERIAL-9"}
+
+
+@pytest.mark.asyncio
+async def test_resolver_builds_profile_and_caches():
+    er = _FakeER()
+    r = SourceProfileResolver(er)
+    await r.ensure(["src-1"])
+    await r.ensure(["src-1"])  # second call must hit cache, not refetch
+    assert er.source_detail_calls == ["src-1"]            # fetched once
+    assert er.assignment_calls == [("src-1",)]            # fetched once
+    res = r.resolve("src-1", _dt("2026-06-01T00:00:00"))
+    assert res.external_source_id == "SERIAL-9"
+    assert res.source_name == "Tau" and res.subject_type == "elephant"
+
+
+@pytest.mark.asyncio
+async def test_resolver_fetch_error_falls_back(mocker):
+    er = _FakeER()
+    mocker.patch.object(er, "get_source_assignments", side_effect=RuntimeError("boom"))
+    r = SourceProfileResolver(er)
+    await r.ensure(["src-1"])
+    res = r.resolve("src-1", _dt("2026-06-01T00:00:00"))
+    assert res.external_source_id == "er-src-src-1"       # fallback, never raises
+    assert res.source_name is None
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest app/actions/tests/test_source_profiles.py -k resolver -v`
+Expected: FAIL — `ImportError: cannot import name 'SourceProfileResolver'`
+
+- [ ] **Step 3: Implement**
+
+```python
+# append to app/actions/source_profiles.py
+def _chunked(seq, size):
+    seq = list(seq)
+    for i in range(0, len(seq), size):
+        yield seq[i:i + size]
+
+
+def _parse_dt(value):
+    from datetime import datetime
+    return datetime.fromisoformat(value) if value else None
+
+
+class SourceProfileResolver:
+    """Per-run resolver: source UUID -> SourceProfile, fetched lazily and cached.
+
+    Covers both pull paths because it keys off the source UUIDs that actually
+    appear in observations. Enrichment failures degrade to a UUID fallback and
+    are never allowed to fail the pull.
+    """
+
+    def __init__(self, er_client, *, integration_id=None):
+        self._er = er_client
+        self._integration_id = integration_id
+        self._cache = {}
+
+    async def ensure(self, source_uuids: Iterable[str]) -> None:
+        missing = sorted({u for u in source_uuids if u and u not in self._cache})
+        if not missing:
+            return
+        ranges_by_source = await self._fetch_ranges(missing)
+        for uuid in missing:
+            try:
+                self._cache[uuid] = await self._build_profile(uuid, ranges_by_source.get(uuid, []))
+            except Exception as e:
+                logger.warning(
+                    "Source profile fetch failed for %s (%s); using UUID fallback.",
+                    uuid, e, extra={"attention_needed": True},
+                )
+                self._cache[uuid] = SourceProfile()
+
+    def resolve(self, source_uuid, recorded_at) -> ResolvedSource:
+        return resolve_source(self._cache.get(source_uuid), source_uuid, recorded_at)
+
+    async def _fetch_ranges(self, source_uuids):
+        """source UUID -> list of (lower, upper, subject_uuid) from /subjectsources."""
+        out = {}
+        for chunk in _chunked(source_uuids, SOURCE_ID_CHUNK_SIZE):
+            try:
+                raw = await self._er.get_source_assignments(source_ids=list(chunk))
+            except Exception:
+                raise  # handled per-source by ensure() fallback below
+            records = raw.get("results", []) if isinstance(raw, dict) else raw
+            for rec in records or []:
+                src = rec.get("source")
+                rng = rec.get("assigned_range") or {}
+                if not src:
+                    continue
+                out.setdefault(src, []).append(
+                    (_parse_dt(rng.get("lower")), _parse_dt(rng.get("upper")), rec.get("subject"))
+                )
+        return out
+
+    async def _build_profile(self, source_uuid, ranges):
+        detail = await self._er.get_source_by_manufacturer_id(source_uuid)  # source/{uuid}/
+        manufacturer_id = (detail or {}).get("manufacturer_id")
+        subjects = await self._er.get_source_subjects(source_uuid)
+        subj_by_id = {s.get("id"): s for s in (subjects or [])}
+        assignments = []
+        for lower, upper, subject_uuid in ranges:
+            if lower is None:
+                continue
+            s = subj_by_id.get(subject_uuid, {})
+            assignments.append(Assignment(
+                lower=lower, upper=upper,
+                subject_name=s.get("name"),
+                subject_type=s.get("subject_type"),
+            ))
+        return SourceProfile(manufacturer_id=manufacturer_id, assignments=assignments)
+```
+
+> The exact join (whether `get_source_subjects` covers historically-assigned subjects) is what Task 1 confirms. If past subjects are missing from it, replace the `get_source_subjects` lookup with per-subject detail fetches keyed by the assignment's `subject` UUID.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest app/actions/tests/test_source_profiles.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/source_profiles.py app/actions/tests/test_source_profiles.py
+git commit -m "feat: add SourceProfileResolver with lazy fetch, cache, and fallback"
+```
+
+---
+
+## Task 5: Use the resolver in the observation transform
+
+**Files:**
+- Modify: `app/actions/handlers.py` (`transform_observations_to_gundi_schema`, ~line 1303)
+- Test: `app/actions/tests/test_actions.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to app/actions/tests/test_actions.py
+from datetime import datetime, timezone
+from app.actions.handlers import transform_observations_to_gundi_schema
+from app.actions.source_profiles import SourceProfile, Assignment, SourceProfileResolver
+
+
+class _StaticResolver:
+    def __init__(self, profile):
+        self._p = profile
+    def resolve(self, source_uuid, recorded_at):
+        from app.actions.source_profiles import resolve_source
+        return resolve_source(self._p, source_uuid, recorded_at)
+
+
+def test_transform_observation_enriches_with_profile():
+    prof = SourceProfile(manufacturer_id="SERIAL-9", assignments=[
+        Assignment(lower=datetime(2026,1,1,tzinfo=timezone.utc), upper=None, subject_name="Tau", subject_type="elephant"),
+    ])
+    obs = [{
+        "source": "src-1",
+        "recorded_at": "2026-06-01T00:00:00+00:00",
+        "location": {"longitude": -72.7, "latitude": -51.7},
+        "speed_kmph": 4,
+    }]
+    out = transform_observations_to_gundi_schema(obs, resolver=_StaticResolver(prof))
+    assert out[0]["source"] == "SERIAL-9"
+    assert out[0]["source_name"] == "Tau"
+    assert out[0]["subject_type"] == "elephant"
+    assert out[0]["location"] == {"lon": -72.7, "lat": -51.7}
+    assert out[0]["additional"]["er_source_id"] == "src-1"
+    assert out[0]["additional"]["speed_kmph"] == 4
+
+
+def test_transform_observation_without_resolver_keeps_legacy_fallback():
+    obs = [{"source": "src-1", "recorded_at": "2026-06-01T00:00:00+00:00"}]
+    out = transform_observations_to_gundi_schema(obs)
+    assert out[0]["source"] == "er-src-src-1"
+    assert "source_name" not in out[0]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest app/actions/tests/test_actions.py -k transform_observation -v`
+Expected: FAIL — `transform_observations_to_gundi_schema() got an unexpected keyword argument 'resolver'`
+
+- [ ] **Step 3: Implement** — replace the body of `transform_observations_to_gundi_schema` (handlers.py:1303-1331)
+
+```python
+def transform_observations_to_gundi_schema(observations, resolver=None):
+    transformed_data = []
+    for observation in observations:
+        try:
+            transformed_observation = {}
+            recorded_at = observation.get("recorded_at")
+            if recorded_at:
+                transformed_observation["recorded_at"] = recorded_at
+            source_uuid = observation.get("source")
+            if source_uuid:
+                if resolver is not None:
+                    from datetime import datetime
+                    when = datetime.fromisoformat(recorded_at) if recorded_at else None
+                    resolved = resolver.resolve(source_uuid, when)
+                    transformed_observation["source"] = resolved.external_source_id
+                    if resolved.source_name:
+                        transformed_observation["source_name"] = resolved.source_name
+                    if resolved.subject_type:
+                        transformed_observation["subject_type"] = resolved.subject_type
+                else:
+                    transformed_observation["source"] = f"er-src-{source_uuid}"
+            if location := observation.get("location"):
+                transformed_observation["location"] = {
+                    "lon": location.get("longitude"),
+                    "lat": location.get("latitude"),
+                }
+            # Everything not already mapped goes to additional; preserve the raw
+            # ER source UUID for traceability/reconciliation after the identity change.
+            additional = {
+                key: value for key, value in observation.items()
+                if key not in transformed_observation.keys() and key != "source"
+            }
+            if source_uuid:
+                additional["er_source_id"] = source_uuid
+            transformed_observation["additional"] = additional
+        except Exception as e:
+            logger.error(
+                f"Error transforming observation {observation}: {e}",
+                extra={"attention_needed": True},
+            )
+            continue
+        else:
+            transformed_data.append(transformed_observation)
+    return transformed_data
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest app/actions/tests/test_actions.py -k transform_observation -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_actions.py
+git commit -m "feat: enrich observation transform with source profile (manufacturer_id + subject)"
+```
+
+---
+
+## Task 6: Construct + thread the resolver through `pull_observations`
+
+**Files:**
+- Modify: `app/actions/handlers.py` (`_pull_source_window` ~line 989; `action_pull_observations` ~line 610)
+- Test: `app/actions/tests/test_actions.py`
+
+- [ ] **Step 1: Write the failing test** (resolver is created and `_pull_source_window` enriches)
+
+```python
+# append to app/actions/tests/test_actions.py
+import pytest
+from app.actions.tests.conftest import AsyncIterator  # existing helper
+from app.actions import handlers
+
+
+@pytest.mark.asyncio
+async def test_pull_source_window_enriches_via_resolver(mocker):
+    er = mocker.MagicMock()
+    er.get_observations.return_value = AsyncIterator([[
+        {"source": "src-1", "recorded_at": "2026-06-01T00:00:00+00:00",
+         "location": {"longitude": 1.0, "latitude": 2.0}},
+    ]])
+    sent = {}
+    async def fake_send(observations, integration_id):
+        sent["observations"] = observations
+        return {}
+    mocker.patch.object(handlers, "send_observations_to_gundi", side_effect=fake_send)
+
+    resolver = mocker.MagicMock()
+    from app.actions.source_profiles import ResolvedSource
+    resolver.ensure = mocker.AsyncMock()
+    resolver.resolve.return_value = ResolvedSource(
+        external_source_id="SERIAL-9", source_name="Tau", subject_type="elephant")
+
+    count = await handlers._pull_source_window(
+        er, "src-1", "2026-06-01T00:00:00+00:00", "2026-06-02T00:00:00+00:00",
+        integration_id="int-1", resolver=resolver,
+    )
+    assert count == 1
+    resolver.ensure.assert_awaited()                       # sources prefetched
+    assert sent["observations"][0]["source"] == "SERIAL-9"
+    assert sent["observations"][0]["source_name"] == "Tau"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest app/actions/tests/test_actions.py -k pull_source_window_enriches -v`
+Expected: FAIL — `_pull_source_window() got an unexpected keyword argument 'resolver'`
+
+- [ ] **Step 3: Implement**
+
+In `_pull_source_window` (handlers.py:989), add a `resolver=None` keyword param. After fetching each `observations` batch and before transforming, prefetch profiles and pass the resolver through:
+
+```python
+async def _pull_source_window(er_client, source, start, end, *, integration_id, resolver=None):
+    params = {"start": start, "end": end, "batch_size": BATCH_SIZE}
+    if source is not None:
+        params["source_id"] = source
+    total = 0
+    async for observations in er_client.get_observations(**params):
+        if resolver is not None:
+            await resolver.ensure({o.get("source") for o in observations if o.get("source")})
+        transformed = transform_observations_to_gundi_schema(observations, resolver=resolver)
+        if transformed:
+            await send_observations_to_gundi(observations=transformed, integration_id=integration_id)
+        total += len(transformed)
+    return total
+```
+
+(Preserve the existing batching/counting logic; only the `resolver` plumbing is new. Match the real function's current structure when editing.)
+
+In `action_pull_observations` (handlers.py:610), construct one resolver per run and pass it into every `_pull_source_window` call:
+
+```python
+from app.actions.source_profiles import SourceProfileResolver
+# ... inside the `async with er_client as earth_ranger:` block, before the unit loop:
+resolver = SourceProfileResolver(earth_ranger, integration_id=integration_id)
+# ... at the call site (the existing _pull_source_window invocation):
+sent = await _pull_source_window(
+    earth_ranger, source, w_start, w_end, integration_id=integration_id, resolver=resolver
+)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest app/actions/tests/test_actions.py -k "pull_source_window_enriches or pull_observations" -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full action suite for regressions**
+
+Run: `pytest app/actions/tests/ -q`
+Expected: PASS (all existing + new)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_actions.py
+git commit -m "feat: thread SourceProfileResolver through pull_observations"
+```
+
+---
+
+## Task 7: Documentation
+
+**Files:**
+- Modify: `docs/data-flow.md` (Observations section)
+- Modify: `docs/actions/pull-observations.md`
+
+- [ ] **Step 1: Update `docs/data-flow.md`** — replace the Observations mapping table so it reads:
+
+```markdown
+| Gundi field | Source |
+|-------------|--------|
+| `source` (external_source_id) | `Source.manufacturer_id`, falling back to `er-src-<ER source UUID>` when absent. |
+| `source_name` | `Subject.name` for the subject assigned at the observation's `recorded_at` (time-accurate via `assigned_range`). |
+| `subject_type` | the assigned subject's type. |
+| `recorded_at` | ER `recorded_at`. |
+| `location` | ER `{longitude, latitude}` → `{lon, lat}`. |
+| `additional.er_source_id` | the raw ER source UUID, preserved for traceability. |
+| `additional` | remaining ER fields. |
+```
+
+Add a sentence: "Enrichment is best-effort — if the device or subject can't be resolved, the observation still sends under `er-src-<uuid>` with no name."
+
+- [ ] **Step 2: Update `docs/actions/pull-observations.md`** — in the "What it does" section, change the line describing the transform to note `external_source_id = manufacturer_id` (fallback `er-src-{uuid}`), `source_name = time-accurate Subject.name`, and `subject_type`.
+
+- [ ] **Step 3: Verify docs build**
+
+Run: `python3 -m venv /tmp/erdocs && /tmp/erdocs/bin/pip install -q -r requirements-docs.txt && /tmp/erdocs/bin/mkdocs build --strict --site-dir /tmp/erdocs_site`
+Expected: "Documentation built" with no warnings/errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/data-flow.md docs/actions/pull-observations.md
+git commit -m "docs: document source-profile enrichment of ER observations"
+```
+
+---
+
+## Final verification
+
+- [ ] `pytest app/actions/tests/ -q` — all pass.
+- [ ] PR description calls out the **identity change** (observations now keyed by `manufacturer_id`, not `er-src-{uuid}`; `additional.er_source_id` preserved) and links the spec.
+
+## Notes for the implementer
+
+- **Pydantic v1** (no `model_config`; use `class Config` if needed). Match the repo's existing models.
+- **`recorded_at` parsing:** observations carry ISO-8601 strings. `datetime.fromisoformat` handles the `+00:00` offset. If any ER timestamps use `Z`, normalize before parsing (the spike fixture will reveal the format).
+- **Never let enrichment fail the pull** — the resolver swallows per-source fetch errors into a UUID fallback. Keep that invariant.
+- **Don't refactor** the surrounding backfill/cursor/lease logic in `_pull_source_window` / `action_pull_observations`; only add the `resolver` plumbing.

--- a/docs/superpowers/specs/2026-06-16-er-observation-source-naming-design.md
+++ b/docs/superpowers/specs/2026-06-16-er-observation-source-naming-design.md
@@ -1,0 +1,167 @@
+# Design: time-accurate source naming for ER observations
+
+**Date:** 2026-06-16
+**Status:** Approved (pending spec review)
+**Component:** `app/actions/handlers.py` — `pull_observations` observation transform
+
+## Problem
+
+Observations pulled from EarthRanger are forwarded to Gundi with only:
+
+```python
+transformed_observation["source"] = f"er-src-{source}"   # source = ER source PK (UUID)
+```
+
+`external_source_id` therefore carries the ER source **primary key**, which is meaningless to a
+user reading the Gundi activity log, an ER map, or a downstream destination. No friendly name and no
+natural device identifier are sent at all.
+
+EarthRanger models three relevant identifiers:
+
+| ER concept | Meaning |
+|------------|---------|
+| `Source.id` (UUID) | Primary key within ER — what we send today as `er-src-{uuid}`. |
+| `Source.manufacturer_id` | Natural ID of the physical device (serial number, etc.), stable upstream of ER. |
+| `Subject.name` | Friendly name shown on ER maps/reports. |
+
+The Gundi v2 `Observation` schema already has slots for all of this (verified in `gundi_core.schemas.v2`):
+
+| Input field | Schema field | Intended use |
+|-------------|--------------|--------------|
+| `source` | `external_source_id` | stable identity / dedup key |
+| `source_name` | `source_name` | friendly display label |
+| `subject_type` | `subject_type` | subject type |
+
+We are simply not populating them.
+
+## Goal
+
+Populate the observation with meaningful identifiers (decision: **both** display and natural identity):
+
+- `external_source_id` = `Source.manufacturer_id` (fall back to `er-src-{uuid}` when absent).
+- `source_name` = `Subject.name`.
+- `subject_type` = `Subject.subject_type`.
+
+The subject must be **time-accurate**: a source/collar can be reassigned to different subjects over
+time, and `pull_observations` backfills historical windows. Each observation is labelled with the
+subject whose assignment `assigned_range` contains the observation's `recorded_at`.
+
+## Decisions (locked during brainstorming)
+
+1. **Both** friendly display *and* natural identity (not display-only).
+2. **Time-accurate** subject mapping via `assigned_range`, not current-assignment.
+3. **Approach A** — a per-run, lazily-populated, cached source-profile resolver threaded into the
+   transform. Works for both the group-filtered and whole-instance pull paths because it keys off the
+   source UUIDs that actually appear in observations.
+4. **`external_source_id` fallback** — `manufacturer_id` when present, else `er-src-{uuid}` (so every
+   source keeps a stable identity; we never emit an empty/duplicated identity).
+
+### Approaches considered
+
+- **A (chosen)** — lazy cached `SourceProfileResolver` threaded into the transform. Only approach that
+  satisfies time-accurate labelling *and* both pull paths, and isolates enrichment as a testable unit.
+- **B (rejected)** — extend `_resolve_source_ids` to emit profiles up front. Only works when
+  `subject_group_ids` is configured (no whole-instance support), and the group walk yields *current*
+  subjects, not the ranged assignment history time-accuracy needs.
+- **C (rejected)** — have ER include subject/source inline on observations. ER's observation endpoint
+  is source-scoped time-series; it returns neither `manufacturer_id` nor a *historical* subject.
+
+## Design
+
+### Component: `SourceProfileResolver`
+
+Created once per `action_pull_observations` run; holds the ER client and an in-memory cache keyed by
+source UUID. Lives in a new module `app/actions/source_profiles.py` — `handlers.py` is already ~1400
+lines, and the resolver (plus its Pydantic models) is a self-contained, independently testable unit, so
+it does not belong in the handler file.
+
+- `async ensure(source_uuids: Iterable[str]) -> None` — for any UUID not already cached, batch-fetch its
+  assignment history and `manufacturer_id`, build and store a `SourceProfile`. Idempotent; only fetches
+  what's missing.
+- `resolve(source_uuid: str, recorded_at: datetime) -> ResolvedSource` — pure (no I/O). Selects the
+  assignment whose `assigned_range` contains `recorded_at` and returns:
+  - `external_source_id` = `manufacturer_id` or `er-src-{uuid}`
+  - `source_name` = matched `subject_name` or `None`
+  - `subject_type` = matched `subject_type` or `None`
+
+### Data model (Pydantic, per repo conventions — no dataclasses)
+
+```text
+SourceProfile {
+    manufacturer_id: str | None
+    assignments: list[Assignment]
+}
+Assignment {
+    lower: datetime
+    upper: datetime | None        # None = still assigned (open-ended)
+    subject_name: str | None
+    subject_type: str | None
+}
+ResolvedSource {
+    external_source_id: str
+    source_name: str | None
+    subject_type: str | None
+}
+```
+
+### Data flow / integration points
+
+1. `action_pull_observations` constructs one `SourceProfileResolver(er_client)` and threads it into
+   `_pull_source_window`.
+2. `_pull_source_window` collects the batch's source UUIDs, calls `await resolver.ensure(uuids)`, then
+   `transform_observations_to_gundi_schema(observations, resolver)`.
+3. The transform, per observation:
+   - `resolved = resolver.resolve(obs["source"], obs["recorded_at"])`
+   - `transformed["source"] = resolved.external_source_id`
+   - `transformed["source_name"] = resolved.source_name` (when present)
+   - `transformed["subject_type"] = resolved.subject_type` (when present)
+   - keeps `recorded_at` and `location` as today
+   - `additional["er_source_id"] = obs["source"]` (preserve the raw ER UUID for traceability/reconciliation)
+   - remaining ER fields continue into `additional` as today
+
+This keys off source UUIDs seen in observations, so it covers both the group-filtered path and the
+whole-instance (`sources = [None]`) path without special-casing.
+
+### Fetching strategy & performance
+
+- Batch `get_source_assignments(source_ids=chunk)` using the existing chunked pattern (add a
+  `SOURCE_ID_CHUNK_SIZE` mirroring `SUBJECT_ID_CHUNK_SIZE`).
+- **Implementation spike (must verify before coding the fetch):** confirm whether a `subjectsources`
+  record embeds `subject.name` / `subject_type` and `source.manufacturer_id`. If yes, one batched call
+  per chunk yields everything. If not, add a batched source-detail and/or subject-detail lookup. Record
+  the finding in the implementation plan.
+- Per-run cache keyed by source UUID prevents refetching within a run. On a resumed backfill chunk the
+  cache is rebuilt from scratch (acceptable — read-only lookups, bounded by the sources in that chunk).
+
+### Edge & error handling
+
+| Case | Behavior |
+|------|----------|
+| No assignment range contains `recorded_at` | Omit `source_name` / `subject_type`; debug-log. Still emit the observation. |
+| `manufacturer_id` missing | `external_source_id = er-src-{uuid}`. |
+| Resolver fetch fails for a source | Fall back to `er-src-{uuid}`, no name; warn; **continue** (enrichment must never fail the pull). |
+| Overlapping assignment ranges (bad ER data) | Pick the latest-starting assignment; warn. |
+| Open-ended `assigned_range.upper` (null) | Treat as ongoing (matches any `recorded_at >= lower`). |
+
+### Testing
+
+- **Resolver unit tests:** range matching — observation before / within / after a range, open `upper`,
+  gaps between ranges, overlapping ranges; `manufacturer_id` present vs missing → fallback.
+- **Transform unit tests:** with a profile → `source`/`source_name`/`subject_type` set and
+  `additional.er_source_id` preserved; without a profile / on resolver miss → `er-src-{uuid}` fallback.
+- **`pull_observations` test:** resolver is constructed and threaded through; `get_source_assignments`
+  is queried for the observed sources (mocked ER client).
+
+## Backward compatibility / migration
+
+Changing `external_source_id` from `er-src-{uuid}` to `manufacturer_id` **changes source identity**
+downstream. Observations already ingested under `er-src-{uuid}` will not stitch together with new ones
+keyed by `manufacturer_id`; destinations (e.g. C-more GNodes) may register *new* sources. This is the
+accepted cost of the more-correct identity. The raw ER UUID is preserved in `additional.er_source_id`
+to support any downstream reconciliation. Call this out in the PR description.
+
+## Out of scope
+
+- Backfilling/relabelling observations already sent under the old `er-src-{uuid}` identity.
+- Persisting the source-profile cache across runs (per-run rebuild is sufficient).
+- Any change to event (non-observation) transforms.


### PR DESCRIPTION
## Summary

Replaces the meaningless `er-src-{uuid}` identifier on pulled ER observations with meaningful ones, populating the Gundi observation schema's existing slots:

- **`external_source_id`** = `Source.manufacturer_id` (the natural device serial), falling back to `er-src-{uuid}` when absent.
- **`source_name`** = the **time-accurate** `Subject.name` — the subject whose `assigned_range` contains the observation's `recorded_at` (correct for collars reassigned across subjects / historical backfills).
- **`subject_type`** = that subject's type.
- The raw ER source UUID is preserved at `additional.er_source_id` for traceability/reconciliation.

Implemented via a new per-run `SourceProfileResolver` (`app/actions/source_profiles.py`) — lazy, cached, threaded through `pull_observations`. It keys off the source UUIDs that appear in observations, so it covers both the group-filtered and whole-instance pull paths. Enrichment is best-effort: any fetch failure, missing data, or absent/`Z`-suffixed/`None` timestamp degrades to the `er-src-{uuid}` fallback and **never fails the pull** (verified at three layers + unit-tested).

Design + plan: `docs/superpowers/specs/2026-06-16-er-observation-source-naming-design.md`, `docs/superpowers/plans/2026-06-16-er-observation-source-naming.md`.

## ⚠️ Breaking identity change

`external_source_id` moves from `er-src-{uuid}` to `manufacturer_id`. Observations already ingested under `er-src-{uuid}` will **not** stitch together with new ones; downstream destinations (e.g. C-more GNodes) may register *new* sources. `additional.er_source_id` is preserved to support reconciliation.

## API shapes — confirmed against `das` source ✅

The three ER responses the resolver depends on were verified against the `das` viewsets (no longer "unverified assumptions"):

1. **`/source/{uuid}/` resolves by PK** → `SourceView._resolve_identifier` looks up by `id` when the identifier is a UUID, so fetching `manufacturer_id` by source UUID works.
2. **`/subjectsources?sources=` returns historical ranges** → `SubjectSourcesAssignmentView` filters by `source_id__in` with no current/active restriction (`order_by("-assigned_range")`), so time-accurate matching across reassignments works.
3. **`/source/{id}/subjects` covers historically-assigned subjects** → `SourceSubjectsView` returns any subject ever linked (`filter(subjectsource__source=source)`).

### Two fail-safe caveats found while confirming
- **Pagination:** `/subjectsources` is paginated; `_fetch_ranges` chunks by source-ID count, not assignment-row count, so a source with more historical assignments than one page could miss the oldest. We `logger.warning` on a `next` page (visible, not silent).
- **Inactive subjects:** `/source/{id}/subjects` may omit deactivated historical subjects, so a window owned by a since-deleted subject gets no `source_name` (identity still correct).

## Still to validate — live data only

API shapes are settled; only deployment **data** needs a live check: do real sources carry populated `manufacturer_id`s, and does a pull emit them? A spike script is included — `dev/spike_source_profile.py` — that runs the three calls for one source UUID against a stage ER token and dumps the JSON (also produces the Task 1 fixture).

## Test plan

- [x] `pytest` — full suite **185 passed** (17 new source-profile tests + transform/wiring tests).
- [ ] Run `dev/spike_source_profile.py` against stage ER: confirm a real source returns a populated `manufacturer_id`, historical `assigned_range`s, and subject `name`/`subject_type`.
- [ ] Stage `pull_observations` smoke test: an emitted observation shows `external_source_id` = `manufacturer_id` and a time-correct `source_name` (not `er-src-…` fallback everywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)