### PR TITLE
list_subject_types reference action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 .vscode
 
 sample-docs
+
+# Local git worktrees
+.worktrees/

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -363,6 +363,11 @@ class ListEventCategoriesQuery(ReferenceActionConfiguration):
     """List the ER event categories visible to this integration's credentials."""
 
 
+class ListSubjectTypesQuery(ReferenceActionConfiguration):
+    """List the subject subtypes observed on this ER site (plus their parent
+    subject types as fallback options)."""
+
+
 class ListEventTypeFieldsQuery(ReferenceActionConfiguration):
     event_type: str
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -22,7 +22,7 @@ from .core import ReferenceDataResponse, ReferenceOption
 from .er_schema import fetch_prerendered_event_schema, parse_er_event_schema
 from .configurations import AuthenticateConfig, EventFilterDateField, PullObservationsConfig, PullEventsConfig, \
     ERAuthenticationType, ShowPermissionsConfig, ListEventTypesQuery, ListEventTypeFieldsQuery, \
-    ListEventFieldValuesQuery, ListEventCategoriesQuery
+    ListEventFieldValuesQuery, ListEventCategoriesQuery, ListSubjectTypesQuery
 from .source_profiles import SourceProfileResolver
 from ..services.activity_logger import activity_logger, log_action_activity
 from ..services.gundi import send_events_to_gundi, send_observations_to_gundi, update_event_in_gundi, send_event_attachments_to_gundi
@@ -1548,6 +1548,57 @@ async def action_list_event_categories(integration: Integration, action_config: 
     ]
     options.sort(key=lambda o: o.label or o.value)
     return ReferenceDataResponse(options=options, truncated=False).dict()
+
+
+async def action_list_subject_types(integration: Integration, action_config: ListSubjectTypesQuery):
+    """Reference action: subject subtypes observed on this ER site.
+
+    Lists the distinct ``subject_subtype`` values of the site's subjects
+    (including inactive ones — their subtypes remain valid mapping
+    vocabulary), grouped by ``subject_type``. Each observed subject_type is
+    itself offered as the first option of its group, marked as a fallback:
+    destination-side subject mappings match subject_subtype first, then
+    subject_type. On a value collision (a subtype slug equal to a type slug)
+    the subtype wins. The subjectgroups fetch is load-bearing — errors
+    propagate so the portal shows its "couldn't load options" degrade
+    instead of silently offering an empty list.
+    """
+    async with _build_er_client(integration) as earth_ranger:
+        groups = await earth_ranger.get_subjectgroups(include_inactive=True, flat=True)
+
+    type_by_subtype: Dict[str, str] = {}
+    observed_types = set()
+    for group in _as_list(groups):
+        if not isinstance(group, dict):
+            continue
+        for subject in group.get("subjects", []) or []:
+            if not isinstance(subject, dict):
+                continue
+            subject_type = subject.get("subject_type")
+            if subject_type:
+                observed_types.add(subject_type)
+            subtype = subject.get("subject_subtype")
+            if subtype:
+                type_by_subtype.setdefault(subtype, subject_type)
+
+    options = [
+        ReferenceOption(value=subtype, group=subject_type)
+        for subtype, subject_type in type_by_subtype.items()
+    ]
+    options.extend(
+        ReferenceOption(
+            value=subject_type,
+            group=subject_type,
+            description=f"Any '{subject_type}' subtype (fallback match)",
+        )
+        for subject_type in observed_types
+        if subject_type not in type_by_subtype  # subtype wins the value
+    )
+    # Fallback-type options (the only ones carrying a description) sort
+    # first within their group; subtypes follow alphabetically.
+    options.sort(key=lambda o: (o.group or "", o.description is None, o.value))
+    return ReferenceDataResponse(options=options, truncated=False).dict()
+
 
 async def action_list_event_type_fields(integration: Integration, action_config: ListEventTypeFieldsQuery):
     """Reference action: field keys defined on one ER event type's schema."""

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -422,3 +422,102 @@ def test_pull_events_ui_schema_annotates_slug_lists_with_references():
         assert "ui:widget" not in node
     # The generated order list is untouched.
     assert "event_types" in ui["ui:order"] and "event_categories" in ui["ui:order"]
+
+
+# --- action_list_subject_types -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_subject_types_offers_observed_subtypes_grouped_by_type(
+    er_integration_v2_provider, mock_er_client
+):
+    """Distinct observed subject_subtypes, grouped by subject_type and sorted
+    by group; each subject_type is itself offered first in its group as a
+    fallback option (the CMORE mapping matches subtype first, then type).
+    Subjects appearing in several groups dedupe; subjects without a
+    subject_subtype contribute only their type."""
+    from app.actions.configurations import ListSubjectTypesQuery
+    from app.actions.handlers import action_list_subject_types
+
+    ranger = {"id": "s1", "name": "Ranger One",
+              "subject_type": "person", "subject_subtype": "ranger"}
+    mock_er_client.get_subjectgroups = AsyncMock(return_value=[
+        {"id": "g1", "name": "Rangers", "subjects": [
+            ranger,
+            {"id": "s2", "name": "Ranger Two",
+             "subject_type": "person", "subject_subtype": "ranger"},
+            {"id": "s3", "name": "Vet",
+             "subject_type": "person", "subject_subtype": "veterinarian"},
+        ]},
+        {"id": "g2", "name": "Wildlife", "subjects": [
+            {"id": "s4", "name": "Rhino A",
+             "subject_type": "wildlife", "subject_subtype": "black_rhino"},
+            ranger,  # same subject in a second group → dedupes
+            {"id": "s5", "name": "Typed only", "subject_type": "wildlife"},
+        ]},
+    ])
+
+    result = await action_list_subject_types(
+        er_integration_v2_provider, ListSubjectTypesQuery()
+    )
+
+    options = [(o["value"], o["group"], o["description"]) for o in result["options"]]
+    assert options == [
+        ("person", "person", "Any 'person' subtype (fallback match)"),
+        ("ranger", "person", None),
+        ("veterinarian", "person", None),
+        ("wildlife", "wildlife", "Any 'wildlife' subtype (fallback match)"),
+        ("black_rhino", "wildlife", None),
+    ]
+    mock_er_client.get_subjectgroups.assert_awaited_once_with(
+        include_inactive=True, flat=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_subject_types_subtype_wins_value_collision_and_handles_missing_type(
+    er_integration_v2_provider, mock_er_client
+):
+    """A subtype slug equal to a type slug yields ONE option (the subtype);
+    a subject with no subject_type still contributes its subtype, ungrouped."""
+    from app.actions.configurations import ListSubjectTypesQuery
+    from app.actions.handlers import action_list_subject_types
+
+    mock_er_client.get_subjectgroups = AsyncMock(return_value=[
+        {"id": "g1", "subjects": [
+            # Subtype literally named like its type.
+            {"id": "s1", "subject_type": "vehicle", "subject_subtype": "vehicle"},
+            # No subject_type at all.
+            {"id": "s2", "subject_subtype": "mystery"},
+        ]},
+    ])
+
+    result = await action_list_subject_types(
+        er_integration_v2_provider, ListSubjectTypesQuery()
+    )
+
+    options = [(o["value"], o["group"], o["description"]) for o in result["options"]]
+    assert options == [
+        ("mystery", None, None),
+        ("vehicle", "vehicle", None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_subject_types_propagates_upstream_errors(
+    er_integration_v2_provider, mock_er_client
+):
+    """The subjectgroups fetch is load-bearing — errors must propagate so the
+    portal shows its "couldn't load options" degrade, never an empty list."""
+    from app.actions.configurations import ListSubjectTypesQuery
+    from app.actions.handlers import action_list_subject_types
+
+    mock_er_client.get_subjectgroups = AsyncMock(
+        side_effect=httpx.HTTPStatusError(
+            "boom", request=MagicMock(), response=MagicMock(status_code=502)
+        )
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        await action_list_subject_types(
+            er_integration_v2_provider, ListSubjectTypesQuery()
+        )

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -36,12 +36,16 @@ def _load_fixture():
 @pytest.fixture
 def mock_er_client(mocker):
     """Patch AsyncERClient in handlers; returns the mock instance the
-    `async with AsyncERClient(...) as earth_ranger:` block yields."""
+    `async with AsyncERClient(...) as earth_ranger:` block yields.
+    The instance is autospecced from the real installed client, so a
+    handler passing kwargs the pinned erclient doesn't support fails
+    here with a TypeError instead of being masked by the mock."""
+    from erclient import AsyncERClient
     from app.actions import handlers as handlers_module
 
-    instance = MagicMock()
-    instance.get_event_types = AsyncMock(return_value=[])
-    instance.get_event_categories = AsyncMock(return_value=[])
+    instance = mocker.create_autospec(AsyncERClient, instance=True)
+    instance.get_event_types.return_value = []
+    instance.get_event_categories.return_value = []
     client_cls = MagicMock()
     client_cls.return_value.__aenter__ = AsyncMock(return_value=instance)
     client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -441,7 +445,9 @@ async def test_list_subject_types_offers_observed_subtypes_grouped_by_type(
 
     ranger = {"id": "s1", "name": "Ranger One",
               "subject_type": "person", "subject_subtype": "ranger"}
-    mock_er_client.get_subjectgroups = AsyncMock(return_value=[
+    # Configured on the autospecced method (not replaced with a bare
+    # AsyncMock) so the call signature stays checked against the real client.
+    mock_er_client.get_subjectgroups.return_value = [
         {"id": "g1", "name": "Rangers", "subjects": [
             ranger,
             {"id": "s2", "name": "Ranger Two",
@@ -455,7 +461,7 @@ async def test_list_subject_types_offers_observed_subtypes_grouped_by_type(
             ranger,  # same subject in a second group → dedupes
             {"id": "s5", "name": "Typed only", "subject_type": "wildlife"},
         ]},
-    ])
+    ]
 
     result = await action_list_subject_types(
         er_integration_v2_provider, ListSubjectTypesQuery()
@@ -483,14 +489,14 @@ async def test_list_subject_types_subtype_wins_value_collision_and_handles_missi
     from app.actions.configurations import ListSubjectTypesQuery
     from app.actions.handlers import action_list_subject_types
 
-    mock_er_client.get_subjectgroups = AsyncMock(return_value=[
+    mock_er_client.get_subjectgroups.return_value = [
         {"id": "g1", "subjects": [
             # Subtype literally named like its type.
             {"id": "s1", "subject_type": "vehicle", "subject_subtype": "vehicle"},
             # No subject_type at all.
             {"id": "s2", "subject_subtype": "mystery"},
         ]},
-    ])
+    ]
 
     result = await action_list_subject_types(
         er_integration_v2_provider, ListSubjectTypesQuery()
@@ -512,10 +518,8 @@ async def test_list_subject_types_propagates_upstream_errors(
     from app.actions.configurations import ListSubjectTypesQuery
     from app.actions.handlers import action_list_subject_types
 
-    mock_er_client.get_subjectgroups = AsyncMock(
-        side_effect=httpx.HTTPStatusError(
-            "boom", request=MagicMock(), response=MagicMock(status_code=502)
-        )
+    mock_er_client.get_subjectgroups.side_effect = httpx.HTTPStatusError(
+        "boom", request=MagicMock(), response=MagicMock(status_code=502)
     )
     with pytest.raises(httpx.HTTPStatusError):
         await action_list_subject_types(

--- a/docs/actions/reference-actions.md
+++ b/docs/actions/reference-actions.md
@@ -12,9 +12,10 @@ populating an "Event Type" dropdown, or the values for a choice field on that ev
 | `list_event_categories` | `ListEventCategoriesQuery` (no fields) | Every ER event-category slug visible to this integration's credentials. |
 | `list_event_type_fields` | `ListEventTypeFieldsQuery` (`event_type`) | The field keys defined on one event type's schema. |
 | `list_event_field_values` | `ListEventFieldValuesQuery` (`event_type`, `field_key`) | The allowed values for one choice field on that event type. |
+| `list_subject_types` | `ListSubjectTypesQuery` (no fields) | The distinct subject **subtypes** observed on the site (from the subjectgroups tree, inactive subjects included), grouped by subject type — with each subject type itself offered first in its group as a fallback option, since destination-side subject mappings match `subject_subtype` first, then `subject_type`. |
 
 `action_list_event_types` / `action_list_event_categories` / `action_list_event_type_fields` /
-`action_list_event_field_values` — `app/actions/handlers.py`.
+`action_list_event_field_values` / `action_list_subject_types` — `app/actions/handlers.py`.
 
 ## Why these exist
 
@@ -24,6 +25,9 @@ resolve them from *this* runner — that's `target: "provider"` in the
 [reference-data design](https://github.com/PADAS/gundi-integration-cmore/blob/main/docs/rfc-reference-data-portal-support.md).
 `list_event_types`, `list_event_type_fields` and `list_event_field_values` are what the portal calls
 to make that dropdown chain (event type → its fields → a field's values) work.
+`list_subject_types` serves the same form's subject-mapping lists (subject type → affiliation /
+classification): it offers the subtypes actually flowing through Gundi observations, so operators
+pick real values instead of guessing slugs.
 
 ## Used by this runner's own form too
 


### PR DESCRIPTION
## Summary

Adds a fifth reference action, `list_subject_types`, serving the CMORE Deliver form's subject-mapping dropdowns (`subject_type_to_affiliation` / `subject_type_to_classification`, annotated provider-target on the CMORE runner — see the paired gundi-integration-cmore PR).

- Vocabulary: the **distinct `subject_subtype` values observed on the site** via `get_subjectgroups(include_inactive=True, flat=True)` (inactive subjects' subtypes remain valid mapping vocabulary), grouped by `subject_type`.
- Each observed subject type is itself offered **first in its group** as a fallback option (`Any '<type>' subtype (fallback match)`) — destination-side mappings match `subject_subtype` first, then `subject_type`. On a value collision (subtype slug == type slug) the subtype wins.
- Errors propagate (load-bearing fetch) so the portal shows its "couldn't load options" degrade, never a silently empty list.
- Registers via the existing action discovery under `REGISTER_REFERENCE_ACTIONS`; the runner re-registers on next deploy.
- Docs: `docs/actions/reference-actions.md` gains the new row + rationale. Also adds `.worktrees/` to `.gitignore`.

## Test plan

- New tests: grouping/dedupe/fallback-ordering, subtype-wins collision + missing-type edge, upstream-error propagation.
- Full suite: 275 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015h7TtgpyczL1YbhqMYCrAL