### PR TITLE
fix: show display labels in Authentication Type dropdown

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -69,24 +69,27 @@ class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
             schema["properties"].pop("username", None)
             schema["properties"].pop("password", None)
 
-            # Inline oneOf of const/title pairs so the portal shows display
-            # labels instead of raw enum values. Stored values are unchanged,
-            # so existing configs and the if/then/else below keep working.
-            schema["properties"]["authentication_type"] = {
-                "type": "string",
-                "title": "Authentication Type",
-                "description": "Type of authentication to use.",
-                "default": ERAuthenticationType.TOKEN.value,
-                "oneOf": [
-                    {
-                        "const": member.value,
-                        "title": AUTH_TYPE_DISPLAY_NAMES.get(
-                            member, member.value.replace("_", " ").title()
-                        ),
-                    }
-                    for member in ERAuthenticationType
-                ],
-            }
+            # Replace the enum $ref with an inline oneOf of const/title pairs
+            # so the portal shows display labels instead of raw enum values.
+            # Generated metadata (description, default) is kept in place so it
+            # can't drift from the Field definition; pydantic v1 emits no
+            # property-level title for enum fields, so set it here. Stored
+            # values are unchanged, so existing configs and the if/then/else
+            # below keep working.
+            auth_type = schema["properties"]["authentication_type"]
+            auth_type.pop("allOf", None)
+            auth_type.pop("$ref", None)
+            auth_type.setdefault("title", "Authentication Type")
+            auth_type["type"] = "string"
+            auth_type["oneOf"] = [
+                {
+                    "const": member.value,
+                    "title": AUTH_TYPE_DISPLAY_NAMES.get(
+                        member, member.value.replace("_", " ").title()
+                    ),
+                }
+                for member in ERAuthenticationType
+            ]
             # Note: the ERAuthenticationType entry in "definitions" stays —
             # pydantic v1 attaches definitions after schema_extra runs — but
             # it's unreferenced now, so rjsf ignores it.

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -13,6 +13,14 @@ class ERAuthenticationType(str, Enum):
     USERNAME_PASSWORD = "username_password"
 
 
+# Display labels for the portal's Authentication Type dropdown. A bare JSON
+# Schema enum carries no labels, so rjsf would render the raw values.
+AUTH_TYPE_DISPLAY_NAMES = {
+    ERAuthenticationType.TOKEN: "Token",
+    ERAuthenticationType.USERNAME_PASSWORD: "Username & Password",
+}
+
+
 class EventFilterDateField(str, Enum):
     """Which ER timestamp on an Event the start/end window applies to.
 
@@ -60,6 +68,28 @@ class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
             schema["properties"].pop("token", None)
             schema["properties"].pop("username", None)
             schema["properties"].pop("password", None)
+
+            # Inline oneOf of const/title pairs so the portal shows display
+            # labels instead of raw enum values. Stored values are unchanged,
+            # so existing configs and the if/then/else below keep working.
+            schema["properties"]["authentication_type"] = {
+                "type": "string",
+                "title": "Authentication Type",
+                "description": "Type of authentication to use.",
+                "default": ERAuthenticationType.TOKEN.value,
+                "oneOf": [
+                    {
+                        "const": member.value,
+                        "title": AUTH_TYPE_DISPLAY_NAMES.get(
+                            member, member.value.replace("_", " ").title()
+                        ),
+                    }
+                    for member in ERAuthenticationType
+                ],
+            }
+            # Note: the ERAuthenticationType entry in "definitions" stays —
+            # pydantic v1 attaches definitions after schema_extra runs — but
+            # it's unreferenced now, so rjsf ignores it.
 
             # Show token OR username & password based on authentication_type
             schema.update({

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -2537,3 +2537,28 @@ async def test_pull_source_window_enriches_via_resolver(mocker):
     assert sent["observations"][0]["source"] == "SERIAL-9"
     assert sent["observations"][0]["source_name"] == "Tau"
     assert sent["observations"][0]["subject_type"] == "elephant"
+
+
+# ---------------------------------------------------------------------------
+# Auth type dropdown labels (PADAS/gundi-integration-earthranger#35)
+# ---------------------------------------------------------------------------
+
+def test_authenticate_config_schema_has_auth_type_display_labels():
+    from app.actions.configurations import AuthenticateConfig
+
+    schema = AuthenticateConfig.schema()
+    auth_type = schema["properties"]["authentication_type"]
+
+    assert auth_type == {
+        "type": "string",
+        "title": "Authentication Type",
+        "description": "Type of authentication to use.",
+        "default": "token",
+        "oneOf": [
+            {"const": "token", "title": "Token"},
+            {"const": "username_password", "title": "Username & Password"},
+        ],
+    }
+    # The bare-enum definition may linger in "definitions" (pydantic v1 adds
+    # definitions after schema_extra), but nothing may reference it anymore.
+    assert "$ref" not in str(schema["properties"]["authentication_type"])

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -2544,21 +2544,27 @@ async def test_pull_source_window_enriches_via_resolver(mocker):
 # ---------------------------------------------------------------------------
 
 def test_authenticate_config_schema_has_auth_type_display_labels():
-    from app.actions.configurations import AuthenticateConfig
+    from app.actions.configurations import AuthenticateConfig, ERAuthenticationType
 
     schema = AuthenticateConfig.schema()
     auth_type = schema["properties"]["authentication_type"]
 
-    assert auth_type == {
-        "type": "string",
-        "title": "Authentication Type",
-        "description": "Type of authentication to use.",
-        "default": "token",
-        "oneOf": [
-            {"const": "token", "title": "Token"},
-            {"const": "username_password", "title": "Username & Password"},
-        ],
-    }
-    # The bare-enum definition may linger in "definitions" (pydantic v1 adds
-    # definitions after schema_extra), but nothing may reference it anymore.
-    assert "$ref" not in str(schema["properties"]["authentication_type"])
+    # The enum $ref is replaced with an inline oneOf. The bare-enum definition
+    # may linger in "definitions" (pydantic v1 adds definitions after
+    # schema_extra), but nothing may reference it anymore.
+    assert "$ref" not in str(auth_type)
+    assert "allOf" not in auth_type
+
+    # Generated Field metadata is preserved alongside the inline oneOf.
+    assert auth_type["type"] == "string"
+    assert auth_type["title"] == "Authentication Type"
+    assert auth_type["description"] == "Type of authentication to use."
+    assert auth_type["default"] == ERAuthenticationType.TOKEN.value
+
+    # Every enum member gets a dropdown entry; known members get their
+    # display labels. Deliberately not exact-dict equality, so adding a new
+    # enum member doesn't break this test.
+    options = {option["const"]: option["title"] for option in auth_type["oneOf"]}
+    assert set(options) == {member.value for member in ERAuthenticationType}
+    assert options["token"] == "Token"
+    assert options["username_password"] == "Username & Password"


### PR DESCRIPTION
The **Authentication Type** dropdown in the Gundi Portal showed the raw enum values `token` / `username_password`; it now shows "Token" and "Username & Password". `AuthenticateConfig.Config.schema_extra` replaces the `authentication_type` property with an inline `oneOf` of `const`/`title` pairs derived from the enum members, so a future enum value can't silently drift out of the dropdown. Stored values are unchanged — existing configs keep validating and the `if`/`then`/`else` token-vs-credentials switch still matches — so no data migration is needed.

One deviation from the proposed fix: popping `ERAuthenticationType` from `definitions` inside `schema_extra` has no effect, because pydantic v1 attaches top-level definitions after `schema_extra` runs. The definition lingers unreferenced, which rjsf ignores.

After merging, re-register the integration type (`python -m app.register`) so the platform picks up the new schema — this also makes it safe for the upsert to overwrite the manual Django-admin edit currently in place.

Validated with a new schema test asserting the rendered `authentication_type` property shape (full suite: 240 passed). Portal rendering wasn't exercised locally, but the manually-applied schema shown working in the related PR's screenshot uses this exact shape.

Related: #35
