### PR TITLE
fix: reword event filter descriptions to match array form widget

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -261,19 +261,19 @@ class PullEventsConfig(PullActionConfiguration):
         default_factory=list,
         title="Event Types",
         description=(
-            "List of ER event-type slugs to pull, e.g. ['wildlife_sighting_rep', 'poacher_sighting_rep']. "
+            "ER event-type slugs to pull. Add one slug per item, e.g. wildlife_sighting_rep. "
             "Run the 'show_permissions' action to see the slugs available for this account. "
             "Combined with Event Categories using ER's AND semantics. "
-            "An empty list applies no event-type constraint."
+            "Leave empty to apply no event-type constraint."
         ),
     )
     event_categories: List[str] = Field(
         default_factory=list,
         title="Event Categories",
         description=(
-            "List of ER event-category slugs, e.g. ['wildlife', 'monitoring']. "
+            "ER event-category slugs. Add one slug per item, e.g. wildlife. "
             "ER applies type and category filters with AND semantics. "
-            "An empty list applies no category constraint."
+            "Leave empty to apply no category constraint."
         ),
     )
     # This integration is most often used only as a destination, so scheduled


### PR DESCRIPTION
Users configuring a connection saw Python-list examples like `['wildlife_sighting_rep', 'poacher_sighting_rep']` in the Event Types and Event Categories descriptions, while the portal renders those fields as add-one-item-at-a-time array editors — suggesting they should type brackets and quotes into the item text box. The descriptions now say "Add one slug per item" with a single bare-slug example, and "An empty list applies no constraint" became "Leave empty to apply no constraint" to match the widget. Wording change only; filtering behavior and the rest of each description (the `show_permissions` tip, AND semantics) are unchanged.
