### PR TITLE
Reference dropdowns for pull_events event_types / event_categories

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -327,9 +327,40 @@ class PullEventsConfig(PullActionConfiguration):
         order=["start_datetime", "end_datetime", "filter_date_field", "event_types", "event_categories", "force_run_since_start", "include_attachments", "run_on_schedule"],
     )
 
+    @classmethod
+    def ui_schema(cls, *args, **kwargs):
+        """Annotate the slug-list fields with gundi:reference so the portal
+        renders each list item as a live dropdown fed by this integration's
+        own reference actions (target "self" — the form being configured IS
+        the ER integration that can answer). Deliberately no ui:widget:
+        portals without reference support keep plain text inputs. The
+        annotation sits on the array's ``items`` node so rjsf applies it to
+        every element. Spec: gundi-integration-cmore
+        docs/superpowers/specs/2026-07-31-reference-data-config-ui-design.md.
+        """
+        base = super().ui_schema(*args, **kwargs)
+        base["event_types"] = {"items": {"gundi:reference": _reference("list_event_types")}}
+        base["event_categories"] = {"items": {"gundi:reference": _reference("list_event_categories")}}
+        return base
+
+
+def _reference(action: str, params: Optional[dict] = None) -> dict:
+    """Build a gundi:reference ui_schema annotation (mirrors the helper in
+    gundi-integration-cmore's configurations.py; ER only needs target "self")."""
+    return {
+        "action": action,
+        "target": "self",
+        "params": params or {},
+        "allow_free_text": True,
+    }
+
 
 class ListEventTypesQuery(ReferenceActionConfiguration):
     """List the ER event types visible to this integration's credentials."""
+
+
+class ListEventCategoriesQuery(ReferenceActionConfiguration):
+    """List the ER event categories visible to this integration's credentials."""
 
 
 class ListEventTypeFieldsQuery(ReferenceActionConfiguration):

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -335,8 +335,8 @@ class PullEventsConfig(PullActionConfiguration):
         the ER integration that can answer). Deliberately no ui:widget:
         portals without reference support keep plain text inputs. The
         annotation sits on the array's ``items`` node so rjsf applies it to
-        every element. Spec: gundi-integration-cmore
-        docs/superpowers/specs/2026-07-31-reference-data-config-ui-design.md.
+        every element. Spec:
+        https://github.com/PADAS/gundi-integration-cmore/blob/main/docs/superpowers/specs/2026-07-31-reference-data-config-ui-design.md
         """
         base = super().ui_schema(*args, **kwargs)
         base["event_types"] = {"items": {"gundi:reference": _reference("list_event_types")}}

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -22,7 +22,7 @@ from .core import ReferenceDataResponse, ReferenceOption
 from .er_schema import fetch_prerendered_event_schema, parse_er_event_schema
 from .configurations import AuthenticateConfig, EventFilterDateField, PullObservationsConfig, PullEventsConfig, \
     ERAuthenticationType, ShowPermissionsConfig, ListEventTypesQuery, ListEventTypeFieldsQuery, \
-    ListEventFieldValuesQuery
+    ListEventFieldValuesQuery, ListEventCategoriesQuery
 from .source_profiles import SourceProfileResolver
 from ..services.activity_logger import activity_logger, log_action_activity
 from ..services.gundi import send_events_to_gundi, send_observations_to_gundi, update_event_in_gundi, send_event_attachments_to_gundi
@@ -1529,6 +1529,25 @@ async def _fetch_event_type_fields(er_client, base_url: str, event_type: str):
         raise
     return parse_er_event_schema(raw_schema)
 
+
+async def action_list_event_categories(integration: Integration, action_config: ListEventCategoriesQuery):
+    """Reference action: ER event categories visible to this integration's credentials.
+
+    Unlike `_fetch_category_display_map` (best-effort enrichment for
+    list_event_types' grouping), this fetch is load-bearing — errors
+    propagate so the portal shows its "couldn't load options" degrade
+    instead of silently offering an empty list.
+    """
+    async with _build_er_client(integration) as earth_ranger:
+        categories = await earth_ranger.get_event_categories()
+
+    options = [
+        ReferenceOption(value=cat["value"], label=cat.get("display") or cat["value"])
+        for cat in _as_list(categories)
+        if isinstance(cat, dict) and cat.get("value")
+    ]
+    options.sort(key=lambda o: o.label or o.value)
+    return ReferenceDataResponse(options=options, truncated=False).dict()
 
 async def action_list_event_type_fields(integration: Integration, action_config: ListEventTypeFieldsQuery):
     """Reference action: field keys defined on one ER event type's schema."""

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -342,3 +342,63 @@ async def test_reference_action_with_schemeless_base_url_raises_clean_error(
     mocker.patch.object(er_integration_v2_provider, "base_url", "gundi-er.pamdas.org")
     with pytest.raises(ValueError, match="Site URL is empty or invalid: 'gundi-er.pamdas.org'"):
         await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
+
+
+# --- action_list_event_categories ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_event_categories_returns_sorted_options(mock_er_client, er_integration_v2_provider):
+    from app.actions.handlers import action_list_event_categories
+    from app.actions.configurations import ListEventCategoriesQuery
+
+    mock_er_client.get_event_categories = AsyncMock(return_value=[
+        {"value": "security", "display": "Security"},
+        {"value": "monitoring", "display": "Monitoring"},
+        {"value": "no_display"},
+        "not-a-dict",
+    ])
+    result = await action_list_event_categories(er_integration_v2_provider, ListEventCategoriesQuery())
+    # Case-sensitive label sort, matching list_event_types' convention.
+    assert [(o["value"], o["label"]) for o in result["options"]] == [
+        ("monitoring", "Monitoring"),
+        ("security", "Security"),
+        ("no_display", "no_display"),
+    ]
+    assert result["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_event_categories_upstream_error_propagates(mock_er_client, er_integration_v2_provider):
+    from app.actions.handlers import action_list_event_categories
+    from app.actions.configurations import ListEventCategoriesQuery
+
+    mock_er_client.get_event_categories = AsyncMock(side_effect=httpx.HTTPStatusError(
+        "boom", request=MagicMock(), response=MagicMock(status_code=500)
+    ))
+    with pytest.raises(httpx.HTTPStatusError):
+        await action_list_event_categories(er_integration_v2_provider, ListEventCategoriesQuery())
+
+
+# --- PullEventsConfig ui_schema annotations ------------------------------------
+
+
+def test_pull_events_ui_schema_annotates_slug_lists_with_references():
+    """The slug-list fields render as reference dropdowns (per array item),
+    without ever setting ui:widget (forward-compat with older portals)."""
+    from app.actions.configurations import PullEventsConfig
+
+    ui = PullEventsConfig.ui_schema()
+    for field, action in (("event_types", "list_event_types"),
+                          ("event_categories", "list_event_categories")):
+        node = ui[field]["items"]
+        ref = node["gundi:reference"]
+        assert ref == {
+            "action": action,
+            "target": "self",
+            "params": {},
+            "allow_free_text": True,
+        }
+        assert "ui:widget" not in node
+    # The generated order list is untouched.
+    assert "event_types" in ui["ui:order"] and "event_categories" in ui["ui:order"]

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -369,6 +369,26 @@ async def test_list_event_categories_returns_sorted_options(mock_er_client, er_i
 
 
 @pytest.mark.asyncio
+async def test_list_event_categories_unwraps_paginated_envelope(mock_er_client, er_integration_v2_provider):
+    """ER can return the categories list wrapped in a paginated envelope
+    ({"results": [...]}); the handler normalizes via _as_list."""
+    from app.actions.handlers import action_list_event_categories
+    from app.actions.configurations import ListEventCategoriesQuery
+
+    mock_er_client.get_event_categories = AsyncMock(return_value={
+        "results": [
+            {"value": "security", "display": "Security"},
+            {"value": "monitoring", "display": "Monitoring"},
+        ]
+    })
+    result = await action_list_event_categories(er_integration_v2_provider, ListEventCategoriesQuery())
+    assert [(o["value"], o["label"]) for o in result["options"]] == [
+        ("monitoring", "Monitoring"),
+        ("security", "Security"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_list_event_categories_upstream_error_propagates(mock_er_client, er_integration_v2_provider):
     from app.actions.handlers import action_list_event_categories
     from app.actions.configurations import ListEventCategoriesQuery

--- a/docs/actions/pull-events.md
+++ b/docs/actions/pull-events.md
@@ -55,7 +55,7 @@ flag was off has an empty seen-file list, so its first update after enabling
 | `end_datetime` | ISO-8601 string | none | Optional ceiling; sent on every run. Leave empty for ongoing pulls; set only for bounded backfills. |
 | `filter_date_field` | enum: `updated_at` / `created_at` / `event_time` | `updated_at` | Which ER timestamp the window applies to. `updated_at` catches edits and backdated events; `event_time` can silently miss backdated events — use it only for bounded backfills. |
 | `force_run_since_start` | bool | `False` | Reset the watermark for one run. Toggle off after the catch-up, or every run re-pulls from `start_datetime`. |
-| `event_types` | list[str] | `[]` | ER event-type slugs to pull (e.g. `wildlife_sighting_rep`). Empty = no type filter. Find slugs via [`show_permissions`](show-permissions.md). |
-| `event_categories` | list[str] | `[]` | ER event-category slugs. Combined with types using ER's AND semantics. Empty = no category filter. |
+| `event_types` | list[str] | `[]` | ER event-type slugs to pull (e.g. `wildlife_sighting_rep`). Empty = no type filter. In a supporting portal each item is a live dropdown ([reference actions](reference-actions.md#used-by-this-runners-own-form-too)); slugs are also listed by [`show_permissions`](show-permissions.md). |
+| `event_categories` | list[str] | `[]` | ER event-category slugs. Combined with types using ER's AND semantics. Empty = no category filter. In a supporting portal each item is a live dropdown ([reference actions](reference-actions.md#used-by-this-runners-own-form-too)). |
 | `include_attachments` | bool | `False` | Forward files attached to ER events (photos, documents) to Gundi as event attachments. See below. |
 | `run_on_schedule` | bool | `False` | Enable scheduled pulling. Off by default — turn on per connection that should pull events. |

--- a/docs/actions/reference-actions.md
+++ b/docs/actions/reference-actions.md
@@ -9,6 +9,7 @@ populating an "Event Type" dropdown, or the values for a choice field on that ev
 | Action | Query model | Purpose |
 |--------|-------------|---------|
 | `list_event_types` | `ListEventTypesQuery` (no fields) | Every **v2** ER event-type slug visible to this integration's credentials, grouped by event category. Classic v1 event types are not offered — see [Scope](#scope-v2-event-types-only). |
+| `list_event_categories` | `ListEventCategoriesQuery` (no fields) | Every ER event-category slug visible to this integration's credentials. |
 | `list_event_type_fields` | `ListEventTypeFieldsQuery` (`event_type`) | The field keys defined on one event type's schema. |
 | `list_event_field_values` | `ListEventFieldValuesQuery` (`event_type`, `field_key`) | The allowed values for one choice field on that event type. |
 
@@ -23,6 +24,15 @@ resolve them from *this* runner — that's `target: "provider"` in the
 [reference-data design](https://github.com/PADAS/gundi-integration-cmore/blob/main/docs/rfc-reference-data-portal-support.md).
 These three actions are what the portal calls to make that dropdown chain (event type → its fields → a
 field's values) work.
+
+## Used by this runner's own form too
+
+`pull_events`' **Event Types** and **Event Categories** config fields carry
+`gundi:reference` annotations with `target: "self"` — in a supporting portal,
+each list item renders as a live dropdown backed by `list_event_types` /
+`list_event_categories` on this very integration, so operators pick slugs
+instead of copying them from `show_permissions` output. Older portals ignore
+the annotation and keep plain text inputs.
 
 ## Scope: v2 event types only
 

--- a/docs/actions/reference-actions.md
+++ b/docs/actions/reference-actions.md
@@ -1,6 +1,6 @@
 # Reference actions
 
-Three config-time lookups the Gundi portal calls while an operator is filling out a form — e.g.
+Config-time lookups the Gundi portal calls while an operator is filling out a form — e.g.
 populating an "Event Type" dropdown, or the values for a choice field on that event type. They are
 **not** scheduled and have no configuration of their own: the caller supplies query params per-call via
 `config_overrides`, and each returns a `ReferenceDataResponse` (an `options` list plus a
@@ -13,8 +13,8 @@ populating an "Event Type" dropdown, or the values for a choice field on that ev
 | `list_event_type_fields` | `ListEventTypeFieldsQuery` (`event_type`) | The field keys defined on one event type's schema. |
 | `list_event_field_values` | `ListEventFieldValuesQuery` (`event_type`, `field_key`) | The allowed values for one choice field on that event type. |
 
-`action_list_event_types` / `action_list_event_type_fields` / `action_list_event_field_values` —
-`app/actions/handlers.py`.
+`action_list_event_types` / `action_list_event_categories` / `action_list_event_type_fields` /
+`action_list_event_field_values` — `app/actions/handlers.py`.
 
 ## Why these exist
 
@@ -22,8 +22,8 @@ CMORE's mapping form lets an operator pick an ER event type and one of its field
 map onto a CMORE tag field. Those are source-side (ER) values, so the CMORE runner's config form needs to
 resolve them from *this* runner — that's `target: "provider"` in the
 [reference-data design](https://github.com/PADAS/gundi-integration-cmore/blob/main/docs/rfc-reference-data-portal-support.md).
-These three actions are what the portal calls to make that dropdown chain (event type → its fields → a
-field's values) work.
+`list_event_types`, `list_event_type_fields` and `list_event_field_values` are what the portal calls
+to make that dropdown chain (event type → its fields → a field's values) work.
 
 ## Used by this runner's own form too
 


### PR DESCRIPTION
## Summary
Dogfoods the reference-data feature on this runner's own form: `pull_events`' **Event Types** and **Event Categories** slug lists now carry `gundi:reference` annotations with `target: "self"` — in a supporting portal (PADAS/gundi-portal#340) each list item renders as a live dropdown fed by this integration's own reference actions, instead of operators copying slugs from `show_permissions` output.

- New fourth reference action **`list_event_categories`** (`get_event_categories()`, results-envelope tolerant, sorted by display label; errors propagate — this fetch is load-bearing, unlike the best-effort category enrichment inside `list_event_types`).
- `PullEventsConfig.ui_schema()` override places the annotations on the arrays' `items` nodes (rjsf applies them per element); never sets `ui:widget`, so older portals keep plain text inputs.
- Docs: new "Used by this runner's own form too" section + action-table row; pull-events field rows link to it.

## Test plan
- [x] 271 passed (3 new: categories happy path incl. envelope/malformed-entry tolerance, upstream-error propagation, ui_schema annotation shape)
- [ ] After merge+deploy (dev auto-registers): open an ER provider's Pull Events config in the portal — Event Types and Event Categories items should offer live dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)