### PR TITLE
Provider-side reference actions: list_event_types, list_event_type_fields, list_event_field_values

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from pydantic import Field, SecretStr
 
 from app.services.utils import FieldWithUIOptions, GlobalUISchemaOptions, UIOptions
-from .core import AuthActionConfiguration, GenericActionConfiguration, PullActionConfiguration, ExecutableActionMixin
+from .core import AuthActionConfiguration, GenericActionConfiguration, PullActionConfiguration, ExecutableActionMixin, ReferenceActionConfiguration
 
 
 class ERAuthenticationType(str, Enum):
@@ -326,4 +326,17 @@ class PullEventsConfig(PullActionConfiguration):
     ui_global_options: GlobalUISchemaOptions = GlobalUISchemaOptions(
         order=["start_datetime", "end_datetime", "filter_date_field", "event_types", "event_categories", "force_run_since_start", "include_attachments", "run_on_schedule"],
     )
+
+
+class ListEventTypesQuery(ReferenceActionConfiguration):
+    """List the ER event types visible to this integration's credentials."""
+
+
+class ListEventTypeFieldsQuery(ReferenceActionConfiguration):
+    event_type: str
+
+
+class ListEventFieldValuesQuery(ReferenceActionConfiguration):
+    event_type: str
+    field_key: str
 

--- a/app/actions/core.py
+++ b/app/actions/core.py
@@ -1,7 +1,7 @@
 import importlib
 import inspect
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 from app.services.utils import UISchemaModelMixin
@@ -59,6 +59,30 @@ class AuthActionConfiguration(ActionConfiguration):
 
 class GenericActionConfiguration(ActionConfiguration):
     pass
+
+
+class ReferenceActionConfiguration(ActionConfiguration):
+    """Marker base for reference-data actions: the config model IS the query.
+
+    Reference actions are stateless — they read the integration's auth config
+    but store no configuration of their own; callers (the Gundi portal)
+    supply query params via config_overrides. They return a
+    ReferenceDataResponse dict. See
+    docs/superpowers/specs/2026-07-31-reference-data-config-ui-design.md.
+    """
+
+
+class ReferenceOption(BaseModel):
+    value: str
+    label: Optional[str] = None        # portal defaults label to value
+    description: Optional[str] = None  # tooltip / help text
+    group: Optional[str] = None        # optional grouping for long lists
+
+
+class ReferenceDataResponse(BaseModel):
+    options: List[ReferenceOption]
+    cache_ttl_seconds: int = 300       # portal-side cache hint
+    truncated: bool = False            # true if the list was capped
 
 
 def discover_actions(module_name, prefix):

--- a/app/actions/er_schema.py
+++ b/app/actions/er_schema.py
@@ -22,7 +22,8 @@ choice fields instead carry a ``$ref`` to an external choices.json list that
 must be fetched separately (``choices_ref`` / ``choice_list`` /
 ``parse_choices_json``). This repo only ever calls the pre-rendered endpoint,
 and every choice field observed in the captured fixture
-(``tests/fixtures/rhino_carcass_schema_from_api.json``) is fully inlined —
+(``app/actions/tests/fixtures/rhino_carcass_schema_from_api.json``) is fully
+inlined —
 so that ref-resolution machinery is dropped here as dead code for this call
 site. Restore it from the CMORE source if a future field is found that isn't
 inlined even under pre_render.
@@ -154,6 +155,13 @@ async def fetch_prerendered_event_schema(er_client, base_url: str, event_type: s
     doesn't model this /schema sub-resource, so we call it directly with the
     client's own auth headers (works for both token and username/password auth)."""
     url_parse = urlparse(base_url)
+    if not url_parse.hostname:
+        # Schemeless base_urls do occur in Gundi (see the _ensure_scheme guard in
+        # gundi-integration-cmore's CLI); urlparse leaves hostname None for them,
+        # which would otherwise build a "https://None/..." URL.
+        raise ValueError(f"Site URL is empty or invalid: '{base_url}'")
+    # scheme://hostname (dropping any port) is the deliberate convention — it
+    # matches every AsyncERClient construction site in handlers.py.
     url = f"{url_parse.scheme}://{url_parse.hostname}/api/v2.0/activity/eventtypes/{quote(event_type, safe='')}/schema"
     headers = await er_client.auth_headers()
     async with httpx.AsyncClient(headers=headers, timeout=30.0) as http:

--- a/app/actions/er_schema.py
+++ b/app/actions/er_schema.py
@@ -1,0 +1,162 @@
+"""Parse an EarthRanger pre-rendered event-type schema into a flat list of fields.
+
+Ported from ``gundi-integration-cmore/app/datasource/er_schema.py`` (CMORE's
+mapping-scaffold tooling) for use by this repo's provider-side reference
+actions (``list_event_type_fields`` / ``list_event_field_values``).
+
+ER's v2 event-type schema is JSON Schema (draft 2020-12), wrapped in a
+top-level ``json`` key (with a sibling ``ui`` block). Each field lives under
+``json.properties`` with a ``title``. When fetched with
+``pre_render=true&s_format=enum`` (see ``fetch_prerendered_event_schema``),
+choice fields carry their values inline as an ``enum`` (+ ``x-enumExtra``
+display names) nested in an ``anyOf`` member::
+
+    "animal_sex": {
+        "title": "Animal Sex", "type": "string",
+        "anyOf": [{"type": "string", "enum": ["female", "male"],
+                    "x-enumExtra": {"female": {"display": "Female"}, ...}}]
+    }
+
+CMORE's original parser also handled schemas *without* ``pre_render``, where
+choice fields instead carry a ``$ref`` to an external choices.json list that
+must be fetched separately (``choices_ref`` / ``choice_list`` /
+``parse_choices_json``). This repo only ever calls the pre-rendered endpoint,
+and every choice field observed in the captured fixture
+(``tests/fixtures/rhino_carcass_schema_from_api.json``) is fully inlined —
+so that ref-resolution machinery is dropped here as dead code for this call
+site. Restore it from the CMORE source if a future field is found that isn't
+inlined even under pre_render.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+from urllib.parse import quote, urlparse
+
+import httpx
+
+
+@dataclass
+class ERChoice:
+    value: str
+    display: str
+
+
+@dataclass
+class ERField:
+    key: str
+    title: str
+    choices: Optional[List[ERChoice]] = None  # populated when this is a choice field
+
+    @property
+    def is_enum(self) -> bool:
+        """True if this is a choice field."""
+        return self.choices is not None
+
+
+def _locate_schema(raw: dict) -> dict:
+    """Descend through ER's ``json``/``schema``/``data`` envelopes to the
+    object that actually holds ``properties``."""
+    node = raw
+    for _ in range(6):  # bounded descent
+        if not isinstance(node, dict):
+            return {}
+        if isinstance(node.get("properties"), dict):
+            return node
+        for key in ("json", "schema", "data"):
+            if isinstance(node.get(key), dict):
+                node = node[key]
+                break
+        else:
+            return {}
+    return node if isinstance(node, dict) else {}
+
+
+def _enum_with_extra(node: dict) -> Optional[List[ERChoice]]:
+    """Parse an ``enum`` (+ optional ``enumNames`` / ``x-enumExtra``) block.
+
+    ER's pre-rendered ``s_format=enum`` schema carries choices as
+    ``{"enum": [...], "x-enumExtra": {value: {"display": ...}}}``.
+    """
+    enum = node.get("enum")
+    if not isinstance(enum, list) or not enum:
+        return None
+    extra = node.get("x-enumExtra")
+    names = node.get("enumNames")
+    out = []
+    for value in enum:
+        display = value
+        if isinstance(extra, dict) and isinstance(extra.get(value), dict):
+            display = extra[value].get("display", value)
+        elif isinstance(names, dict):
+            display = names.get(value, value)
+        out.append(ERChoice(str(value), str(display)))
+    if isinstance(names, list) and len(names) == len(enum):
+        out = [ERChoice(str(v), str(label)) for v, label in zip(enum, names)]
+    return out
+
+
+def _inline_choices(prop: dict) -> Optional[List[ERChoice]]:
+    """Choices carried directly on the property: a top-level ``enum``, an
+    ``enum`` nested in an ``anyOf``/``oneOf`` member (ER's pre-rendered form),
+    or a ``oneOf``/``anyOf`` list of ``{const/value, title/display}``."""
+    direct = _enum_with_extra(prop)
+    if direct is not None:
+        return direct
+
+    for key in ("anyOf", "oneOf"):
+        members = prop.get(key)
+        if not isinstance(members, list):
+            continue
+        for member in members:
+            if not isinstance(member, dict):
+                continue
+            nested = _enum_with_extra(member)
+            if nested is not None:
+                return nested
+        # const/value-style choice members (no enum).
+        dict_members = [m for m in members if isinstance(m, dict)]
+        if dict_members and all(("const" in m or "value" in m) for m in dict_members):
+            return [
+                ERChoice(
+                    str(m.get("const", m.get("value"))),
+                    str(m.get("title", m.get("display", m.get("const", m.get("value"))))),
+                )
+                for m in dict_members
+            ]
+    return None
+
+
+def parse_er_event_schema(raw: dict) -> List[ERField]:
+    """Parse a pre-rendered ER event-type schema response into a flat list of
+    ``ERField``. Fields with no inline choices are free-text. Order follows
+    the schema's ``properties`` insertion order.
+    """
+    schema = _locate_schema(raw or {})
+    props = schema.get("properties") if isinstance(schema, dict) else None
+    if not isinstance(props, dict):
+        return []
+    fields: List[ERField] = []
+    for key, prop in props.items():
+        if not isinstance(prop, dict):
+            continue
+        title = str(prop.get("title") or key)
+        fields.append(ERField(
+            key=key,
+            title=title,
+            choices=_inline_choices(prop),
+        ))
+    return fields
+
+
+async def fetch_prerendered_event_schema(er_client, base_url: str, event_type: str) -> dict:
+    """GET the v2 pre-rendered event-type schema (pre_render + s_format=enum inline
+    each choice field's values, so no separate choices fetch is needed). erclient
+    doesn't model this /schema sub-resource, so we call it directly with the
+    client's own auth headers (works for both token and username/password auth)."""
+    url_parse = urlparse(base_url)
+    url = f"{url_parse.scheme}://{url_parse.hostname}/api/v2.0/activity/eventtypes/{quote(event_type, safe='')}/schema"
+    headers = await er_client.auth_headers()
+    async with httpx.AsyncClient(headers=headers, timeout=30.0) as http:
+        resp = await http.get(url, params={"pre_render": "true", "s_format": "enum"})
+        resp.raise_for_status()
+        return resp.json()

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -18,8 +18,11 @@ from gundi_core.schemas.v2 import Integration
 from app import settings
 from app.services.utils import find_config_for_action
 from app.services.state import IntegrationStateManager
+from .core import ReferenceDataResponse, ReferenceOption
+from .er_schema import fetch_prerendered_event_schema, parse_er_event_schema
 from .configurations import AuthenticateConfig, EventFilterDateField, PullObservationsConfig, PullEventsConfig, \
-    ERAuthenticationType, ShowPermissionsConfig
+    ERAuthenticationType, ShowPermissionsConfig, ListEventTypesQuery, ListEventTypeFieldsQuery, \
+    ListEventFieldValuesQuery
 from .source_profiles import SourceProfileResolver
 from ..services.activity_logger import activity_logger, log_action_activity
 from ..services.gundi import send_events_to_gundi, send_observations_to_gundi, update_event_in_gundi, send_event_attachments_to_gundi
@@ -1140,10 +1143,18 @@ class EventTypeMaps:
       slugs must be resolved before being sent in the filter blob.
     - ``category_id_by_slug``: category slug → ER EventCategory UUID. Same
       story for ``event_type__category__id__in``.
+    - ``category_slug_by_type_slug``: event-type slug → its category slug.
+      Used by the ``list_event_types`` reference action to group options by
+      category. v1 carries this as the nested category dict's ``value``; v2
+      carries it as a bare string.
+    - ``category_display_by_slug``: category slug → human-readable display
+      name. Same reference-action grouping use as above.
     """
     display_by_slug: Dict[str, str] = field(default_factory=dict)
     id_by_slug: Dict[str, str] = field(default_factory=dict)
     category_id_by_slug: Dict[str, str] = field(default_factory=dict)
+    category_slug_by_type_slug: Dict[str, str] = field(default_factory=dict)
+    category_display_by_slug: Dict[str, str] = field(default_factory=dict)
 
 
 async def _fetch_event_type_maps(er_client) -> EventTypeMaps:
@@ -1215,6 +1226,8 @@ async def _fetch_event_type_maps(er_client) -> EventTypeMaps:
                 cat_id = cat.get("id")
                 if cat_slug and cat_id:
                     maps.category_id_by_slug.setdefault(cat_slug, cat_id)
+                if cat_slug and cat.get("display"):
+                    maps.category_display_by_slug.setdefault(cat_slug, cat["display"])
 
     return maps
 
@@ -1233,13 +1246,21 @@ def _absorb_event_type(maps: EventTypeMaps, et: dict, *, with_category: bool) ->
         maps.display_by_slug.setdefault(slug, et["display"])
     if et.get("id"):
         maps.id_by_slug.setdefault(slug, et["id"])
-    if with_category:
-        category = et.get("category") or {}
-        if isinstance(category, dict):
-            cat_slug = category.get("value")
-            cat_id = category.get("id")
-            if cat_slug and cat_id:
-                maps.category_id_by_slug.setdefault(cat_slug, cat_id)
+    category = et.get("category")
+    if isinstance(category, dict):
+        # v1: nested category object with its own slug/id/display.
+        cat_slug = category.get("value")
+        cat_id = category.get("id")
+        if cat_slug:
+            maps.category_slug_by_type_slug.setdefault(slug, cat_slug)
+            if category.get("display"):
+                maps.category_display_by_slug.setdefault(cat_slug, category["display"])
+        if with_category and cat_slug and cat_id:
+            maps.category_id_by_slug.setdefault(cat_slug, cat_id)
+    elif isinstance(category, str) and category:
+        # v2: category is a bare slug string; no display name available here
+        # (resolved via the categories-endpoint fallback above, if needed).
+        maps.category_slug_by_type_slug.setdefault(slug, category)
 
 
 def _resolve_slugs(configured_slugs, slug_to_id):
@@ -1387,6 +1408,114 @@ def transform_observations_to_gundi_schema(observations, resolver=None):
         else:
             transformed_data.append(transformed_observation)
     return transformed_data
+
+
+# ---------------------------------------------------------------------------
+# Reference actions: config-time lookups the Gundi portal calls while an
+# operator is filling out a form (e.g. populating an "Event Type" dropdown).
+# Stateless — they read only the integration's auth config and propagate
+# upstream ER errors rather than swallowing them (see
+# docs/superpowers/specs/2026-07-31-reference-data-config-ui-design.md).
+# ---------------------------------------------------------------------------
+
+def _build_er_client(integration: Integration) -> AsyncERClient:
+    """Standard AsyncERClient construction shared by the reference actions
+    (mirrors action_pull_events / action_pull_observations)."""
+    auth_config = get_authentication_config(integration=integration)
+    url_parse = urlparse(integration.base_url)
+    return AsyncERClient(
+        service_root=f"{url_parse.scheme}://{url_parse.hostname}/api/v1.0",
+        username=auth_config.username or None,
+        password=auth_config.password.get_secret_value() if auth_config.password else None,
+        token=auth_config.token.get_secret_value() if auth_config.token else None,
+        token_url=f"{url_parse.scheme}://{url_parse.hostname}/oauth2/token",
+        client_id="das_web_client",
+        connect_timeout=DEFAULT_CONNECT_TIMEOUT_SECONDS,
+    )
+
+
+async def action_list_event_types(integration: Integration, action_config: ListEventTypesQuery):
+    """Reference action: ER event types visible to this integration's credentials.
+
+    Reuses `_fetch_event_type_maps`'s v1+v2 merge. Options are grouped by ER
+    event category (falling back to no group when the category has no known
+    display name), sorted by group then label.
+    """
+    async with _build_er_client(integration) as earth_ranger:
+        maps = await _fetch_event_type_maps(earth_ranger)
+
+    options = [
+        ReferenceOption(
+            value=slug,
+            label=display,
+            group=maps.category_display_by_slug.get(
+                maps.category_slug_by_type_slug.get(slug)
+            ),
+        )
+        for slug, display in maps.display_by_slug.items()
+    ]
+    options.sort(key=lambda o: (o.group or "", o.label or o.value))
+    return ReferenceDataResponse(options=options, truncated=False).dict()
+
+
+async def _fetch_event_type_fields(er_client, base_url: str, event_type: str):
+    """Fetch + parse an ER event type's pre-rendered schema into ERFields.
+
+    A 404 from ER (unknown event type) is translated to a ValueError so it
+    reads naturally as a config-form error; any other upstream failure
+    (e.g. a 5xx) propagates unchanged.
+    """
+    try:
+        raw_schema = await fetch_prerendered_event_schema(er_client, base_url, event_type)
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise ValueError(f"Event type '{event_type}' not found in EarthRanger.") from e
+        raise
+    return parse_er_event_schema(raw_schema)
+
+
+async def action_list_event_type_fields(integration: Integration, action_config: ListEventTypeFieldsQuery):
+    """Reference action: field keys defined on one ER event type's schema."""
+    async with _build_er_client(integration) as earth_ranger:
+        fields = await _fetch_event_type_fields(
+            earth_ranger, integration.base_url, action_config.event_type
+        )
+
+    options = [
+        ReferenceOption(
+            value=f.key,
+            label=f.title or f.key,
+            description="choices" if f.is_enum else None,
+        )
+        for f in fields
+    ]
+    return ReferenceDataResponse(options=options).dict()
+
+
+async def action_list_event_field_values(integration: Integration, action_config: ListEventFieldValuesQuery):
+    """Reference action: allowed values for one choice field on an ER event type.
+
+    Non-enum fields legitimately return an empty options list — they are
+    free-text in ER, so there is nothing to suggest.
+    """
+    async with _build_er_client(integration) as earth_ranger:
+        fields = await _fetch_event_type_fields(
+            earth_ranger, integration.base_url, action_config.event_type
+        )
+
+    field_match = next((f for f in fields if f.key == action_config.field_key), None)
+    if field_match is None:
+        raise ValueError(
+            f"Field '{action_config.field_key}' not found on event type "
+            f"'{action_config.event_type}' in EarthRanger."
+        )
+    if not field_match.is_enum:
+        return ReferenceDataResponse(options=[]).dict()
+    options = [
+        ReferenceOption(value=choice.value, label=choice.display)
+        for choice in field_match.choices
+    ]
+    return ReferenceDataResponse(options=options).dict()
 
 
 # Maps an ER event field name to the corresponding key the sensors-API

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1149,12 +1149,19 @@ class EventTypeMaps:
       carries it as a bare string.
     - ``category_display_by_slug``: category slug → human-readable display
       name. Same reference-action grouping use as above.
+    - ``v2_slugs``: event-type slugs that came from the v2 endpoint. Used by
+      the ``list_event_types`` reference action to offer only v2 event
+      types — ER's v2 pre-rendered schema endpoint 404s for classic v1
+      event types, which would dead-end the list_event_type_fields /
+      list_event_field_values cascade, so reference actions don't offer
+      them at all.
     """
     display_by_slug: Dict[str, str] = field(default_factory=dict)
     id_by_slug: Dict[str, str] = field(default_factory=dict)
     category_id_by_slug: Dict[str, str] = field(default_factory=dict)
     category_slug_by_type_slug: Dict[str, str] = field(default_factory=dict)
     category_display_by_slug: Dict[str, str] = field(default_factory=dict)
+    v2_slugs: set = field(default_factory=set)
 
 
 async def _fetch_event_type_maps(er_client) -> EventTypeMaps:
@@ -1205,7 +1212,7 @@ async def _fetch_event_type_maps(er_client) -> EventTypeMaps:
             # v2 carries category as a bare slug, not as a nested object —
             # we resolve category UUIDs separately below.
             if isinstance(et, dict):
-                _absorb_event_type(maps, et, with_category=False)
+                _absorb_event_type(maps, et, with_category=False, is_v2=True)
 
     # If we got no category UUIDs from the v1 event types (e.g. ER has only
     # v2 types defined), the canonical categories endpoint fills the gap.
@@ -1232,7 +1239,7 @@ async def _fetch_event_type_maps(er_client) -> EventTypeMaps:
     return maps
 
 
-def _absorb_event_type(maps: EventTypeMaps, et: dict, *, with_category: bool) -> None:
+def _absorb_event_type(maps: EventTypeMaps, et: dict, *, with_category: bool, is_v2: bool = False) -> None:
     """Merge one ER event-type record into the shared maps.
 
     Uses ``setdefault`` so v1 and v2 entries for the same slug (shouldn't
@@ -1246,6 +1253,8 @@ def _absorb_event_type(maps: EventTypeMaps, et: dict, *, with_category: bool) ->
         maps.display_by_slug.setdefault(slug, et["display"])
     if et.get("id"):
         maps.id_by_slug.setdefault(slug, et["id"])
+    if is_v2:
+        maps.v2_slugs.add(slug)
     category = et.get("category")
     if isinstance(category, dict):
         # v1: nested category object with its own slug/id/display.
@@ -1434,25 +1443,60 @@ def _build_er_client(integration: Integration) -> AsyncERClient:
     )
 
 
-async def action_list_event_types(integration: Integration, action_config: ListEventTypesQuery):
-    """Reference action: ER event types visible to this integration's credentials.
+async def _fetch_category_display_map(er_client) -> Dict[str, str]:
+    """Best-effort category slug → display name, unconditionally fetched.
 
-    Reuses `_fetch_event_type_maps`'s v1+v2 merge. Options are grouped by ER
-    event category (falling back to no group when the category has no known
-    display name), sorted by group then label.
+    Unlike `_fetch_event_type_maps`'s `category_id_by_slug` fallback (which
+    only hits `get_event_categories` when v1 records didn't already supply
+    category UUIDs — a condition tuned for `pull_events`' filter-resolution
+    needs), `list_event_types` needs display names for every category that
+    has a v2 event type in it, regardless of what v1 already resolved. A
+    v1-heavy merge can leave category_id_by_slug non-empty (skipping that
+    fallback) while a v2-only category's display name is still unknown, so
+    this reference action always fetches the categories endpoint itself.
+    """
+    try:
+        categories = await er_client.get_event_categories()
+    except Exception as e:
+        logger.warning(
+            "Could not fetch ER event categories for list_event_types grouping: %s: %s.",
+            type(e).__name__, e,
+        )
+        return {}
+    return {
+        cat["value"]: cat["display"]
+        for cat in _as_list(categories)
+        if isinstance(cat, dict) and cat.get("value") and cat.get("display")
+    }
+
+
+async def action_list_event_types(integration: Integration, action_config: ListEventTypesQuery):
+    """Reference action: v2 ER event types visible to this integration's credentials.
+
+    Reuses `_fetch_event_type_maps`'s v1+v2 merge but offers only the v2-
+    sourced slugs: ER's v2 pre-rendered schema endpoint 404s for classic v1
+    event types, which would dead-end the list_event_type_fields /
+    list_event_field_values cascade for them, so they're excluded here
+    rather than offered and then failing one step later. Options are
+    grouped by ER event category (falling back to no group when the
+    category has no known display name), sorted by group then label.
     """
     async with _build_er_client(integration) as earth_ranger:
         maps = await _fetch_event_type_maps(earth_ranger)
+        category_display = await _fetch_category_display_map(earth_ranger)
+
+    # The unconditional fetch above is authoritative (covers every category,
+    # regardless of what `_fetch_event_type_maps` already resolved from v1);
+    # `maps.category_display_by_slug` fills any gap if that fetch failed.
+    group_display_by_slug = {**maps.category_display_by_slug, **category_display}
 
     options = [
         ReferenceOption(
             value=slug,
-            label=display,
-            group=maps.category_display_by_slug.get(
-                maps.category_slug_by_type_slug.get(slug)
-            ),
+            label=maps.display_by_slug.get(slug, slug),
+            group=group_display_by_slug.get(maps.category_slug_by_type_slug.get(slug)),
         )
-        for slug, display in maps.display_by_slug.items()
+        for slug in maps.v2_slugs
     ]
     options.sort(key=lambda o: (o.group or "", o.label or o.value))
     return ReferenceDataResponse(options=options, truncated=False).dict()
@@ -1461,7 +1505,8 @@ async def action_list_event_types(integration: Integration, action_config: ListE
 async def _fetch_event_type_fields(er_client, base_url: str, event_type: str):
     """Fetch + parse an ER event type's pre-rendered schema into ERFields.
 
-    A 404 from ER (unknown event type) is translated to a ValueError so it
+    A 404 from ER (unknown event type, or a classic v1 event type — the v2
+    schema endpoint 404s for those too) is translated to a ValueError so it
     reads naturally as a config-form error; any other upstream failure
     (e.g. a 5xx) propagates unchanged.
     """
@@ -1469,7 +1514,10 @@ async def _fetch_event_type_fields(er_client, base_url: str, event_type: str):
         raw_schema = await fetch_prerendered_event_schema(er_client, base_url, event_type)
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 404:
-            raise ValueError(f"Event type '{event_type}' not found in EarthRanger.") from e
+            raise ValueError(
+                f"Event type '{event_type}' has no v2 schema in EarthRanger "
+                "(classic v1 event types are not supported by reference actions)."
+            ) from e
         raise
     return parse_er_event_schema(raw_schema)
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1422,8 +1422,11 @@ def transform_observations_to_gundi_schema(observations, resolver=None):
 # ---------------------------------------------------------------------------
 # Reference actions: config-time lookups the Gundi portal calls while an
 # operator is filling out a form (e.g. populating an "Event Type" dropdown).
-# Stateless — they read only the integration's auth config and propagate
-# upstream ER errors rather than swallowing them (see
+# Stateless — they read only the integration's auth config. Errors from the
+# load-bearing fetches (event types, schemas) propagate rather than being
+# swallowed; the one exception is list_event_types' category-display lookup,
+# which is best-effort enrichment for grouping and degrades to ungrouped
+# options on failure (see
 # docs/superpowers/specs/2026-07-31-reference-data-config-ui-design.md).
 # ---------------------------------------------------------------------------
 
@@ -1432,6 +1435,11 @@ def _build_er_client(integration: Integration) -> AsyncERClient:
     (mirrors action_pull_events / action_pull_observations)."""
     auth_config = get_authentication_config(integration=integration)
     url_parse = urlparse(integration.base_url)
+    if not url_parse.hostname:
+        # Schemeless/empty base_urls occur in Gundi; without this guard the
+        # client would be built against "https://None/...". Same message as
+        # action_auth's validation for consistency.
+        raise ValueError(f"Site URL is empty or invalid: '{integration.base_url}'")
     return AsyncERClient(
         service_root=f"{url_parse.scheme}://{url_parse.hostname}/api/v1.0",
         username=auth_config.username or None,

--- a/app/actions/tests/fixtures/rhino_carcass_schema_from_api.json
+++ b/app/actions/tests/fixtures/rhino_carcass_schema_from_api.json
@@ -1,0 +1,454 @@
+{
+    "json": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+            "cause_of_death": {
+                "deprecated": false,
+                "description": "",
+                "title": "Cause Of Death",
+                "type": "string",
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "title": "Choices",
+                        "description": "All choices schema list",
+                        "enum": [
+                            "disease",
+                            "fence",
+                            "fighting",
+                            "fire",
+                            "gunshot",
+                            "injury",
+                            "oldage",
+                            "predation",
+                            "snare",
+                            "nutrition",
+                            "vehicle",
+                            "weather",
+                            "unknown",
+                            "other"
+                        ],
+                        "x-enumExtra": {
+                            "disease": {
+                                "display": "Disease",
+                                "description": "carcass_causeofdeath"
+                            },
+                            "fence": {
+                                "display": "Fence",
+                                "description": "carcass_causeofdeath"
+                            },
+                            "fighting": {
+                                "display": "Fighting",
+                                "description": "carcass_causeofdeath"
+                            },
+                            "fire": {
+                                "display": "Fire",
+                                "description": "carcass_causeofdeath"
+                            },
+                            "gunshot": {
+                                "display": "Gunshot",
+                                "description": "carcass_causeofdeath"
+                            },
+                            "injury": {
+                                "display": "Injury",
+                                "description": "carcass_causeofdeath"
+                            },
+                            "oldage": {
+                                "display": "Old age",
+                                "description": "carcass_causeofdeath"
+                            },
+                            "predation": {
+                                "display": "Predation",
+                                "description": "carcass_causeofdeath"
+                            },
+                            "snare": {
+                                "display": "Snare",
+                                "description": "carcass_causeofdeath"
+                            },
+                            "nutrition": {
+                                "display": "Nutrition",
+                                "description": "carcass_causeofdeath"
+                            },
+                            "vehicle": {
+                                "display": "Vehicle",
+                                "description": "carcass_causeofdeath"
+                            },
+                            "weather": {
+                                "display": "Weather",
+                                "description": "carcass_causeofdeath"
+                            },
+                            "unknown": {
+                                "display": "Unknown",
+                                "description": "carcass_causeofdeath"
+                            },
+                            "other": {
+                                "display": "Other",
+                                "description": "carcass_causeofdeath"
+                            }
+                        }
+                    }
+                ]
+            },
+            "age_of_carcass": {
+                "deprecated": false,
+                "description": "",
+                "title": "Age Of Carcass",
+                "type": "string",
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "title": "Choices",
+                        "description": "All choices schema list",
+                        "enum": [
+                            "very_fresh",
+                            "fresh",
+                            "old",
+                            "very_old"
+                        ],
+                        "x-enumExtra": {
+                            "very_fresh": {
+                                "display": "Very fresh",
+                                "description": "leopardtrack_trackage"
+                            },
+                            "fresh": {
+                                "display": "Fresh",
+                                "description": "leopardtrack_trackage"
+                            },
+                            "old": {
+                                "display": "Old",
+                                "description": "leopardtrack_trackage"
+                            },
+                            "very_old": {
+                                "display": "Very old",
+                                "description": "leopardtrack_trackage"
+                            }
+                        }
+                    }
+                ]
+            },
+            "animal_sex": {
+                "deprecated": false,
+                "description": "",
+                "title": "Animal Sex",
+                "type": "string",
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "title": "Choices",
+                        "description": "All choices schema list",
+                        "enum": [
+                            "female",
+                            "male",
+                            "Unknown"
+                        ],
+                        "x-enumExtra": {
+                            "female": {
+                                "display": "Female",
+                                "description": "allrep_sex"
+                            },
+                            "male": {
+                                "display": "Male",
+                                "description": "allrep_sex"
+                            },
+                            "Unknown": {
+                                "display": "Unknown",
+                                "description": "allrep_sex"
+                            }
+                        }
+                    }
+                ]
+            },
+            "animal_id": {
+                "default": "",
+                "deprecated": false,
+                "description": "",
+                "title": "Animal ID",
+                "type": "string"
+            },
+            "age_of_animal": {
+                "deprecated": false,
+                "description": "",
+                "title": "Age Of Animal",
+                "type": "string",
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "title": "Choices",
+                        "description": "All choices schema list",
+                        "enum": [
+                            "a_0-3_months",
+                            "b_3_months1_year",
+                            "c_1-2_years",
+                            "d_2-3.5years",
+                            "e_3.5-7years",
+                            "f_7_years_and_more"
+                        ],
+                        "x-enumExtra": {
+                            "a_0-3_months": {
+                                "display": "A: 0-3 Months",
+                                "description": "rhinomonitoringrep_rhino1ageclass"
+                            },
+                            "b_3_months1_year": {
+                                "display": "B: 3 Months - 1 Year",
+                                "description": "rhinomonitoringrep_rhino1ageclass"
+                            },
+                            "c_1-2_years": {
+                                "display": "C: 1 - 2 Years",
+                                "description": "rhinomonitoringrep_rhino1ageclass"
+                            },
+                            "d_2-3.5years": {
+                                "display": "D: 2 - 3.5 Years",
+                                "description": "rhinomonitoringrep_rhino1ageclass"
+                            },
+                            "e_3.5-7years": {
+                                "display": "E: 3.5 - 7 Years",
+                                "description": "rhinomonitoringrep_rhino1ageclass"
+                            },
+                            "f_7_years_and_more": {
+                                "display": "F: 7 Years and More",
+                                "description": "rhinomonitoringrep_rhino1ageclass"
+                            }
+                        }
+                    }
+                ]
+            },
+            "animal_common_name": {
+                "deprecated": false,
+                "description": "",
+                "title": "Animal Common Name",
+                "type": "string",
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "title": "Choices",
+                        "description": "All choices schema list",
+                        "enum": [
+                            "Black Rhino",
+                            "White Rhino"
+                        ],
+                        "x-enumExtra": {
+                            "Black Rhino": {
+                                "display": "Black Rhino",
+                                "description": "rhinospecies"
+                            },
+                            "White Rhino": {
+                                "display": "White Rhino",
+                                "description": "rhinospecies"
+                            }
+                        }
+                    }
+                ]
+            },
+            "reported_to_opswpu": {
+                "deprecated": false,
+                "description": "",
+                "title": "Reported to OPS/WPU",
+                "type": "string",
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "title": "Choices",
+                        "description": "All choices schema list",
+                        "enum": [
+                            "yes",
+                            "no"
+                        ],
+                        "x-enumExtra": {
+                            "yes": {
+                                "display": "Yes",
+                                "description": "yesno"
+                            },
+                            "no": {
+                                "display": "No",
+                                "description": "yesno"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "required": [
+            "cause_of_death",
+            "age_of_carcass",
+            "animal_sex",
+            "age_of_animal",
+            "animal_common_name",
+            "reported_to_opswpu"
+        ],
+        "type": "object"
+    },
+    "ui": {
+        "fields": {
+            "cause_of_death": {
+                "choices": {
+                    "eventTypeCategories": [],
+                    "existingChoiceList": [
+                        "carcass_causeofdeath"
+                    ],
+                    "featureCategories": [],
+                    "myDataType": "SUBJECTS_FROM_SUBJECT_GROUP",
+                    "subjectGroups": [],
+                    "subjectSubtypes": [],
+                    "type": "EXISTING_CHOICE_LIST"
+                },
+                "inputType": "DROPDOWN",
+                "placeholder": "",
+                "type": "CHOICE_LIST",
+                "parent": "section-1"
+            },
+            "age_of_carcass": {
+                "choices": {
+                    "eventTypeCategories": [],
+                    "existingChoiceList": [
+                        "leopardtrack_trackage"
+                    ],
+                    "featureCategories": [],
+                    "myDataType": "SUBJECTS_FROM_SUBJECT_GROUP",
+                    "subjectGroups": [],
+                    "subjectSubtypes": [],
+                    "type": "EXISTING_CHOICE_LIST"
+                },
+                "inputType": "DROPDOWN",
+                "placeholder": "",
+                "type": "CHOICE_LIST",
+                "parent": "section-1"
+            },
+            "animal_sex": {
+                "choices": {
+                    "eventTypeCategories": [],
+                    "existingChoiceList": [
+                        "allrep_sex"
+                    ],
+                    "featureCategories": [],
+                    "myDataType": "SUBJECTS_FROM_SUBJECT_GROUP",
+                    "subjectGroups": [],
+                    "subjectSubtypes": [],
+                    "type": "EXISTING_CHOICE_LIST"
+                },
+                "inputType": "DROPDOWN",
+                "placeholder": "",
+                "type": "CHOICE_LIST",
+                "parent": "section-1"
+            },
+            "animal_id": {
+                "inputType": "SHORT_TEXT",
+                "placeholder": "",
+                "type": "TEXT",
+                "parent": "section-1"
+            },
+            "age_of_animal": {
+                "choices": {
+                    "eventTypeCategories": [],
+                    "existingChoiceList": [
+                        "rhinomonitoringrep_rhino1ageclass"
+                    ],
+                    "featureCategories": [],
+                    "myDataType": "SUBJECTS_FROM_SUBJECT_GROUP",
+                    "subjectGroups": [],
+                    "subjectSubtypes": [],
+                    "type": "EXISTING_CHOICE_LIST"
+                },
+                "inputType": "DROPDOWN",
+                "placeholder": "",
+                "type": "CHOICE_LIST",
+                "parent": "section-1"
+            },
+            "animal_common_name": {
+                "choices": {
+                    "eventTypeCategories": [],
+                    "existingChoiceList": [
+                        "rhinospecies"
+                    ],
+                    "featureCategories": [],
+                    "myDataType": "SUBJECTS_FROM_SUBJECT_GROUP",
+                    "subjectGroups": [],
+                    "subjectSubtypes": [],
+                    "type": "EXISTING_CHOICE_LIST"
+                },
+                "inputType": "DROPDOWN",
+                "placeholder": "",
+                "type": "CHOICE_LIST",
+                "parent": "section-1"
+            },
+            "reported_to_opswpu": {
+                "choices": {
+                    "eventTypeCategories": [],
+                    "existingChoiceList": [
+                        "yesno"
+                    ],
+                    "featureCategories": [],
+                    "myDataType": "SUBJECTS_FROM_SUBJECT_GROUP",
+                    "subjectGroups": [],
+                    "subjectSubtypes": [],
+                    "type": "EXISTING_CHOICE_LIST"
+                },
+                "inputType": "DROPDOWN",
+                "placeholder": "",
+                "type": "CHOICE_LIST",
+                "parent": "section-1"
+            }
+        },
+        "headers": {
+            "header-1": {
+                "label": "Contact OPS immediately if carcass found",
+                "section": "section-2",
+                "size": "LARGE"
+            }
+        },
+        "order": [
+            "section-2",
+            "section-1"
+        ],
+        "sections": {
+            "section-1": {
+                "columns": 2,
+                "isActive": true,
+                "label": "",
+                "leftColumn": [
+                    {
+                        "type": "field",
+                        "name": "cause_of_death"
+                    },
+                    {
+                        "name": "age_of_animal",
+                        "type": "field"
+                    },
+                    {
+                        "name": "animal_common_name",
+                        "type": "field"
+                    },
+                    {
+                        "name": "reported_to_opswpu",
+                        "type": "field"
+                    }
+                ],
+                "rightColumn": [
+                    {
+                        "type": "field",
+                        "name": "age_of_carcass"
+                    },
+                    {
+                        "type": "field",
+                        "name": "animal_sex"
+                    },
+                    {
+                        "type": "field",
+                        "name": "animal_id"
+                    }
+                ]
+            },
+            "section-2": {
+                "columns": 1,
+                "isActive": true,
+                "label": "",
+                "leftColumn": [
+                    {
+                        "name": "header-1",
+                        "type": "header"
+                    }
+                ],
+                "rightColumn": []
+            }
+        }
+    }
+}

--- a/app/actions/tests/test_er_schema.py
+++ b/app/actions/tests/test_er_schema.py
@@ -1,0 +1,136 @@
+"""Tests for app.actions.er_schema: the pre-rendered event-type schema parser
+and fetch helper consumed by the reference actions (list_event_type_fields,
+list_event_field_values). ``parse_er_event_schema`` is exercised against a
+real captured ER response (rhino_carcass_schema_from_api.json, copied from
+gundi-integration-cmore/docs/) rather than a hand-built fixture."""
+
+import json
+import os
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import respx
+
+from app.actions.er_schema import ERChoice, ERField, parse_er_event_schema, fetch_prerendered_event_schema
+
+_FIXTURE_PATH = os.path.join(os.path.dirname(__file__), "fixtures", "rhino_carcass_schema_from_api.json")
+
+
+def _load_fixture():
+    with open(_FIXTURE_PATH) as fh:
+        return json.load(fh)
+
+
+# --- parse_er_event_schema against the real rhino_carcass fixture ----------
+
+
+def test_parse_er_event_schema_returns_all_fields_in_order():
+    fields = parse_er_event_schema(_load_fixture())
+    assert [f.key for f in fields] == [
+        "cause_of_death",
+        "age_of_carcass",
+        "animal_sex",
+        "animal_id",
+        "age_of_animal",
+        "animal_common_name",
+        "reported_to_opswpu",
+    ]
+    by_key = {f.key: f for f in fields}
+    assert by_key["cause_of_death"].title == "Cause Of Death"
+    assert by_key["animal_sex"].title == "Animal Sex"
+    assert by_key["animal_id"].title == "Animal ID"
+
+
+def test_parse_er_event_schema_inlines_choices_with_value_and_display():
+    fields = parse_er_event_schema(_load_fixture())
+    by_key = {f.key: f for f in fields}
+
+    animal_sex = by_key["animal_sex"]
+    assert animal_sex.is_enum
+    assert animal_sex.choices == [
+        ERChoice("female", "Female"),
+        ERChoice("male", "Male"),
+        ERChoice("Unknown", "Unknown"),
+    ]
+
+    cause_of_death = by_key["cause_of_death"]
+    assert cause_of_death.is_enum
+    assert ERChoice("gunshot", "Gunshot") in cause_of_death.choices
+    assert ERChoice("oldage", "Old age") in cause_of_death.choices
+
+
+def test_parse_er_event_schema_free_text_field_is_not_enum():
+    fields = parse_er_event_schema(_load_fixture())
+    by_key = {f.key: f for f in fields}
+    assert by_key["animal_id"].is_enum is False
+    assert by_key["animal_id"].choices is None
+
+
+def test_parse_er_event_schema_empty_when_no_properties():
+    assert parse_er_event_schema({"nonsense": True}) == []
+
+
+def test_er_field_is_enum_true_only_when_choices_present():
+    assert ERField(key="k", title="K", choices=[ERChoice("a", "A")]).is_enum is True
+    assert ERField(key="k", title="K", choices=None).is_enum is False
+
+
+# --- fetch_prerendered_event_schema -----------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_prerendered_event_schema_builds_url_and_forwards_auth():
+    er_client = AsyncMock()
+    er_client.auth_headers = AsyncMock(return_value={"Authorization": "Bearer x"})
+
+    payload = {"json": {"properties": {}}}
+    route = respx.get(
+        "https://er.example.com/api/v2.0/activity/eventtypes/rhino_carcass/schema"
+    ).mock(return_value=httpx.Response(200, json=payload))
+
+    result = await fetch_prerendered_event_schema(
+        er_client, base_url="https://er.example.com/api/v1.0", event_type="rhino_carcass"
+    )
+
+    assert result == payload
+    assert route.called
+    sent_request = route.calls.last.request
+    assert sent_request.url.params["pre_render"] == "true"
+    assert sent_request.url.params["s_format"] == "enum"
+    assert sent_request.headers["Authorization"] == "Bearer x"
+    er_client.auth_headers.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_prerendered_event_schema_url_encodes_event_type():
+    er_client = AsyncMock()
+    er_client.auth_headers = AsyncMock(return_value={"Authorization": "Bearer x"})
+
+    route = respx.get(
+        "https://er.example.com/api/v2.0/activity/eventtypes/rhino%2Fcarcass%20type/schema"
+    ).mock(return_value=httpx.Response(200, json={}))
+
+    await fetch_prerendered_event_schema(
+        er_client, base_url="https://er.example.com/api/v1.0", event_type="rhino/carcass type"
+    )
+
+    assert route.called
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_prerendered_event_schema_raises_on_404():
+    er_client = AsyncMock()
+    er_client.auth_headers = AsyncMock(return_value={"Authorization": "Bearer x"})
+
+    respx.get(
+        "https://er.example.com/api/v2.0/activity/eventtypes/unknown_type/schema"
+    ).mock(return_value=httpx.Response(404, json={"detail": "Not found"}))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await fetch_prerendered_event_schema(
+            er_client, base_url="https://er.example.com", event_type="unknown_type"
+        )

--- a/app/actions/tests/test_er_schema.py
+++ b/app/actions/tests/test_er_schema.py
@@ -134,3 +134,23 @@ async def test_fetch_prerendered_event_schema_raises_on_404():
         await fetch_prerendered_event_schema(
             er_client, base_url="https://er.example.com", event_type="unknown_type"
         )
+
+
+# --- base_url validation -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_prerendered_event_schema_rejects_schemeless_base_url():
+    # Schemeless base_urls occur in Gundi; urlparse leaves hostname None for
+    # them, which would otherwise build a "https://None/..." URL.
+    er_client = AsyncMock()
+    with pytest.raises(ValueError, match="Site URL is empty or invalid: 'gundi-er.pamdas.org'"):
+        await fetch_prerendered_event_schema(er_client, "gundi-er.pamdas.org", "rhino_carcass")
+    er_client.auth_headers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_prerendered_event_schema_rejects_empty_base_url():
+    er_client = AsyncMock()
+    with pytest.raises(ValueError, match="Site URL is empty or invalid"):
+        await fetch_prerendered_event_schema(er_client, "", "rhino_carcass")

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -324,3 +324,21 @@ async def test_list_event_field_values_unknown_event_type_raises(
             er_integration_v2_provider,
             ListEventFieldValuesQuery(event_type="no_such_type", field_key="animal_sex"),
         )
+
+
+# --- base_url validation in _build_er_client ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reference_action_with_schemeless_base_url_raises_clean_error(
+    mocker, er_integration_v2_provider
+):
+    """A schemeless/empty integration.base_url must fail with the same clean
+    'Site URL is empty or invalid' message action_auth uses, not a confusing
+    downstream error against https://None/..."""
+    from app.actions.handlers import action_list_event_types
+    from app.actions.configurations import ListEventTypesQuery
+
+    mocker.patch.object(er_integration_v2_provider, "base_url", "gundi-er.pamdas.org")
+    with pytest.raises(ValueError, match="Site URL is empty or invalid: 'gundi-er.pamdas.org'"):
+        await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -1,0 +1,254 @@
+"""Tests for the three ER provider-side reference actions: list_event_types,
+list_event_type_fields, and list_event_field_values. AsyncERClient and
+fetch_prerendered_event_schema are mocked at the app.actions.handlers module
+level; parse_er_event_schema runs for real against the captured rhino_carcass
+fixture so these tests also exercise the schema-driven handlers end to end.
+"""
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from app.actions.configurations import (
+    ListEventTypesQuery,
+    ListEventTypeFieldsQuery,
+    ListEventFieldValuesQuery,
+)
+from app.actions.handlers import (
+    action_list_event_types,
+    action_list_event_type_fields,
+    action_list_event_field_values,
+)
+
+_FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "fixtures", "rhino_carcass_schema_from_api.json"
+)
+
+
+def _load_fixture():
+    with open(_FIXTURE_PATH) as fh:
+        return json.load(fh)
+
+
+@pytest.fixture
+def mock_er_client(mocker):
+    """Patch AsyncERClient in handlers; returns the mock instance the
+    `async with AsyncERClient(...) as earth_ranger:` block yields."""
+    from app.actions import handlers as handlers_module
+
+    instance = MagicMock()
+    instance.get_event_types = AsyncMock(return_value=[])
+    instance.get_event_categories = AsyncMock(return_value=[])
+    client_cls = MagicMock()
+    client_cls.return_value.__aenter__ = AsyncMock(return_value=instance)
+    client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch.object(handlers_module, "AsyncERClient", client_cls)
+    return instance
+
+
+@pytest.fixture
+def mock_fetch_schema(mocker):
+    """Patch fetch_prerendered_event_schema in handlers (Task 2's fetch
+    helper) so list_event_type_fields/list_event_field_values tests don't
+    depend on real ER schema HTTP calls."""
+    from app.actions import handlers as handlers_module
+
+    mock = AsyncMock()
+    mocker.patch.object(handlers_module, "fetch_prerendered_event_schema", mock)
+    return mock
+
+
+# --- action_list_event_types -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_event_types_groups_by_category(
+    er_integration_v2_provider, mock_er_client
+):
+    """v1 and v2 event types are merged; options are grouped by category
+    display name (from v1's nested category dict, including for a v2-only
+    type sharing that category slug) and sorted by group then label."""
+    from erclient import VERSION_1_0, VERSION_2_0
+
+    async def fake_get_event_types(version=VERSION_1_0, **kwargs):
+        if version == VERSION_1_0:
+            return [
+                {
+                    "value": "rhino_carcass", "display": "Rhino Carcass", "id": "id1",
+                    "category": {"value": "wildlife", "id": "catw", "display": "Wildlife"},
+                },
+                {
+                    "value": "accident_rep", "display": "Accident Report", "id": "id2",
+                    "category": {"value": "security", "id": "cats", "display": "Security"},
+                },
+            ]
+        if version == VERSION_2_0:
+            return [
+                # v2-only type sharing the "wildlife" category slug seen from v1.
+                {"value": "coyote_carcass", "display": "Coyote Carcass", "id": "id3", "category": "wildlife"},
+            ]
+        return []
+
+    mock_er_client.get_event_types = fake_get_event_types
+
+    result = await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
+
+    values = [(o["value"], o["label"], o["group"]) for o in result["options"]]
+    assert values == [
+        ("accident_rep", "Accident Report", "Security"),
+        ("coyote_carcass", "Coyote Carcass", "Wildlife"),
+        ("rhino_carcass", "Rhino Carcass", "Wildlife"),
+    ]
+    assert result["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_event_types_ungrouped_when_no_category_display_known(
+    er_integration_v2_provider, mock_er_client
+):
+    """A v2-only type whose category slug never resolved to a display name
+    (get_event_categories also came up empty) gets no group rather than an
+    error."""
+    from erclient import VERSION_1_0, VERSION_2_0
+
+    async def fake_get_event_types(version=VERSION_1_0, **kwargs):
+        if version == VERSION_1_0:
+            return []
+        if version == VERSION_2_0:
+            return [{"value": "lone_type", "display": "Lone Type", "id": "id1", "category": "mystery"}]
+        return []
+
+    mock_er_client.get_event_types = fake_get_event_types
+    mock_er_client.get_event_categories = AsyncMock(return_value=[])
+
+    result = await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
+
+    assert result["options"] == [
+        {"value": "lone_type", "label": "Lone Type", "description": None, "group": None}
+    ]
+
+
+# --- action_list_event_type_fields ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_event_type_fields_returns_options_from_schema(
+    er_integration_v2_provider, mock_er_client, mock_fetch_schema
+):
+    mock_fetch_schema.return_value = _load_fixture()
+
+    result = await action_list_event_type_fields(
+        er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="rhino_carcass")
+    )
+
+    by_value = {o["value"]: o for o in result["options"]}
+    assert [o["value"] for o in result["options"]] == [
+        "cause_of_death", "age_of_carcass", "animal_sex", "animal_id",
+        "age_of_animal", "animal_common_name", "reported_to_opswpu",
+    ]
+    assert by_value["animal_sex"]["label"] == "Animal Sex"
+    assert by_value["animal_sex"]["description"] == "choices"
+    assert by_value["animal_id"]["label"] == "Animal ID"
+    assert by_value["animal_id"]["description"] is None
+    mock_fetch_schema.assert_awaited_once_with(
+        mock_er_client, er_integration_v2_provider.base_url, "rhino_carcass"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_event_type_fields_unknown_event_type_raises(
+    er_integration_v2_provider, mock_er_client, mock_fetch_schema
+):
+    mock_fetch_schema.side_effect = httpx.HTTPStatusError(
+        "Not Found", request=MagicMock(), response=MagicMock(status_code=404)
+    )
+
+    with pytest.raises(ValueError, match="rhino_carcass.*not found in EarthRanger"):
+        await action_list_event_type_fields(
+            er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="rhino_carcass")
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_event_type_fields_upstream_500_propagates(
+    er_integration_v2_provider, mock_er_client, mock_fetch_schema
+):
+    """A non-404 upstream failure (e.g. a 500) must propagate, not be
+    swallowed or mistranslated into the 404 ValueError."""
+    mock_fetch_schema.side_effect = httpx.HTTPStatusError(
+        "Server Error", request=MagicMock(), response=MagicMock(status_code=500)
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await action_list_event_type_fields(
+            er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="rhino_carcass")
+        )
+
+
+# --- action_list_event_field_values -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_event_field_values_returns_choices_for_enum_field(
+    er_integration_v2_provider, mock_er_client, mock_fetch_schema
+):
+    mock_fetch_schema.return_value = _load_fixture()
+
+    result = await action_list_event_field_values(
+        er_integration_v2_provider,
+        ListEventFieldValuesQuery(event_type="rhino_carcass", field_key="animal_sex"),
+    )
+
+    assert [(o["value"], o["label"]) for o in result["options"]] == [
+        ("female", "Female"),
+        ("male", "Male"),
+        ("Unknown", "Unknown"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_event_field_values_non_enum_field_returns_empty(
+    er_integration_v2_provider, mock_er_client, mock_fetch_schema
+):
+    """animal_id is free-text in the fixture (no inline choices) — matches
+    CMORE's list_field_options non-lookup behavior: empty options, not an
+    error."""
+    mock_fetch_schema.return_value = _load_fixture()
+
+    result = await action_list_event_field_values(
+        er_integration_v2_provider,
+        ListEventFieldValuesQuery(event_type="rhino_carcass", field_key="animal_id"),
+    )
+
+    assert result["options"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_event_field_values_unknown_field_raises(
+    er_integration_v2_provider, mock_er_client, mock_fetch_schema
+):
+    mock_fetch_schema.return_value = _load_fixture()
+
+    with pytest.raises(ValueError, match="no_such_field"):
+        await action_list_event_field_values(
+            er_integration_v2_provider,
+            ListEventFieldValuesQuery(event_type="rhino_carcass", field_key="no_such_field"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_event_field_values_unknown_event_type_raises(
+    er_integration_v2_provider, mock_er_client, mock_fetch_schema
+):
+    mock_fetch_schema.side_effect = httpx.HTTPStatusError(
+        "Not Found", request=MagicMock(), response=MagicMock(status_code=404)
+    )
+
+    with pytest.raises(ValueError, match="not found in EarthRanger"):
+        await action_list_event_field_values(
+            er_integration_v2_provider,
+            ListEventFieldValuesQuery(event_type="no_such_type", field_key="animal_sex"),
+        )

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -68,9 +68,11 @@ def mock_fetch_schema(mocker):
 async def test_list_event_types_groups_by_category(
     er_integration_v2_provider, mock_er_client
 ):
-    """v1 and v2 event types are merged; options are grouped by category
-    display name (from v1's nested category dict, including for a v2-only
-    type sharing that category slug) and sorted by group then label."""
+    """Only v2 event types are offered (see
+    test_list_event_types_excludes_v1_only_types), grouped by category
+    display name and sorted by group then label. Category display names can
+    come from either version's response — here both groups are known via
+    v1's nested category dict."""
     from erclient import VERSION_1_0, VERSION_2_0
 
     async def fake_get_event_types(version=VERSION_1_0, **kwargs):
@@ -87,22 +89,89 @@ async def test_list_event_types_groups_by_category(
             ]
         if version == VERSION_2_0:
             return [
-                # v2-only type sharing the "wildlife" category slug seen from v1.
+                # v2-only types, one sharing the "wildlife" category slug seen from v1.
                 {"value": "coyote_carcass", "display": "Coyote Carcass", "id": "id3", "category": "wildlife"},
+                {"value": "sit_rep_v2", "display": "Sit Rep", "id": "id4", "category": "security"},
             ]
+        return []
+
+    mock_er_client.get_event_types = fake_get_event_types
+    mock_er_client.get_event_categories = AsyncMock(return_value=[])
+
+    result = await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
+
+    values = [(o["value"], o["label"], o["group"]) for o in result["options"]]
+    assert values == [
+        ("sit_rep_v2", "Sit Rep", "Security"),
+        ("coyote_carcass", "Coyote Carcass", "Wildlife"),
+    ]
+    assert result["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_event_types_excludes_v1_only_types(
+    er_integration_v2_provider, mock_er_client
+):
+    """Classic v1 event types dead-end the list_event_type_fields /
+    list_event_field_values cascade (ER's v2 schema endpoint 404s for them),
+    so list_event_types must not offer them at all — only v2-sourced slugs
+    appear, even though the v1 type is known (it contributes display_by_slug
+    and category info, just not an option)."""
+    from erclient import VERSION_1_0, VERSION_2_0
+
+    async def fake_get_event_types(version=VERSION_1_0, **kwargs):
+        if version == VERSION_1_0:
+            return [{"value": "rhino_carcass", "display": "Rhino Carcass", "id": "id1", "category": {}}]
+        if version == VERSION_2_0:
+            return [{"value": "coyote_carcass", "display": "Coyote Carcass", "id": "id2", "category": {}}]
         return []
 
     mock_er_client.get_event_types = fake_get_event_types
 
     result = await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
 
-    values = [(o["value"], o["label"], o["group"]) for o in result["options"]]
-    assert values == [
-        ("accident_rep", "Accident Report", "Security"),
-        ("coyote_carcass", "Coyote Carcass", "Wildlife"),
-        ("rhino_carcass", "Rhino Carcass", "Wildlife"),
+    assert [o["value"] for o in result["options"]] == ["coyote_carcass"]
+
+
+@pytest.mark.asyncio
+async def test_list_event_types_group_resolves_via_unconditional_categories_fetch(
+    er_integration_v2_provider, mock_er_client
+):
+    """A v1 event type already populates category_id_by_slug, which would
+    normally suppress `_fetch_event_type_maps`'s own categories-endpoint
+    fallback (that fallback is tuned for pull_events' UUID-resolution need,
+    not display names). list_event_types must still resolve display names
+    for categories only seen via v2 — via its own unconditional
+    get_event_categories fetch — rather than leaving them ungrouped."""
+    from erclient import VERSION_1_0, VERSION_2_0
+
+    async def fake_get_event_types(version=VERSION_1_0, **kwargs):
+        if version == VERSION_1_0:
+            return [
+                {
+                    "value": "rhino_carcass", "display": "Rhino Carcass", "id": "id1",
+                    "category": {"value": "wildlife", "id": "catw", "display": "Wildlife"},
+                },
+            ]
+        if version == VERSION_2_0:
+            # v2-only type in a category v1 never mentioned.
+            return [{"value": "lone_type", "display": "Lone Type", "id": "id2", "category": "mystery"}]
+        return []
+
+    mock_er_client.get_event_types = fake_get_event_types
+    mock_er_client.get_event_categories = AsyncMock(
+        return_value=[{"value": "mystery", "id": "catm", "display": "Mystery"}]
+    )
+
+    result = await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
+
+    # rhino_carcass (v1-only) is excluded; lone_type's group resolved to
+    # "Mystery" via the unconditional fetch even though category_id_by_slug
+    # was already non-empty from v1.
+    assert result["options"] == [
+        {"value": "lone_type", "label": "Lone Type", "description": None, "group": "Mystery"}
     ]
-    assert result["truncated"] is False
+    mock_er_client.get_event_categories.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -166,7 +235,10 @@ async def test_list_event_type_fields_unknown_event_type_raises(
         "Not Found", request=MagicMock(), response=MagicMock(status_code=404)
     )
 
-    with pytest.raises(ValueError, match="rhino_carcass.*not found in EarthRanger"):
+    with pytest.raises(
+        ValueError,
+        match="rhino_carcass.*has no v2 schema in EarthRanger.*classic v1 event types are not supported",
+    ):
         await action_list_event_type_fields(
             er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="rhino_carcass")
         )
@@ -247,7 +319,7 @@ async def test_list_event_field_values_unknown_event_type_raises(
         "Not Found", request=MagicMock(), response=MagicMock(status_code=404)
     )
 
-    with pytest.raises(ValueError, match="not found in EarthRanger"):
+    with pytest.raises(ValueError, match="has no v2 schema in EarthRanger"):
         await action_list_event_field_values(
             er_integration_v2_provider,
             ListEventFieldValuesQuery(event_type="no_such_type", field_key="animal_sex"),

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -16,7 +16,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from gundi_core.events import IntegrationActionFailed, ActionExecutionFailed, LogLevel
 
-from app.actions.core import PullActionConfiguration
+from app.actions.core import PullActionConfiguration, ReferenceActionConfiguration
 from .config_manager import IntegrationConfigurationManager
 from .state import IntegrationStateManager
 from .activity_logger import publish_event, log_action_activity
@@ -234,10 +234,18 @@ async def execute_action(
     # portal) doesn't silently fall through to the automated default.
     is_manual = (triggered_by or "").strip().lower() == ActionTrigger.MANUAL.value
     skippable_pull = is_pull_action and not is_manual
+    # Reference actions are stateless: they never have stored config, and a
+    # caller sending no config_overrides (e.g. a zero-param query like
+    # list_tag_names) is a legitimate, complete request — not a 404. Required
+    # query params still fail Pydantic validation below with a 422, which is
+    # the correct signal to the portal.
+    is_reference_action = isinstance(config_model, type) and issubclass(
+        config_model, ReferenceActionConfiguration
+    )
 
     # Get the configuration needed to execute the action
     action_config = await config_manager.get_action_configuration(integration_id, action_id)
-    if not action_config and not config_overrides:
+    if not action_config and not config_overrides and not is_reference_action:
         if skippable_pull:
             return _skip_quietly(
                 integration_id, action_id,
@@ -283,6 +291,17 @@ async def execute_action(
         except pydantic.ValidationError as e:
             return await _handle_error(e, integration_id, action_id, data, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
+    # Reference actions are portal-invoked at interactive-fetch frequency (e.g.
+    # every dropdown open), so a handler failure is routine rather than
+    # exceptional (an unknown tag after a rename, a transient 5xx from the
+    # third-party API). Unlike other action types, their errors must not carry
+    # the integration's stored configurations — which include raw auth
+    # secrets (e.g. a bearer token) — into the published IntegrationActionFailed
+    # event or the JSON error response.
+    handler_error_config_data = None if is_reference_action else {
+        "configurations": [c.dict() for c in integration.configurations]
+    }
+
     try:  # Execute the action handler with a timeout
         start_time = time.monotonic()
         handler_kwargs = {
@@ -301,13 +320,13 @@ async def execute_action(
         return await _handle_error(
             asyncio.TimeoutError(f"Action '{action_id}' timed out"),
             integration_id, action_id,
-            config_data={"configurations": [c.dict() for c in integration.configurations]},
+            config_data=handler_error_config_data,
             status_code=status.HTTP_504_GATEWAY_TIMEOUT,
             classify_heuristics=True,
         )
     except Exception as e:
         return await _handle_error(e, integration_id, action_id,
-                                   config_data={"configurations": [c.dict() for c in integration.configurations]},
+                                   config_data=handler_error_config_data,
                                    classify_heuristics=True)
 
     # Success. Log the execution time and return the result

--- a/app/services/core.py
+++ b/app/services/core.py
@@ -6,3 +6,4 @@ class ActionTypeEnum(str, Enum):
     PULL_DATA = "pull"
     PUSH_DATA = "push"
     GENERIC = "generic"
+    REFERENCE = "reference"

--- a/app/services/self_registration.py
+++ b/app/services/self_registration.py
@@ -12,8 +12,14 @@ from app.actions import (
     PushActionConfiguration,
     ExecutableActionMixin,
     InternalActionConfiguration,
+    ReferenceActionConfiguration,
 )
-from app.settings import INTEGRATION_TYPE_SLUG, INTEGRATION_TYPE_NAME, INTEGRATION_SERVICE_URL
+from app.settings import (
+    INTEGRATION_TYPE_SLUG,
+    INTEGRATION_TYPE_NAME,
+    INTEGRATION_SERVICE_URL,
+    REGISTER_REFERENCE_ACTIONS,
+)
 from .core import ActionTypeEnum
 from app.webhooks.core import get_webhook_handler, GenericJsonTransformConfig
 
@@ -48,10 +54,18 @@ async def register_integration_in_gundi(gundi_client, type_slug=None, type_name=
         if issubclass(config_model, InternalActionConfiguration):
             logger.info(f"Skipping internal action '{action_id}'.")
             continue  # Internal actions are not registered in Gundi
+        if issubclass(config_model, ReferenceActionConfiguration) and not REGISTER_REFERENCE_ACTIONS:
+            logger.info(
+                f"Skipping reference action '{action_id}' "
+                "(REGISTER_REFERENCE_ACTIONS is off until the platform supports the 'reference' type)."
+            )
+            continue
         action_name = getattr(func, "action_title", None) or action_id.replace("_", " ").title()
         action_schema = json.loads(config_model.schema_json())
         action_ui_schema = config_model.ui_schema()
-        if issubclass(config_model, AuthActionConfiguration):
+        if issubclass(config_model, ReferenceActionConfiguration):
+            action_type = ActionTypeEnum.REFERENCE.value
+        elif issubclass(config_model, AuthActionConfiguration):
             action_type = ActionTypeEnum.AUTHENTICATION.value
         elif issubclass(config_model, PullActionConfiguration):
             action_type = ActionTypeEnum.PULL_DATA.value

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -724,3 +724,119 @@ async def test_execute_action_handles_httpx_error_carrying_no_request(
     error_details = json.loads(response.body)["detail"]
     assert error_details["error"] == "Could not reach the provider — connection failed"
     assert error_details["error_type"] == "connectivity"
+
+
+@pytest.mark.asyncio
+async def test_execute_reference_action_with_no_stored_config_and_no_overrides(
+        mocker, mock_gundi_client_v2, mock_publish_event, mock_config_manager,
+        integration_v2_as_dict,
+):
+    """A stateless reference action with an all-optional query must execute
+    even when the integration stores no config for it and the caller sends
+    no config_overrides (previously a 404 'configuration missing')."""
+    from gundi_core.schemas.v2 import Integration
+    from app.actions.core import ReferenceActionConfiguration
+
+    class ListThingsQuery(ReferenceActionConfiguration):
+        parent: str = ""
+
+    captured = {}
+
+    async def action_list_things(integration, action_config: ListThingsQuery):
+        captured["config"] = action_config
+        return {"options": [{"value": "a"}]}
+
+    integration_no_config = Integration.parse_obj({**integration_v2_as_dict, "configurations": []})
+
+    mocker.patch(
+        "app.services.action_runner.action_handlers",
+        {"list_things": (action_list_things, ListThingsQuery, None)},
+    )
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mock_config_manager.get_integration_details.return_value = async_return(integration_no_config)
+    mock_config_manager.get_action_configuration.return_value = async_return(None)
+
+    result = await execute_action(
+        integration_id=str(integration_no_config.id),
+        action_id="list_things",
+    )
+
+    assert captured["config"].parent == ""
+    assert result == {"options": [{"value": "a"}]}
+
+
+@pytest.mark.asyncio
+async def test_execute_reference_action_handler_error_does_not_leak_config(
+        mocker, mock_gundi_client_v2, mock_publish_event, mock_config_manager,
+        integration_v2,
+):
+    """A reference action's handler failure (e.g. an unknown tag after a CMORE
+    rename, or a 5xx from CMORE) is routine at interactive-fetch frequency.
+    Unlike other action types, it must NOT attach the integration's stored
+    configurations (which include the raw auth token) to the published
+    IntegrationActionFailed event or the JSON error response."""
+    from app.actions.core import ReferenceActionConfiguration
+
+    class ListThingsQuery(ReferenceActionConfiguration):
+        parent: str = ""
+
+    async def action_list_things_boom(integration, action_config: ListThingsQuery):
+        raise ValueError("boom")
+
+    mocker.patch(
+        "app.services.action_runner.action_handlers",
+        {"list_things": (action_list_things_boom, ListThingsQuery, None)},
+    )
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mock_config_manager.get_action_configuration.return_value = async_return(None)
+
+    response = await execute_action(
+        integration_id=str(integration_v2.id),
+        action_id="list_things",
+    )
+
+    # The auth config in the shared integration_v2 fixture carries this token.
+    auth_token = "testtoken2a97022f21732461ee103a08fac8a35"
+
+    response_body = json.loads(response.body)
+    assert auth_token not in json.dumps(response_body)
+    assert "configurations" not in response_body["detail"]["config_data"]
+
+    failed_events = _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+    assert len(failed_events) == 1
+    assert auth_token not in failed_events[0].json()
+    assert not failed_events[0].payload.config_data.get("configurations")
+
+
+@pytest.mark.asyncio
+async def test_non_pull_non_reference_action_with_no_config_and_no_overrides_still_404s(
+        mocker, mock_gundi_client_v2, integration_v2, mock_config_manager,
+        mock_publish_event, mock_action_handlers,
+):
+    # Pins the three-way branch in execute_action: a plain (non-pull,
+    # non-reference) action with neither stored config nor config_overrides
+    # must still hit the strict "configuration missing" 404 path.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mock_config_manager.get_action_configuration.return_value = async_return(None)
+
+    response = api_client.post(
+        "/v1/actions/execute/",
+        json={
+            "integration_id": str(integration_v2.id),
+            "action_id": "pull_observations_by_date",
+        }
+    )
+
+    assert response.status_code == 404
+    mock_action_handler, _, _ = mock_action_handlers["pull_observations_by_date"]
+    assert not mock_action_handler.called

--- a/app/services/tests/test_self_registration.py
+++ b/app/services/tests/test_self_registration.py
@@ -769,6 +769,63 @@ def test_discover_actions_ignores_functions_without_action_config():
     assert list(handlers.keys()) == ["pull_observations"]
 
 
+def _mock_reference_action_handlers():
+    from app.actions.core import ReferenceActionConfiguration
+
+    class MockListThingsQuery(ReferenceActionConfiguration):
+        parent: str
+
+    async def action_list_things(integration, action_config: MockListThingsQuery):
+        return {"options": []}
+
+    return {"list_things": (action_list_things, MockListThingsQuery, None)}
+
+
+@pytest.mark.asyncio
+async def test_reference_actions_excluded_from_registration_by_default(
+    mocker,
+    mock_gundi_client_v2,
+    mock_get_webhook_handler_for_fixed_json_payload,
+):
+    mocker.patch("app.services.self_registration.INTEGRATION_TYPE_SLUG", "x_tracker")
+    mocker.patch(
+        "app.services.self_registration.action_handlers",
+        _mock_reference_action_handlers(),
+    )
+    mocker.patch(
+        "app.services.self_registration.get_webhook_handler",
+        mock_get_webhook_handler_for_fixed_json_payload,
+    )
+    await register_integration_in_gundi(gundi_client=mock_gundi_client_v2)
+    data = mock_gundi_client_v2.register_integration_type.call_args.args[0]
+    assert data["actions"] == []
+
+
+@pytest.mark.asyncio
+async def test_reference_actions_registered_with_reference_type_when_enabled(
+    mocker,
+    mock_gundi_client_v2,
+    mock_get_webhook_handler_for_fixed_json_payload,
+):
+    mocker.patch("app.services.self_registration.INTEGRATION_TYPE_SLUG", "x_tracker")
+    mocker.patch("app.services.self_registration.REGISTER_REFERENCE_ACTIONS", True)
+    mocker.patch(
+        "app.services.self_registration.action_handlers",
+        _mock_reference_action_handlers(),
+    )
+    mocker.patch(
+        "app.services.self_registration.get_webhook_handler",
+        mock_get_webhook_handler_for_fixed_json_payload,
+    )
+    await register_integration_in_gundi(gundi_client=mock_gundi_client_v2)
+    data = mock_gundi_client_v2.register_integration_type.call_args.args[0]
+    assert len(data["actions"]) == 1
+    action = data["actions"][0]
+    assert action["value"] == "list_things"
+    assert action["type"] == "reference"
+    assert action["is_periodic_action"] is False
+
+
 @pytest.mark.asyncio
 async def test_crontab_schedule_decorator(
         mocker, mock_publish_event, integration_v2, pull_observations_config

--- a/app/settings/integration.py
+++ b/app/settings/integration.py
@@ -5,3 +5,10 @@ from .base import env
 # The product name is one word — the slug-derived fallback in
 # self-registration would render "Earth Ranger".
 INTEGRATION_TYPE_NAME = env.str("INTEGRATION_TYPE_NAME", "EarthRanger")
+
+# Phase 0 of the reference-data design (docs/superpowers/specs/
+# 2026-07-31-reference-data-config-ui-design.md): reference actions are only
+# registered in Gundi once the platform accepts the "reference" action type.
+# Until then this stays off so self-registration never sends a type the API
+# would reject.
+REGISTER_REFERENCE_ACTIONS = env.bool("REGISTER_REFERENCE_ACTIONS", False)

--- a/docs/actions/index.md
+++ b/docs/actions/index.md
@@ -1,6 +1,6 @@
 # Actions
 
-The runner exposes four actions, all implemented in `app/actions/handlers.py` as `action_*` functions
+The runner exposes seven actions, all implemented in `app/actions/handlers.py` as `action_*` functions
 with a matching config model in `app/actions/configurations.py`.
 
 | Action | Type | Purpose |
@@ -9,9 +9,11 @@ with a matching config model in `app/actions/configurations.py`.
 | [`pull_events`](pull-events.md) | pull | ER events + note/field updates → Gundi events & event updates. |
 | [`pull_observations`](pull-observations.md) | pull | ER subject tracking → Gundi observations. |
 | [`show_permissions`](show-permissions.md) | generic / diagnostic | Show what the account can access and the UUIDs the pull actions need. |
+| [`list_event_types`, `list_event_type_fields`, `list_event_field_values`](reference-actions.md) | reference | Config-time lookups for the Gundi portal's mapping forms. Disabled by default — see [`REGISTER_REFERENCE_ACTIONS`](../configuration.md#register_reference_actions). |
 
 **Typical setup order:** run `auth` to confirm credentials → run `show_permissions` to discover event-type
 / category slugs and subject-group UUIDs → configure and enable `pull_events` / `pull_observations` with
-those values.
+those values. The reference actions require no setup of their own — the portal calls them directly once
+`REGISTER_REFERENCE_ACTIONS` is enabled.
 
 See the [Configuration reference](../configuration.md) for every field of every model in one place.

--- a/docs/actions/index.md
+++ b/docs/actions/index.md
@@ -1,7 +1,9 @@
 # Actions
 
-The runner exposes seven actions, all implemented in `app/actions/handlers.py` as `action_*` functions
-with a matching config model in `app/actions/configurations.py`.
+The runner implements seven actions in `app/actions/handlers.py` as `action_*` functions
+with a matching config model in `app/actions/configurations.py`. Four self-register
+unconditionally; the three reference actions register only when
+[`REGISTER_REFERENCE_ACTIONS`](../configuration.md#register_reference_actions) is enabled.
 
 | Action | Type | Purpose |
 |--------|------|---------|

--- a/docs/actions/reference-actions.md
+++ b/docs/actions/reference-actions.md
@@ -8,7 +8,7 @@ populating an "Event Type" dropdown, or the values for a choice field on that ev
 
 | Action | Query model | Purpose |
 |--------|-------------|---------|
-| `list_event_types` | `ListEventTypesQuery` (no fields) | Every ER event-type slug visible to this integration's credentials, grouped by event category. |
+| `list_event_types` | `ListEventTypesQuery` (no fields) | Every **v2** ER event-type slug visible to this integration's credentials, grouped by event category. Classic v1 event types are not offered — see [Scope](#scope-v2-event-types-only). |
 | `list_event_type_fields` | `ListEventTypeFieldsQuery` (`event_type`) | The field keys defined on one event type's schema. |
 | `list_event_field_values` | `ListEventFieldValuesQuery` (`event_type`, `field_key`) | The allowed values for one choice field on that event type. |
 
@@ -24,13 +24,31 @@ resolve them from *this* runner — that's `target: "provider"` in the
 These three actions are what the portal calls to make that dropdown chain (event type → its fields → a
 field's values) work.
 
+## Scope: v2 event types only
+
+`list_event_types` offers only **v2**-sourced event types. ER's v2 pre-rendered schema endpoint (the one
+`list_event_type_fields` / `list_event_field_values` depend on) 404s for classic v1 event types — offering
+a v1 slug here would dead-end the dropdown cascade one step later, with a "not supported" error where an
+operator would expect a list of fields. Rather than offer a type that can't be followed, `list_event_types`
+excludes v1 slugs entirely.
+
+This doesn't block an operator from referencing a v1 event type in a mapping — the `gundi:reference`
+widget contract degrades to a plain free-text input whenever the reference fetch has nothing to offer (or
+fails), so a v1 `event_type` / `event_details` key can still be typed in by hand; it just doesn't get
+autocomplete. No further integration-side work is planned for v1 — this is the intended long-term shape,
+not an interim gap to close later.
+
 ## How they're implemented
 
 - `list_event_types` reuses the same `_fetch_event_type_maps` helper `pull_events` uses to resolve
-  operator-configured slugs (queries ER's v1 and v2 event-type endpoints and merges the results, falling
-  back to the categories endpoint for any category display name neither version's response carried).
-  Options are grouped by category display name (or ungrouped, if no display name could be resolved) and
-  sorted by group then label.
+  operator-configured slugs (queries ER's v1 and v2 event-type endpoints and merges the results), but
+  narrows the result to `EventTypeMaps.v2_slugs` before building options. Category display names can come
+  from either version's response; unlike `_fetch_event_type_maps`'s own categories-endpoint fallback (which
+  only fires when v1 didn't already resolve category UUIDs — tuned for `pull_events`' filter-resolution
+  need), `list_event_types` always fetches `get_event_categories` itself, so a v2-only category's display
+  name resolves even when a v1 type elsewhere already satisfied that fallback's trigger condition. Options
+  are grouped by category display name (or ungrouped, if no display name could be resolved) and sorted by
+  group then label.
 - `list_event_type_fields` and `list_event_field_values` both fetch ER's pre-rendered event-type schema
   (`/api/v2.0/activity/eventtypes/{event_type}/schema?pre_render=true&s_format=enum` — not modeled by
   `erclient`, so called directly with the client's own auth headers) and parse it with
@@ -42,7 +60,9 @@ field's values) work.
 
 - Unknown `event_type` or `field_key` → the handler raises `ValueError`, which the runner turns into an
   error response (never a leaked config, per the reference-action error carve-out — see
-  [Configuration reference](../configuration.md#register_reference_actions)).
+  [Configuration reference](../configuration.md#register_reference_actions)). A classic v1 `event_type`
+  passed to `list_event_type_fields` / `list_event_field_values` surfaces the same way (ER's 404), with
+  wording that calls out the v1/v2 distinction rather than implying the slug is simply unknown.
 - Any other upstream ER failure (e.g. a 5xx) propagates unchanged.
 
 ## Registration is gated

--- a/docs/actions/reference-actions.md
+++ b/docs/actions/reference-actions.md
@@ -1,0 +1,52 @@
+# Reference actions
+
+Three config-time lookups the Gundi portal calls while an operator is filling out a form — e.g.
+populating an "Event Type" dropdown, or the values for a choice field on that event type. They are
+**not** scheduled and have no configuration of their own: the caller supplies query params per-call via
+`config_overrides`, and each returns a `ReferenceDataResponse` (an `options` list plus a
+`cache_ttl_seconds` cache hint) rather than performing any side effect.
+
+| Action | Query model | Purpose |
+|--------|-------------|---------|
+| `list_event_types` | `ListEventTypesQuery` (no fields) | Every ER event-type slug visible to this integration's credentials, grouped by event category. |
+| `list_event_type_fields` | `ListEventTypeFieldsQuery` (`event_type`) | The field keys defined on one event type's schema. |
+| `list_event_field_values` | `ListEventFieldValuesQuery` (`event_type`, `field_key`) | The allowed values for one choice field on that event type. |
+
+`action_list_event_types` / `action_list_event_type_fields` / `action_list_event_field_values` —
+`app/actions/handlers.py`.
+
+## Why these exist
+
+CMORE's mapping form lets an operator pick an ER event type and one of its fields (e.g. `animal_sex`) to
+map onto a CMORE tag field. Those are source-side (ER) values, so the CMORE runner's config form needs to
+resolve them from *this* runner — that's `target: "provider"` in the
+[reference-data design](https://github.com/PADAS/gundi-integration-cmore/blob/main/docs/rfc-reference-data-portal-support.md).
+These three actions are what the portal calls to make that dropdown chain (event type → its fields → a
+field's values) work.
+
+## How they're implemented
+
+- `list_event_types` reuses the same `_fetch_event_type_maps` helper `pull_events` uses to resolve
+  operator-configured slugs (queries ER's v1 and v2 event-type endpoints and merges the results, falling
+  back to the categories endpoint for any category display name neither version's response carried).
+  Options are grouped by category display name (or ungrouped, if no display name could be resolved) and
+  sorted by group then label.
+- `list_event_type_fields` and `list_event_field_values` both fetch ER's pre-rendered event-type schema
+  (`/api/v2.0/activity/eventtypes/{event_type}/schema?pre_render=true&s_format=enum` — not modeled by
+  `erclient`, so called directly with the client's own auth headers) and parse it with
+  `app/actions/er_schema.py`. A choice field's `description` is set to `"choices"` so the caller can tell
+  which fields have a fixed value set; free-text fields return no choices for `list_event_field_values`
+  (an empty `options` list, not an error — the field is legitimately free text in ER).
+
+## Error semantics
+
+- Unknown `event_type` or `field_key` → the handler raises `ValueError`, which the runner turns into an
+  error response (never a leaked config, per the reference-action error carve-out — see
+  [Configuration reference](../configuration.md#register_reference_actions)).
+- Any other upstream ER failure (e.g. a 5xx) propagates unchanged.
+
+## Registration is gated
+
+These actions register with `"type": "reference"`, a type the Gundi API doesn't accept yet. They stay out
+of self-registration entirely until `REGISTER_REFERENCE_ACTIONS` is turned on — see
+[Configuration reference](../configuration.md#register_reference_actions).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,3 +51,29 @@ The ER **base URL** comes from the integration record, not this config.
     pulling is opt-in per connection.
 
 See [State & scheduling](state-and-scheduling.md) for watermark, backfill, and scheduling semantics.
+
+## `ListEventTypesQuery` / `ListEventTypeFieldsQuery` / `ListEventFieldValuesQuery` — reference actions
+
+| Model | Field | Type | Notes |
+|-------|-------|------|-------|
+| `ListEventTypesQuery` | — | — | No fields; lists every event type visible to this integration's credentials. |
+| `ListEventTypeFieldsQuery` | `event_type` | string | ER event-type slug (e.g. `rhino_carcass`). Unknown slug → error. |
+| `ListEventFieldValuesQuery` | `event_type` | string | Same as above. |
+| `ListEventFieldValuesQuery` | `field_key` | string | Field key from that event type's schema. Unknown key → error. |
+
+These are stateless config-time lookups, not scheduled actions — see [Reference actions](actions/reference-actions.md)
+for what they return and how the portal uses them.
+
+## Environment variables
+
+### `REGISTER_REFERENCE_ACTIONS`
+
+Default: `False`.
+
+Gates whether `list_event_types`, `list_event_type_fields`, and `list_event_field_values` are included
+when this runner self-registers with Gundi. They would register with `"type": "reference"`, a type the
+Gundi API doesn't accept yet — flipping this on before the platform side
+([PADAS/cdip#461](https://github.com/PADAS/cdip/pull/461)) is merged **and** deployed would 400 the
+whole registration call, not just these three actions. Leave it off in every environment until that lands;
+flip it on afterward to expose the actions (mirrors CMORE's identically-named, identically-gated flag from
+its own Phase 0 reference-actions work).

--- a/docs/superpowers/plans/2026-08-11-er-reference-actions.md
+++ b/docs/superpowers/plans/2026-08-11-er-reference-actions.md
@@ -10,7 +10,7 @@
 
 ## Global Constraints
 
-- The framework port (Task 1) must be a faithful copy of CMORE's diff — do not redesign. Source files: `/Users/chrisdo/padas/gundi-integration-cmore/app/actions/core.py:64-87` (+`List` import), `app/services/core.py:9`, `app/services/self_registration.py:15,21,57-62,66-67`, `app/services/action_runner.py:19,242-244,248,294-304,323,329`, `app/settings/integration.py:14-19`.
+- The framework port (Task 1) must be a faithful copy of CMORE's diff — do not redesign. Source files: `gundi-integration-cmore/app/actions/core.py:64-87` (+`List` import), `app/services/core.py:9`, `app/services/self_registration.py:15,21,57-62,66-67`, `app/services/action_runner.py:19,242-244,248,294-304,323,329`, `app/settings/integration.py:14-19`.
 - `REGISTER_REFERENCE_ACTIONS` defaults **False** (the Gundi API PR PADAS/cdip#461 is not merged/deployed yet; registering `"reference"` before it lands would 400 the whole registration).
 - Reference handlers are stateless: read only the integration's `auth` config (via the existing `get_authentication_config(integration)` at `app/actions/handlers.py:1119-1129`), take query params from `config_overrides` via their Pydantic query model, return `ReferenceDataResponse(...).dict()`.
 - Handler errors: unknown event_type/field → raise `ValueError` (matches CMORE; the runner scrubs configs from reference-action error payloads per the ported carve-out).

--- a/docs/superpowers/plans/2026-08-11-er-reference-actions.md
+++ b/docs/superpowers/plans/2026-08-11-er-reference-actions.md
@@ -1,0 +1,116 @@
+# ER Provider Reference Actions Implementation Plan (Phase 2)
+
+> **For agentic workers:** execute task-by-task with a review after each task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The EarthRanger runner exposes three provider-side reference actions — `list_event_types`, `list_event_type_fields(event_type)`, `list_event_field_values(event_type, field_key)` — per the reference-data RFC (`gundi-integration-cmore/docs/rfc-reference-data-portal-support.md`, Phase 2) and design doc §4 (`gundi-integration-cmore/docs/superpowers/specs/2026-07-31-reference-data-config-ui-design.md`), gated behind a default-off `REGISTER_REFERENCE_ACTIONS` env flag exactly like CMORE's Phase 0.
+
+**Architecture:** Two parts. (1) A verbatim port of CMORE Phase 0's framework support — the two repos' template files are byte-identical apart from that diff: `ReferenceActionConfiguration`/`ReferenceOption`/`ReferenceDataResponse` marker+envelope in `app/actions/core.py`, `REFERENCE` in `app/services/core.py`'s `ActionTypeEnum`, the registration gate + type branch in `app/services/self_registration.py`, and the 404-exemption + secret-scrubbing carve-outs in `app/services/action_runner.py`, plus the settings flag. (2) ER-specific handlers: `list_event_types` uses `AsyncERClient.get_event_types`/`get_event_categories` (the `_fetch_event_type_maps` pattern already in handlers.py); the two schema-driven actions fetch ER's pre-rendered v2 schema endpoint (`/api/v2.0/activity/eventtypes/{event_type}/schema?pre_render=true&s_format=enum` — not exposed by erclient, so a raw httpx GET authenticated via `await er_client.auth_headers()`) and parse it with a ported copy of CMORE's `parse_er_event_schema`.
+
+**Tech Stack:** Python 3.10, FastAPI action-runner template, erclient (AsyncERClient), httpx, pytest (+pytest-asyncio, pytest-mock). Test command from repo root: `.venv/bin/pytest` (baseline to record at start).
+
+## Global Constraints
+
+- The framework port (Task 1) must be a faithful copy of CMORE's diff — do not redesign. Source files: `/Users/chrisdo/padas/gundi-integration-cmore/app/actions/core.py:64-87` (+`List` import), `app/services/core.py:9`, `app/services/self_registration.py:15,21,57-62,66-67`, `app/services/action_runner.py:19,242-244,248,294-304,323,329`, `app/settings/integration.py:14-19`.
+- `REGISTER_REFERENCE_ACTIONS` defaults **False** (the Gundi API PR PADAS/cdip#461 is not merged/deployed yet; registering `"reference"` before it lands would 400 the whole registration).
+- Reference handlers are stateless: read only the integration's `auth` config (via the existing `get_authentication_config(integration)` at `app/actions/handlers.py:1119-1129`), take query params from `config_overrides` via their Pydantic query model, return `ReferenceDataResponse(...).dict()`.
+- Handler errors: unknown event_type/field → raise `ValueError` (matches CMORE; the runner scrubs configs from reference-action error payloads per the ported carve-out).
+- Options envelope semantics: `value` is what gets stored in downstream config (event-type **slug**, field **key**, choice **value**); `label` is the human display name.
+- Follow ER handler conventions: `AsyncERClient` built per-handler from `urlparse(integration.base_url)` exactly like `action_show_permissions` (`handlers.py:308-316`); `DEFAULT_CONNECT_TIMEOUT_SECONDS` for connect timeout.
+
+## Key verified facts
+
+- ER's `self_registration.py`/`action_runner.py`/`actions/core.py`/`services/core.py` are byte-identical to CMORE's minus the Phase 0 diff (verified file-by-file). `app/settings/integration.py` differs structurally — add only the flag lines.
+- erclient: `get_event_types(include_inactive=False, include_schema=False, version=...)` (client.py:1610; v1 path `activity/events/eventtypes`, v2 `activity/eventtypes`), `get_event_categories()` (:1625), `get_event_type(name, version, include_schema)` (:1648). `VERSION_1_0`/`VERSION_2_0` already imported in ER handlers.py:13. The async client has `auth_headers()` (used by `get_file`) — returns the Authorization header dict, handling both token and username/password auth.
+- The pre-rendered schema endpoint (inlines each choice field's enum + `x-enumExtra` so no separate choices fetch is needed) is only reachable via raw httpx — mirror `gundi-integration-cmore/app/datasource/cli.py:598-608`.
+- Parser to port: `gundi-integration-cmore/app/datasource/er_schema.py` — `ERField` (key/title/choices/choices_ref/choice_list), `ERChoice(value, display)`, `parse_er_event_schema(raw) -> List[ERField]`, `_inline_choices`. Port as `app/actions/er_schema.py` in the ER repo (module docstring crediting the origin); drop the parts only the CLI needs (`parse_choices_json`, `choices_ref` external resolution) ONLY if the pre-rendered endpoint truly inlines everything — verify against the fixture first and keep them if any fixture field uses refs.
+- Test fixture source: `gundi-integration-cmore/docs/rhino_carcass_schema_from_api.json` is a REAL captured response from the pre-rendered endpoint — copy it into the ER repo's test fixtures (`app/actions/tests/fixtures/`).
+- CMORE tests to port/adapt: `app/services/tests/test_self_registration.py:766-829` (gate off/on + type assertion), `app/services/tests/test_action_runner.py:730-830` (zero-param no-404, error-no-config-leak, ordinary-action-still-404s). ER's equivalents live in `app/services/tests/` with the same fixtures (verify names; the repos' conftest.py for services tests should match).
+
+## File structure
+
+| File | Change |
+|---|---|
+| `app/actions/core.py` | Port marker + envelope models |
+| `app/services/core.py` | Port `REFERENCE` enum member |
+| `app/services/self_registration.py` | Port gate + type branch |
+| `app/services/action_runner.py` | Port 404-exemption + secret-scrub carve-outs |
+| `app/settings/integration.py` | Add `REGISTER_REFERENCE_ACTIONS = env.bool(..., False)` (+env import if absent) |
+| `app/actions/er_schema.py` | Create — ported schema parser |
+| `app/actions/configurations.py` | Add 3 query models |
+| `app/actions/handlers.py` | Add 3 handlers + schema-fetch helper |
+| `app/actions/tests/fixtures/rhino_carcass_schema_from_api.json` | Copy fixture |
+| `app/actions/tests/test_reference_actions.py` | Create — handler tests |
+| `app/services/tests/test_self_registration.py`, `test_action_runner.py` | Port reference-action test groups |
+| `docs/actions/` + `docs/configuration.md` | Document the actions + flag |
+
+---
+
+### Task 1: framework port (verbatim) + registration/runner tests
+
+- [ ] Copy each CMORE hunk listed in Global Constraints into the ER twins — after each file, `diff` it against the CMORE version to confirm the only remaining differences are pre-existing/unrelated ones (state.py-style divergences are listed in the scout notes; these four files should end up byte-identical or explainably close).
+- [ ] `app/settings/integration.py`: append the flag block (mirroring CMORE lines 14-19, including the comment about staying off until the platform supports the type). Verify `from app import settings; settings.REGISTER_REFERENCE_ACTIONS` imports.
+- [ ] Port the CMORE test groups (self_registration gate off/on; action_runner zero-param no-404 / error-no-config-leak / ordinary-action-404 guard), adapting fixture names to ER's test files. TDD order: tests first (fail on missing imports), then the port.
+- [ ] Full suite green. Commit: `feat: framework support for reference actions (ported from CMORE Phase 0)`.
+
+### Task 2: ER schema module + fixture
+
+- [ ] Copy `rhino_carcass_schema_from_api.json` into `app/actions/tests/fixtures/`.
+- [ ] Create `app/actions/er_schema.py` ported from CMORE's `app/datasource/er_schema.py` (keep `ERField`/`ERChoice`/`parse_er_event_schema`/`_inline_choices`; decide on ref-resolution parts per the fixture). Add:
+
+```python
+async def fetch_prerendered_event_schema(er_client, base_url: str, event_type: str) -> dict:
+    """GET the v2 pre-rendered event-type schema (pre_render + s_format=enum inline
+    each choice field's values, so no separate choices fetch is needed). erclient
+    doesn't model this /schema sub-resource, so we call it directly with the
+    client's own auth headers (works for both token and username/password auth)."""
+    url_parse = urlparse(base_url)
+    url = f"{url_parse.scheme}://{url_parse.hostname}/api/v2.0/activity/eventtypes/{quote(event_type, safe='')}/schema"
+    headers = await er_client.auth_headers()
+    async with httpx.AsyncClient(headers=headers, timeout=30.0) as http:
+        resp = await http.get(url, params={"pre_render": "true", "s_format": "enum"})
+        resp.raise_for_status()
+        return resp.json()
+```
+
+- [ ] Unit tests (`test_reference_actions.py` or a dedicated `test_er_schema.py`): `parse_er_event_schema` against the fixture (assert known rhino_carcass fields + inlined choices); `fetch_prerendered_event_schema` with mocked `auth_headers` + `respx`/mocked httpx asserting URL, params, and auth header propagation; a 404 from ER surfaces as `httpx.HTTPStatusError`.
+- [ ] Full suite green. Commit: `feat: ER pre-rendered event-schema fetch + parser for reference actions`.
+
+### Task 3: query models, handlers, docs
+
+- [ ] `app/actions/configurations.py` — three models (mirror CMORE's style; `ReferenceActionConfiguration` import from `.core`):
+
+```python
+class ListEventTypesQuery(ReferenceActionConfiguration):
+    """List the ER event types visible to this integration's credentials."""
+
+
+class ListEventTypeFieldsQuery(ReferenceActionConfiguration):
+    event_type: str
+
+
+class ListEventFieldValuesQuery(ReferenceActionConfiguration):
+    event_type: str
+    field_key: str
+```
+
+- [ ] `app/actions/handlers.py` — three handlers using `get_authentication_config` + the standard `AsyncERClient` construction:
+  - `action_list_event_types`: reuse the `_fetch_event_type_maps` approach (v2 first, v1 fallback, categories for grouping): options = `ReferenceOption(value=<slug>, label=<display>, group=<category display or None>)`; sort by group then label; `truncated=False`.
+  - `action_list_event_type_fields`: `fetch_prerendered_event_schema` → `parse_er_event_schema` → options = `ReferenceOption(value=field.key, label=field.title or field.key, description=("choices" if field.is_enum else None))`. Unknown event_type (HTTP 404 from ER) → `raise ValueError(f"Event type '{...}' not found in EarthRanger.")`.
+  - `action_list_event_field_values`: same fetch/parse, locate the field by key (`ValueError` if absent), options = its choices as `ReferenceOption(value=choice.value, label=choice.display)`; non-enum field → empty options (matches CMORE's `list_field_options` non-lookup behavior).
+- [ ] Handler tests in `test_reference_actions.py` (mock AsyncERClient + the fetch helper; use the fixture): happy paths for all three; grouping in `list_event_types`; unknown event_type → ValueError; unknown field_key → ValueError; non-enum field → empty options; upstream HTTP 500 propagates.
+- [ ] Docs: add a "Reference actions" section to the actions docs + the `REGISTER_REFERENCE_ACTIONS` row in `docs/configuration.md` (mirroring the CMORE wording; note default-off until PADAS/cdip#461 is deployed).
+- [ ] Full suite green. Commit: `feat: reference actions — list_event_types, list_event_type_fields, list_event_field_values`.
+
+### Task 4: rollout checklist (manual)
+
+- [ ] Keep `REGISTER_REFERENCE_ACTIONS=false` everywhere until PADAS/cdip#461 is merged AND deployed to the target environment.
+- [ ] Then flip it on the dev ER runner, confirm registration succeeds and the three actions appear with `"type": "reference"`, and smoke-test via `POST /v1/actions/execute` against dev ER.
+- [ ] Phase 2 completion (separate change, CMORE repo): flip CMORE's `event_type`/`event_details_key` annotations to `target: "provider"` once the portal supports provider-target resolution.
+
+---
+
+## Self-Review
+
+- RFC Phase 2 asks → Tasks 2-3 (the three actions); parity with Phase 0's platform-safety behavior (gate, 404-exemption, no-secret-leak) → Task 1; rollout ordering vs cdip#461 → Task 4 and the default-off constraint.
+- Names consistent: `fetch_prerendered_event_schema`/`parse_er_event_schema` (T2) consumed in T3; query models' fields (`event_type`, `field_key`) match the design doc §4 signature `list_event_field_values(event_type, field_key)`.
+- Deliberate scope cuts: no external choices-ref resolution unless the fixture demands it; no erclient upstream PR (raw httpx documented as the reason); `target:"provider"` annotation flips stay out (separate CMORE change).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - pull_events: actions/pull-events.md
       - pull_observations: actions/pull-observations.md
       - show_permissions: actions/show-permissions.md
+      - Reference actions: actions/reference-actions.md
   - Data flow: data-flow.md
   - State & scheduling: state-and-scheduling.md
   - Configuration reference: configuration.md


### PR DESCRIPTION
## Summary
Phase 2 of the reference-data RFC (`gundi-integration-cmore/docs/rfc-reference-data-portal-support.md`): the ER runner exposes three stateless reference actions so downstream destinations' config forms (e.g. the CMORE ER→CMORE mapping form) can offer live dropdowns of source-side vocabulary via `target: "provider"` annotations.

- **Framework support** ported verbatim from CMORE Phase 0 (four files land byte-identical): `ReferenceActionConfiguration` marker + `ReferenceOption`/`ReferenceDataResponse` envelope, `"reference"` action type, registration gated behind default-off `REGISTER_REFERENCE_ACTIONS`, and the action-runner carve-outs (zero-param reference calls aren't 404'd; reference-action errors never attach integration configs/secrets).
- **`app/actions/er_schema.py`**: parser ported from the CMORE CLI (`parse_er_event_schema`) + `fetch_prerendered_event_schema` — a raw httpx GET to ER's v2 `.../eventtypes/{type}/schema?pre_render=true&s_format=enum` (not modeled by erclient), authenticated via `er_client.auth_headers()` so both token and username/password auth work. Tested against a real captured rhino_carcass schema.
- **Three handlers**: `list_event_types` (v2 event types, grouped by category display), `list_event_type_fields(event_type)`, `list_event_field_values(event_type, field_key)` (non-enum fields → empty options; unknown type/field → clean errors without secrets).

## Scope: v2 event types only
Classic v1 event types are **not offered** by `list_event_types` (the v2 schema endpoint they'd need 404s for them, which would dead-end the type→fields→values cascade). Operators can still enter v1 slugs manually — the portal widget's free-text contract means those fields simply degrade to today's plain-input experience. `EventTypeMaps` tracks version provenance additively; `pull_events`/`pull_observations` still see the merged v1+v2 maps unchanged. Group displays now resolve via an unconditional categories fetch scoped to the reference handler.

## Rollout
`REGISTER_REFERENCE_ACTIONS` stays **off** until PADAS/cdip#461 is deployed (registering `"reference"` earlier 400s the whole registration). Then flip on the dev runner, verify the three actions register with `"type": "reference"`, and smoke-test via `/v1/actions/execute` against dev ER — confirming v1 types are absent from `list_event_types` and a v2 type's full cascade works.

## Follow-ups (non-blocking)
- Add `respx` to `requirements-dev.in` (currently only a transitive pin via gundi-client-v2).

## Test plan
- [x] 265 passed (baseline 241 + 24 new: framework port, schema module, handlers, v2-only scope)

Related: PADAS/cdip#461 (platform), PADAS/gundi-portal#340 (widget), PADAS/gundi-integration-cmore#25 (Phase 0 pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)