### PR TITLE
docs: auth type dropdown shows raw enum values in the portal

### DIFF
--- a/docs/auth-type-dropdown-labels.md
+++ b/docs/auth-type-dropdown-labels.md
@@ -1,0 +1,77 @@
+# Issue: Raw enum values shown in the portal's Authentication Type dropdown
+
+## Problem
+
+When configuring EarthRanger as a destination in the Gundi Portal, the
+**Authentication Type** dropdown in the `auth` action form shows the raw enum
+values:
+
+- `token`
+- `username_password`
+
+This is not polished for a configuration screen that end users see. The field
+label also falls back to the raw class name (`ERAuthenticationType`) instead of
+a human-friendly title.
+
+## Root cause
+
+`ERAuthenticationType` in `app/actions/configurations.py` is a plain
+`str`-based `Enum`. Pydantic emits it in the JSON Schema as a bare `enum` in
+`definitions`, referenced from the `authentication_type` property via
+`allOf`/`$ref`:
+
+```json
+"authentication_type": {
+  "allOf": [{"$ref": "#/definitions/ERAuthenticationType"}],
+  "default": "token",
+  "description": "Type of authentication to use."
+},
+"definitions": {
+  "ERAuthenticationType": {
+    "enum": ["token", "username_password"],
+    "type": "string",
+    "title": "ERAuthenticationType"
+  }
+}
+```
+
+JSON Schema `enum` carries no display labels, so the portal (rjsf) renders the
+values verbatim.
+
+Editing the JSON Schema manually in the Gundi Django admin is only a temporary
+workaround: `python -m app.register` **upserts** action schemas, so the next
+re-registration of this integration type overwrites any manual edit.
+
+## Potential solution
+
+In `AuthenticateConfig.Config.schema_extra` (which already customizes this
+schema to build the `if`/`then`/`else` token-vs-credentials switch), replace
+the `authentication_type` property with an inline `oneOf` of `const`/`title`
+pairs:
+
+```python
+schema["properties"]["authentication_type"] = {
+    "type": "string",
+    "title": "Authentication Type",
+    "description": "Type of authentication to use.",
+    "default": "token",
+    "oneOf": [
+        {"const": "token", "title": "Token"},
+        {"const": "username_password", "title": "Username & Password"},
+    ],
+}
+schema.get("definitions", {}).pop("ERAuthenticationType", None)
+```
+
+Notes:
+
+- Stored values are unchanged (`"token"` / `"username_password"`), so existing
+  configs keep validating and the `if`/`then`/`else` condition still matches —
+  no data migration needed.
+- `oneOf` + `const` + `title` are standard JSON Schema keywords accepted by
+  ajv in strict mode (unlike the deprecated rjsf `enumNames` extension, which
+  ajv strict rejects).
+- rjsf renders a `oneOf` of consts as a select showing each option's `title`.
+- After merging, re-register the integration type
+  (`python -m app.register --slug earth_ranger`) so the platform picks up the
+  new schema.


### PR DESCRIPTION
## Summary

When configuring EarthRanger as a destination in the Gundi Portal, the **Authentication Type** dropdown shows the raw enum values `token` / `username_password`, which doesn't look polished for a configuration end users see.

This PR only adds a doc ([docs/auth-type-dropdown-labels.md](docs/auth-type-dropdown-labels.md)) describing:

- **Root cause**: `ERAuthenticationType` is a plain str Enum — pydantic emits a bare JSON Schema `enum` with no display labels, so rjsf renders the values verbatim. Manual schema edits in the Django admin get overwritten on the next `python -m app.register` upsert.
- **Proposed fix**: in `AuthenticateConfig.Config.schema_extra`, replace the `authentication_type` property with an inline `oneOf` of `const`/`title` pairs ("Token" / "Username & Password"). Stored values unchanged, no data migration, ajv-strict safe.

No code changes yet — fix to follow in a separate PR if the approach is agreed.

## Workaround 
In the meantime, we have manually updated the JSON schema to fix how the options appear in the portal:
<img width="761" height="405" alt="image" src="https://github.com/user-attachments/assets/9f91b782-9d99-429c-acfb-9e4dd6f60c25" />

Action updated manually:
https://api.gundiservice.org/admin/integrations/integrationaction/c1af44b6-fc54-4c2e-a65b-bf377d0f217d/change/?_changelist_filters=integration_type__id__exact%3D52e30b0f-2fff-42f7-8079-3443c1113c33
