### PR TITLE
ci: pin pip<26 for pip-tools compatibility

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -15,8 +15,13 @@ jobs:
         run: python -m ensurepip --upgrade
       - name: Install pip tools
         # typing_extensions listed explicitly: pip-tools 7.6.0 imports it on
-        # Python 3.10 without declaring it as a dependency
-        run: pip install pip-tools typing_extensions
+        # Python 3.10 without declaring it as a dependency.
+        # pip pinned <26: pip-tools 7.6.0 (latest as of 2026-08) calls pip
+        # internals that changed in pip 26 (make_requirement_preparer grew a
+        # required allow_editables kwarg) — the 2026-08-10 runner image ships
+        # pip 26, crashing pip-compile before tests run. Unpin once pip-tools
+        # releases pip-26 support.
+        run: pip install "pip<26" pip-tools typing_extensions
       - name: Install compile dependencies
         run: pip-compile --output-file=requirements.txt requirements-base.in requirements-dev.in requirements.in
       - name: Install dependencies


### PR DESCRIPTION
## Summary
Main's CI went red on the PR #40 merge commit — but the failure is environmental, not from that change: the unit-test job crashes inside `pip-compile` before any test runs.

- The 2026-08-10 GitHub runner image ships **pip 26**, whose internal `make_requirement_preparer` API grew a required `allow_editables` kwarg.
- `pip-tools` 7.6.0 (the latest release — no pip-26-compatible version exists yet) calls that API without it → `TypeError`.
- Reproduced locally (pip 26.2.1 + pip-tools 7.6.0 → identical TypeError) and verified the fix (pip 25.3 → clean compile).

One-line fix: pin `pip<26` in the pip-tools install step, with a comment explaining when to unpin.

Note: `gundi-integration-cmore` and `gundi-integration-action-runner` (the template) share this workflow verbatim and will fail the same way on their next CI run — companion PRs to follow.

## Test plan
- [x] Local repro + fix verification (above)
- [ ] This PR's own CI run is the real proof — the unit-test job should get past pip-compile and run the 268-test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)