### PR TITLE
fix: register integration type as "EarthRanger", not "Earth Ranger"

### DIFF
--- a/app/services/tests/test_integration_settings.py
+++ b/app/services/tests/test_integration_settings.py
@@ -1,8 +1,21 @@
-from app import settings
+import importlib
+import os
+from unittest import mock
+
+from app.settings import integration
 
 
 def test_integration_type_name_defaults_to_earthranger():
     # The product name is "EarthRanger" (one word). Without an explicit
     # setting, self-registration falls back to title-casing the slug,
     # which renders "Earth Ranger" in the Gundi portal.
-    assert settings.INTEGRATION_TYPE_NAME == "EarthRanger"
+    # The module snapshots the env var at import time, so unset it and
+    # reload to assert the default regardless of the ambient environment.
+    try:
+        with mock.patch.dict(os.environ):
+            os.environ.pop("INTEGRATION_TYPE_NAME", None)
+            reloaded = importlib.reload(integration)
+            assert reloaded.INTEGRATION_TYPE_NAME == "EarthRanger"
+    finally:
+        # Re-read the real environment so other tests see the actual value.
+        importlib.reload(integration)

--- a/app/services/tests/test_integration_settings.py
+++ b/app/services/tests/test_integration_settings.py
@@ -1,0 +1,8 @@
+from app import settings
+
+
+def test_integration_type_name_defaults_to_earthranger():
+    # The product name is "EarthRanger" (one word). Without an explicit
+    # setting, self-registration falls back to title-casing the slug,
+    # which renders "Earth Ranger" in the Gundi portal.
+    assert settings.INTEGRATION_TYPE_NAME == "EarthRanger"

--- a/app/services/tests/test_self_registration.py
+++ b/app/services/tests/test_self_registration.py
@@ -19,6 +19,7 @@ async def test_register_integration_with_slug_setting(
     mock_get_webhook_handler_for_fixed_json_payload,
 ):
     mocker.patch("app.services.self_registration.INTEGRATION_TYPE_SLUG", "x_tracker")
+    mocker.patch("app.services.self_registration.INTEGRATION_TYPE_NAME", None)
     mocker.patch("app.services.self_registration.action_handlers", mock_action_handlers)
     mocker.patch(
         "app.services.self_registration.get_webhook_handler",
@@ -146,6 +147,7 @@ async def test_register_integration_with_slug_arg(
     mock_action_handlers,
     mock_get_webhook_handler_for_fixed_json_payload,
 ):
+    mocker.patch("app.services.self_registration.INTEGRATION_TYPE_NAME", None)
     mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
     mocker.patch("app.services.self_registration.action_handlers", mock_action_handlers)
     mocker.patch(
@@ -276,6 +278,7 @@ async def test_register_integration_with_service_url_arg(
     mock_get_webhook_handler_for_fixed_json_payload,
 ):
     mocker.patch("app.services.self_registration.INTEGRATION_TYPE_SLUG", "x_tracker")
+    mocker.patch("app.services.self_registration.INTEGRATION_TYPE_NAME", None)
     mocker.patch("app.services.self_registration.action_handlers", mock_action_handlers)
     mocker.patch(
         "app.services.self_registration.get_webhook_handler",
@@ -408,6 +411,7 @@ async def test_register_integration_with_service_url_setting(
 ):
     service_url = "https://xtracker-actions-runner-jabcutl8yb-uc.a.run.app"
     mocker.patch("app.services.self_registration.INTEGRATION_TYPE_SLUG", "x_tracker")
+    mocker.patch("app.services.self_registration.INTEGRATION_TYPE_NAME", None)
     mocker.patch("app.services.self_registration.INTEGRATION_SERVICE_URL", service_url)
     mocker.patch("app.services.self_registration.action_handlers", mock_action_handlers)
     mocker.patch(
@@ -541,6 +545,7 @@ async def test_register_integration_with_executable_action(
     mock_get_webhook_handler_for_fixed_json_payload,
 ):
     mocker.patch("app.services.self_registration.INTEGRATION_TYPE_SLUG", "x_tracker")
+    mocker.patch("app.services.self_registration.INTEGRATION_TYPE_NAME", None)
     mocker.patch(
         "app.services.self_registration.action_handlers", mock_auth_action_handlers
     )
@@ -677,6 +682,7 @@ async def test_register_integration_with_action_title(
     mock_get_webhook_handler_for_fixed_json_payload,
 ):
     mocker.patch("app.services.self_registration.INTEGRATION_TYPE_SLUG", "x_tracker")
+    mocker.patch("app.services.self_registration.INTEGRATION_TYPE_NAME", None)
     mock_action_handlers["pull_observations"][0].action_title = "Fetch Collar Positions"
     mocker.patch("app.services.self_registration.action_handlers", mock_action_handlers)
     mocker.patch(

--- a/app/settings/integration.py
+++ b/app/settings/integration.py
@@ -1,1 +1,7 @@
 # Add your integration-specific settings here
+from .base import env
+
+# Display name used when this action runner registers itself in Gundi.
+# The product name is one word — the slug-derived fallback in
+# self-registration would render "Earth Ranger".
+INTEGRATION_TYPE_NAME = env.str("INTEGRATION_TYPE_NAME", "EarthRanger")


### PR DESCRIPTION
When this action runner registers itself in Gundi, the integration type showed up as "Earth Ranger" — `INTEGRATION_TYPE_NAME` was unset, so registration fell back to title-casing the slug. The ER-specific settings module now defaults the name to "EarthRanger" (the product's one-word spelling), still overridable via the `INTEGRATION_TYPE_NAME` env var, and a test pins the default. After merging, re-register (`python -m app.register`) so the platform picks up the corrected name.

The generic self-registration tests relied on the name being unset, so they now mock `INTEGRATION_TYPE_NAME` to `None` alongside the slug they already mock — that isolation fix is a no-op in the `gundi-integration-action-runner` template and worth upstreaming there.
