### PR TITLE
chore: sync template (ephemeral reference actions, shared retry policy, cache fixes)

### DIFF
--- a/app/actions/core.py
+++ b/app/actions/core.py
@@ -62,7 +62,14 @@ class GenericActionConfiguration(ActionConfiguration):
 
 
 class ReferenceActionConfiguration(ActionConfiguration):
-    pass
+    """Marker base for reference-data actions: the config model IS the query.
+
+    Reference actions are stateless — they read the integration's auth config
+    but store no configuration of their own; callers (the Gundi portal)
+    supply query params via config_overrides. The runner therefore executes
+    them without a stored config row, and they are one of the two action
+    types (with auth) allowed to run ephemerally against a draft integration.
+    """
 
 
 def discover_actions(module_name, prefix):

--- a/app/actions/core.py
+++ b/app/actions/core.py
@@ -61,6 +61,10 @@ class GenericActionConfiguration(ActionConfiguration):
     pass
 
 
+class ReferenceActionConfiguration(ActionConfiguration):
+    pass
+
+
 def discover_actions(module_name, prefix):
     action_handlers = {}
     # Import the module using importlib

--- a/app/api_schemas.py
+++ b/app/api_schemas.py
@@ -16,7 +16,8 @@ class IntegrationState(BaseModel):
 
 class ActionRequest(BaseModel):
     # `integration_id` is optional: when absent, `integration_state` must be
-    # present and the action must be a reference action.
+    # present and the action must be reference or auth (the ephemerally-safe
+    # whitelist enforced in action_runner._execute_action_impl).
     integration_id: Optional[str] = None
     action_id: str
     run_in_background: bool = False

--- a/app/api_schemas.py
+++ b/app/api_schemas.py
@@ -1,10 +1,23 @@
-from typing import Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+
+class DraftActionConfig(BaseModel):
+    action_value: str
+    data: dict
+
+
+class IntegrationState(BaseModel):
+    type_value: str
+    base_url: Optional[str] = None
+    configurations: List[DraftActionConfig] = Field(default_factory=list)
 
 
 class ActionRequest(BaseModel):
-    integration_id: str
+    # `integration_id` is optional: when absent, `integration_state` must be
+    # present and the action must be a reference action.
+    integration_id: Optional[str] = None
     action_id: str
     run_in_background: bool = False
     config_overrides: dict = None
@@ -12,4 +25,4 @@ class ActionRequest(BaseModel):
     # invocation, so it defaults to "manual" when unset (see the router) —
     # keeping the strict 404/422 behavior for misconfigured pull actions.
     triggered_by: Optional[str] = None
-
+    integration_state: Optional[IntegrationState] = None

--- a/app/api_schemas.py
+++ b/app/api_schemas.py
@@ -3,13 +3,21 @@ from typing import List, Optional
 from pydantic import BaseModel, Field
 
 
+# Same constraints gundi_core puts on IntegrationType.value and
+# IntegrationAction.value. Enforcing them here means a bad natural key is a
+# request-validation 422 that names `integration_state.type_value`, instead of
+# surfacing later from Integration.parse_obj against synthesized fields such
+# as `type.actions.0.value` that never appeared in the request.
+_NATURAL_KEY = dict(min_length=2, max_length=200, regex=r"^[a-z0-9_]+$")
+
+
 class DraftActionConfig(BaseModel):
-    action_value: str
+    action_value: str = Field(..., **_NATURAL_KEY)
     data: dict
 
 
 class IntegrationState(BaseModel):
-    type_value: str
+    type_value: str = Field(..., **_NATURAL_KEY)
     base_url: Optional[str] = None
     configurations: List[DraftActionConfig] = Field(default_factory=list)
 

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -943,6 +943,8 @@ def mock_config_manager(mocker, integration_v2):
         (integration_v2.configurations[0], integration_v2.configurations[0].json())
     )
     mock_config_manager.replace_cached_entry.return_value = async_return(True)
+    mock_config_manager.install_action_configuration_if_missing.return_value = async_return(True)
+    mock_config_manager._fetch_integration_from_gundi.return_value = async_return(integration_v2)
     mock_config_manager.set_integration.return_value = async_return(None)
     mock_config_manager.set_action_configuration.return_value = async_return(None)
     mock_config_manager.delete_integration.return_value = async_return(None)

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -939,6 +939,9 @@ def mock_config_manager(mocker, integration_v2):
     )
     mock_config_manager.get_integration_details.return_value = async_return(integration_v2)
     mock_config_manager.get_action_configuration.return_value = async_return(integration_v2.configurations[0])
+    mock_config_manager.get_action_configuration_and_sentinel.return_value = async_return(
+        (integration_v2.configurations[0], None)
+    )
     mock_config_manager.set_integration.return_value = async_return(None)
     mock_config_manager.set_action_configuration.return_value = async_return(None)
     mock_config_manager.delete_integration.return_value = async_return(None)

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -939,7 +939,7 @@ def mock_config_manager(mocker, integration_v2):
     )
     mock_config_manager.get_integration_details.return_value = async_return(integration_v2)
     mock_config_manager.get_action_configuration.return_value = async_return(integration_v2.configurations[0])
-    mock_config_manager.get_action_configuration_and_sentinel.return_value = async_return(
+    mock_config_manager.read_cached_action_configuration.return_value = async_return(
         (integration_v2.configurations[0], None)
     )
     mock_config_manager.set_integration.return_value = async_return(None)

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -92,7 +92,7 @@ def mock_redis_empty(mocker, mock_integration_state):
     redis_client.incr.return_value = redis_client
     redis_client.decr.return_value = async_return(None)
     redis_client.expire.return_value = redis_client
-    redis_client.ttl.return_value = async_return(120)  # an expiring key, unless a test says otherwise
+    redis_client.eval.return_value = async_return(0)  # scripts (compare-and-expire) report "nothing changed"
     redis_client.execute.return_value = async_return((1, True))
     redis_client.__aenter__.return_value = redis_client
     redis_client.__aexit__.return_value = None

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -940,8 +940,9 @@ def mock_config_manager(mocker, integration_v2):
     mock_config_manager.get_integration_details.return_value = async_return(integration_v2)
     mock_config_manager.get_action_configuration.return_value = async_return(integration_v2.configurations[0])
     mock_config_manager.read_cached_action_configuration.return_value = async_return(
-        (integration_v2.configurations[0], None)
+        (integration_v2.configurations[0], integration_v2.configurations[0].json())
     )
+    mock_config_manager.replace_cached_entry.return_value = async_return(True)
     mock_config_manager.set_integration.return_value = async_return(None)
     mock_config_manager.set_action_configuration.return_value = async_return(None)
     mock_config_manager.delete_integration.return_value = async_return(None)

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -92,6 +92,7 @@ def mock_redis_empty(mocker, mock_integration_state):
     redis_client.incr.return_value = redis_client
     redis_client.decr.return_value = async_return(None)
     redis_client.expire.return_value = redis_client
+    redis_client.ttl.return_value = async_return(120)  # an expiring key, unless a test says otherwise
     redis_client.execute.return_value = async_return((1, True))
     redis_client.__aenter__.return_value = redis_client
     redis_client.__aexit__.return_value = None

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -73,6 +73,7 @@ def mock_redis(mocker, mock_integration_state):
     redis_client.incr.return_value = redis_client
     redis_client.decr.return_value = async_return(None)
     redis_client.expire.return_value = redis_client
+    redis_client.eval.return_value = async_return(0)  # scripts (compare-and-expire) report "nothing changed"
     redis_client.execute.return_value = async_return((1, True))
     redis_client.__aenter__.return_value = redis_client
     redis_client.__aexit__.return_value = None
@@ -112,6 +113,7 @@ def mock_redis_with_integration_config(mocker, integration_v2_as_json):
     redis_client.incr.return_value = redis_client
     redis_client.decr.return_value = async_return(None)
     redis_client.expire.return_value = redis_client
+    redis_client.eval.return_value = async_return(0)  # scripts (compare-and-expire) report "nothing changed"
     redis_client.execute.return_value = async_return((1, True))
     redis_client.__aenter__.return_value = redis_client
     redis_client.__aexit__.return_value = None
@@ -131,6 +133,7 @@ def mock_redis_with_action_config(mocker, pull_observations_config_as_json):
     redis_client.incr.return_value = redis_client
     redis_client.decr.return_value = async_return(None)
     redis_client.expire.return_value = redis_client
+    redis_client.eval.return_value = async_return(0)  # scripts (compare-and-expire) report "nothing changed"
     redis_client.execute.return_value = async_return((1, True))
     redis_client.__aenter__.return_value = redis_client
     redis_client.__aexit__.return_value = None
@@ -152,6 +155,7 @@ def mock_redis_with_webhook_config(mocker, integration_v2_with_webhook):
     redis_client.incr.return_value = redis_client
     redis_client.decr.return_value = async_return(None)
     redis_client.expire.return_value = redis_client
+    redis_client.eval.return_value = async_return(0)  # scripts (compare-and-expire) report "nothing changed"
     redis_client.execute.return_value = async_return((1, True))
     redis_client.__aenter__.return_value = redis_client
     redis_client.__aexit__.return_value = None

--- a/app/main.py
+++ b/app/main.py
@@ -146,19 +146,17 @@ app.include_router(
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
-    # Full body — including any draft credentials on the ephemeral path — stays
-    # in the DEBUG server log (ops-controlled) but MUST NOT round-trip back to
-    # the caller in the response. Strip pydantic's `input`/`ctx` fields off
-    # each error for the same reason: pydantic v2 mirrors the offending value
-    # into `input` which would leak a bad token/password verbatim.
-    logger.debug(
-        "Failed handling body: %s",
-        jsonable_encoder({"detail": exc.errors(), "body": exc.body}),
-    )
+    # The request body can carry draft credentials on the ephemeral path, so
+    # neither the response nor the log gets it: log access and retention are
+    # usually broader than access to the originating request. Keep only
+    # loc/msg/type per error. On the pinned pydantic 1.x, `ctx` can carry
+    # values from the offending input; `input` is dropped too so a pydantic 2
+    # upgrade, which mirrors the value there, does not reopen the leak.
     safe_errors = [
         {k: v for k, v in err.items() if k not in ("input", "ctx")}
         for err in exc.errors()
     ]
+    logger.debug("Failed handling body: %s", jsonable_encoder({"detail": safe_errors}))
     return JSONResponse(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         content=jsonable_encoder({"detail": safe_errors}),

--- a/app/main.py
+++ b/app/main.py
@@ -83,20 +83,28 @@ async def execute(
     # scheduled tick vs an operator's "Run now"). Absent the marker we default
     # to automated, so scheduled pulls on destination-only integrations skip
     # quietly instead of erroring.
+    #
+    # It is read from the PubSub message attributes as well as the body:
+    # gundi_core's RunIntegrationAction command has no `triggered_by` field, so
+    # a portal that serializes that model cannot put the marker in the payload
+    # and the MANUAL branch would never be reachable over PubSub.
+    triggered_by = json_payload.get("triggered_by") or (
+        json_data["message"].get("attributes") or {}
+    ).get("triggered_by")
     if settings.PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND:
         background_tasks.add_task(
             execute_action,
             integration_id=json_payload.get("integration_id"),
             action_id=json_payload.get("action_id"),
             config_overrides=json_payload.get("config_overrides"),
-            triggered_by=json_payload.get("triggered_by"),
+            triggered_by=triggered_by,
         )
     else:
         await execute_action(
             integration_id=json_payload.get("integration_id"),
             action_id=json_payload.get("action_id"),
             config_overrides=json_payload.get("config_overrides"),
-            triggered_by=json_payload.get("triggered_by"),
+            triggered_by=triggered_by,
         )
     return {}
 

--- a/app/main.py
+++ b/app/main.py
@@ -146,13 +146,20 @@ app.include_router(
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
-
+    # Full body — including any draft credentials on the ephemeral path — stays
+    # in the DEBUG server log (ops-controlled) but MUST NOT round-trip back to
+    # the caller in the response. Strip pydantic's `input`/`ctx` fields off
+    # each error for the same reason: pydantic v2 mirrors the offending value
+    # into `input` which would leak a bad token/password verbatim.
     logger.debug(
         "Failed handling body: %s",
         jsonable_encoder({"detail": exc.errors(), "body": exc.body}),
     )
-
+    safe_errors = [
+        {k: v for k, v in err.items() if k not in ("input", "ctx")}
+        for err in exc.errors()
+    ]
     return JSONResponse(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-        content=jsonable_encoder({"detail": exc.errors(), "body": exc.body}),
+        content=jsonable_encoder({"detail": safe_errors}),
     )

--- a/app/routers/actions.py
+++ b/app/routers/actions.py
@@ -30,20 +30,24 @@ async def execute(
     # Direct /execute calls are explicit invocations → manual by default, so a
     # misconfigured pull action surfaces a 404/422 here rather than skipping.
     triggered_by = request.triggered_by or ActionTrigger.MANUAL.value
+    # Match action_runner's error shape ({"detail": {"action_id", "error"}}) so
+    # clients see one stable schema across router-level and runner-level 422s.
+    def _shape_error(message: str) -> dict:
+        return {"action_id": request.action_id, "error": message}
     if request.integration_id is None and request.integration_state is None:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Provide either integration_id or integration_state.",
+            detail=_shape_error("Provide either integration_id or integration_state."),
         )
     if request.integration_id is not None and request.integration_state is not None:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Provide either integration_id or integration_state, not both.",
+            detail=_shape_error("Provide either integration_id or integration_state, not both."),
         )
     if request.integration_state is not None and request.run_in_background:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Ephemeral executions cannot run in background.",
+            detail=_shape_error("Ephemeral executions cannot run in background."),
         )
     if request.run_in_background:
         background_tasks.add_task(

--- a/app/routers/actions.py
+++ b/app/routers/actions.py
@@ -1,9 +1,9 @@
 import logging
 from typing import List
 import app.settings
-from fastapi import APIRouter, BackgroundTasks, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks
 from app.actions import get_actions
-from app.services.action_runner import execute_action, ActionTrigger
+from app.services.action_runner import execute_action, ActionTrigger, _request_error_response
 from app.api_schemas import ActionRequest
 
 logger = logging.getLogger(__name__)
@@ -30,25 +30,14 @@ async def execute(
     # Direct /execute calls are explicit invocations → manual by default, so a
     # misconfigured pull action surfaces a 404/422 here rather than skipping.
     triggered_by = request.triggered_by or ActionTrigger.MANUAL.value
-    # Match action_runner's error shape ({"detail": {"action_id", "error"}}) so
-    # clients see one stable schema across router-level and runner-level 422s.
-    def _shape_error(message: str) -> dict:
-        return {"action_id": request.action_id, "error": message}
+    # Request-shape rejections share the runner's {"detail": {"action_id",
+    # "error"}} response and, like the runner's, publish no activity event.
     if request.integration_id is None and request.integration_state is None:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=_shape_error("Provide either integration_id or integration_state."),
-        )
+        return _request_error_response(request.action_id, "Provide either integration_id or integration_state.")
     if request.integration_id is not None and request.integration_state is not None:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=_shape_error("Provide either integration_id or integration_state, not both."),
-        )
+        return _request_error_response(request.action_id, "Provide either integration_id or integration_state, not both.")
     if request.integration_state is not None and request.run_in_background:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=_shape_error("Ephemeral executions cannot run in background."),
-        )
+        return _request_error_response(request.action_id, "Ephemeral executions cannot run in background.")
     if request.run_in_background:
         background_tasks.add_task(
             execute_action,

--- a/app/routers/actions.py
+++ b/app/routers/actions.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List
 import app.settings
-from fastapi import APIRouter, BackgroundTasks
+from fastapi import APIRouter, BackgroundTasks, HTTPException, status
 from app.actions import get_actions
 from app.services.action_runner import execute_action, ActionTrigger
 from app.api_schemas import ActionRequest
@@ -30,6 +30,21 @@ async def execute(
     # Direct /execute calls are explicit invocations → manual by default, so a
     # misconfigured pull action surfaces a 404/422 here rather than skipping.
     triggered_by = request.triggered_by or ActionTrigger.MANUAL.value
+    if request.integration_id is None and request.integration_state is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Provide either integration_id or integration_state.",
+        )
+    if request.integration_id is not None and request.integration_state is not None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Provide either integration_id or integration_state, not both.",
+        )
+    if request.integration_state is not None and request.run_in_background:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Ephemeral executions cannot run in background.",
+        )
     if request.run_in_background:
         background_tasks.add_task(
             execute_action,
@@ -45,4 +60,5 @@ async def execute(
             action_id=request.action_id,
             config_overrides=request.config_overrides,
             triggered_by=triggered_by,
+            integration_state=request.integration_state,
         )

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -123,23 +123,33 @@ def _request_error_response(action_id: Optional[str], message: str,
     )
 
 
+# Server-owned text per pydantic error type, the only validation messages the
+# ephemeral path forwards. A dotted type does not prove pydantic authored the
+# message: a connector's PydanticValueError subclass gets one too
+# (value_error.<code>) and its msg_template can interpolate the submitted
+# value. Everything outside this allowlist reads "invalid value".
+_SAFE_VALIDATION_MESSAGES = {
+    "value_error.missing": "field required",
+    "value_error.extra": "extra fields not permitted",
+}
+
+
 def _ephemeral_error_text(exc: Exception, *, expose_message: bool) -> str:
     """Portal-facing text for a failure on the ephemeral path.
 
     Redaction is by provenance, not by path. Runner-authored errors
     (expose_message=True) keep their message: the runner built it, so it
     cannot contain draft credentials. A pydantic ValidationError exposes
-    field locations, and the message only for pydantic's own errors
-    (dotted types such as value_error.missing, whose templates never embed
-    the input); a connector validator's ValueError text is arbitrary and is
-    replaced. Anything raised by a handler is reduced to the curated
+    field locations plus server-owned text from _SAFE_VALIDATION_MESSAGES;
+    any other message, connector-authored or not, is replaced, since
+    validators run on draft credentials. Anything raised by a handler is reduced to the curated
     classification title plus the HTTP status, never str(exc), which can
     embed our outgoing request (auth headers) or the source's response body.
     """
     if isinstance(exc, pydantic.ValidationError):
         fields = "; ".join(
             f"{'.'.join(str(part) for part in err['loc'])}: "
-            f"{err['msg'] if '.' in err.get('type', '') else 'invalid value'}"
+            f"{_SAFE_VALIDATION_MESSAGES.get(err.get('type', ''), 'invalid value')}"
             for err in exc.errors()
         )
         return f"{type(exc).__name__}: {fields}" if fields else type(exc).__name__

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -24,7 +24,7 @@ from .config_manager import IntegrationConfigurationManager
 from .state import IntegrationStateManager
 from .utils import find_config_for_action
 from .activity_logger import publish_event, log_action_activity, ephemeral_run
-from .errors import classify_error, format_classified_error, source_status_code, IntegrationError
+from .errors import classify_error, format_classified_error, source_status_code, IntegrationError, IntegrationConfigurationError
 from .gundi import EphemeralWriteBlocked
 
 _portal = GundiClient()
@@ -161,10 +161,13 @@ def _ephemeral_error_text(exc: Exception, *, classified, expose_message: bool) -
         message = exc.args[0] if exc.args else str(exc)
         return f"{type(exc).__name__}: {message}"
     if classified:
-        text = classified.title
-        if classified.status_code:
-            text = f"{text} (HTTP {classified.status_code})"
-        return text
+        # One renderer with the activity log (errors.format_classified_error),
+        # minus the message: it may hold str(exc) from the source. The one
+        # exception is IntegrationConfigurationError, whose message the
+        # connector vouches for (see its docstring).
+        return format_classified_error(
+            classified, include_message=isinstance(exc, IntegrationConfigurationError),
+        )
     return type(exc).__name__
 
 
@@ -179,12 +182,17 @@ def _ephemeral_status_for(exc: Exception, fallback: int) -> int:
     are forwarded: statuses below 400 are not failures the portal can
     classify (a redirect surfaced by raise_for_status with redirects off is
     the common one), and anything outside the HTTP range is a connector bug,
-    not a status the runner should answer with. Everything else keeps the
-    caller's `fallback` (500 for a handler exception, 504 for a timeout).
+    not a status the runner should answer with. A connector's
+    IntegrationConfigurationError is not a source verdict either: it is a
+    422, the request was understood but its content cannot be acted on.
+    Everything else keeps the caller's `fallback` (500 for a handler
+    exception, 504 for a timeout).
     """
     source_status = source_status_code(exc)
     if source_status is None and isinstance(exc, IntegrationError) and exc.error_type == "auth":
         return status.HTTP_401_UNAUTHORIZED
+    if isinstance(exc, IntegrationConfigurationError):
+        return status.HTTP_422_UNPROCESSABLE_ENTITY
     if source_status is not None and 400 <= source_status <= 599:
         return source_status
     return fallback

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -379,20 +379,25 @@ async def _execute_action_impl(
     is_manual = (triggered_by or "").strip().lower() == ActionTrigger.MANUAL.value
     skippable_pull = is_pull_action and not is_manual
 
+    # Reference actions are stateless: they never have a stored config row, and
+    # a caller sending no config_overrides (e.g. ER's zero-param
+    # list_event_types) is a legitimate, complete request — not a 404. The
+    # ephemeral path has the same property for every action: the wizard only
+    # forwards `configurations` for the sections the user edited (auth), never
+    # a row for the action being executed. Either way `config_model
+    # .parse_obj({})` below decides whether params are actually required and
+    # raises ValidationError → 422 if they are.
+    is_reference_action = isinstance(config_model, type) and issubclass(
+        config_model, ReferenceActionConfiguration
+    )
+    skip_missing_config = is_ephemeral or is_reference_action
+
     # Get the configuration needed to execute the action
     if is_ephemeral:
         action_config = find_config_for_action(integration.configurations, action_id)
     else:
         action_config = await config_manager.get_action_configuration(integration_id, action_id)
-    # Ephemeral runs skip the missing-config 404 entirely: reference actions
-    # are frequently parameter-less (ER's list_event_types /
-    # list_event_categories both declare `params: {}`), and the wizard only
-    # forwards `configurations` for the sections the user edited (auth) —
-    # never a config row for the reference action itself. `config_model
-    # .parse_obj({})` below already decides whether params are required and
-    # raises ValidationError → 422 if they are, so the 404 branch was pure
-    # feature-blocking noise on this path.
-    if not is_ephemeral and not action_config and not config_overrides:
+    if not skip_missing_config and not action_config and not config_overrides:
         if skippable_pull:
             return _skip_quietly(
                 integration_id, action_id,
@@ -404,8 +409,9 @@ async def _execute_action_impl(
         logger.error(message)
         return await _handle_error(
             ValueError(message), integration_id, action_id,
-            # Reached only for non-ephemeral runs (see the guard above), so
-            # dumping the saved integration's configurations here is safe.
+            # Reached only for non-ephemeral, non-reference runs (see the
+            # guard above), so dumping the saved integration's configurations
+            # here is safe.
             config_data={"configurations": [i.dict() for i in integration.configurations]},
             status_code=status.HTTP_404_NOT_FOUND
         )

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -118,8 +118,9 @@ async def _handle_error(
         *, classify_heuristics: bool = False,
 ):
     """
-    Handles errors by logging, extracting details as available, and publishing events for activity logs.
-    Returns a JSON response with error details too.
+    Log the error and return a JSON response with details. On non-ephemeral
+    runs, also publishes an IntegrationActionFailed event for the activity
+    feed; ephemeral runs skip the publish (no integration to log against).
     """
     is_ephemeral = ephemeral_run.get()
 

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -2,12 +2,14 @@ import asyncio
 import logging
 import time
 import traceback
+import uuid
 from enum import Enum
 from typing import Optional
 
 import pydantic
 import stamina
 from gundi_client_v2 import GundiClient
+from gundi_core.schemas.v2 import Integration
 
 from app.actions import action_handlers, get_action_handler_by_data_type
 from app import settings
@@ -16,16 +18,19 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from gundi_core.events import IntegrationActionFailed, ActionExecutionFailed, LogLevel
 
-from app.actions.core import PullActionConfiguration
+from app.actions.core import PullActionConfiguration, ReferenceActionConfiguration
+from app.api_schemas import IntegrationState
 from .config_manager import IntegrationConfigurationManager
 from .state import IntegrationStateManager
-from .activity_logger import publish_event, log_action_activity
+from .utils import find_config_for_action
+from .activity_logger import publish_event, log_action_activity, ephemeral_run
 from .errors import classify_error, format_classified_error, IntegrationError
 
 _portal = GundiClient()
 config_manager = IntegrationConfigurationManager()
 state_manager = IntegrationStateManager()
 logger = logging.getLogger(__name__)
+
 
 # How often (seconds) to publish a portal activity-log WARNING for a pull
 # action that keeps skipping on an invalid config. Pull actions are scheduled
@@ -54,15 +59,84 @@ class ActionTrigger(str, Enum):
     MANUAL = "manual"
 
 
+def _build_synthetic_integration(state: IntegrationState) -> Integration:
+    # Unique per run so concurrent drafts by different users don't collide on
+    # any state_manager keys downstream handlers might set under
+    # `integration.id` (`integration_state.{integration_id}.{action_id}.…`).
+    run_id = str(uuid.uuid4())
+    return Integration.parse_obj({
+        "id": run_id,
+        "name": "(ephemeral)",
+        "base_url": state.base_url or "",
+        "enabled": True,
+        "type": {
+            "id": run_id,
+            "name": state.type_value,
+            "value": state.type_value,
+            "description": "",
+            "actions": [
+                {
+                    "id": run_id,
+                    "type": "generic",
+                    "name": cfg.action_value,
+                    "value": cfg.action_value,
+                    "schema": {},
+                }
+                for cfg in state.configurations
+            ],
+        },
+        "owner": {
+            "id": run_id,
+            "name": "(ephemeral)",
+            "description": "",
+        },
+        "configurations": [
+            {
+                "id": run_id,
+                "integration": run_id,
+                "action": {
+                    "id": run_id,
+                    "type": "generic",
+                    "name": cfg.action_value,
+                    "value": cfg.action_value,
+                },
+                "data": cfg.data,
+            }
+            for cfg in state.configurations
+        ],
+        "additional": {},
+        "default_route": None,
+        "status": "healthy",
+        "status_details": "",
+    })
+
+
 async def _handle_error(
-        exc: Exception, integration_id: str, action_id: Optional[str] = None,
+        exc: Exception, integration_id: Optional[str], action_id: Optional[str] = None,
         config_data=None, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        *, classify_heuristics: bool = False
+        *, classify_heuristics: bool = False,
 ):
     """
     Handles errors by logging, extracting details as available, and publishing events for activity logs.
     Returns a JSON response with error details too.
     """
+    is_ephemeral = ephemeral_run.get()
+
+    log_message = f"Error in action '{action_id}' for integration '{integration_id}': {type(exc).__name__}: {exc}"
+    logger.exception(log_message)
+
+    if is_ephemeral:
+        # Third-party exceptions may embed our outgoing request (with auth
+        # headers) or the source's response body. Return only the exception
+        # class name to the caller — full details stay in the server log
+        # above — and skip the activity-log publish entirely.
+        return JSONResponse(
+            status_code=status_code,
+            content=jsonable_encoder({"detail": {
+                "action_id": action_id,
+                "error": type(exc).__name__,
+            }}),
+        )
 
     # Classified errors (auth, connectivity, rate limit, bad response) get
     # short human-first text — the portal prepends "Error running action
@@ -79,12 +153,7 @@ async def _handle_error(
     # third-party provider one, and must not render as "Authentication
     # failed" (which would misdirect operators at the provider).
     classified = classify_error(exc) if (classify_heuristics or isinstance(exc, IntegrationError)) else None
-    log_message = f"Error in action '{action_id}' for integration '{integration_id}': {type(exc).__name__}: {exc}"
     message = format_classified_error(classified) if classified else log_message
-    # The application log always keeps the verbose form — the action and
-    # integration ids are what server-side log searches key on; the clean
-    # text is only for the portal-facing event and JSON response.
-    logger.exception(log_message)
 
     error_details = {
         "integration_id": integration_id,
@@ -116,7 +185,6 @@ async def _handle_error(
             "server_response_body": str(getattr(response, "text", getattr(response, "content", None)) or "")
         })
 
-    # Publish the error event
     await publish_event(
         event=IntegrationActionFailed(
             payload=ActionExecutionFailed(**error_details)
@@ -124,7 +192,6 @@ async def _handle_error(
         topic_name=settings.INTEGRATION_EVENTS_TOPIC,
     )
 
-    # Return the JSON response
     return JSONResponse(
         status_code=status_code,
         content=jsonable_encoder({"detail": error_details}),
@@ -187,13 +254,61 @@ async def _skip_invalid_config(integration_id, action_id, *, error):
 
 
 async def execute_action(
-        integration_id: str, action_id: Optional[str] = None, config_overrides: dict = None,
-        data: dict = None, metadata: dict = None, triggered_by: Optional[str] = None
+        integration_id: Optional[str], action_id: Optional[str] = None, config_overrides: dict = None,
+        data: dict = None, metadata: dict = None, triggered_by: Optional[str] = None,
+        integration_state: Optional[IntegrationState] = None,
 ):
-    try:  # Get the integration details to pass it to the action handler
-        integration = await config_manager.get_integration_details(integration_id)
-    except Exception as e:
-        return await _handle_error(e, integration_id, action_id)
+    if integration_id is not None and integration_state is not None:
+        return await _handle_error(
+            ValueError("Provide either integration_id or integration_state, not both"),
+            integration_id, action_id,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
+    is_ephemeral = integration_id is None and integration_state is not None
+    # OR-fold the contextvar so a nested saved-integration call inside an
+    # ephemeral outer run doesn't re-enable publishing (e.g. a reference
+    # handler that triggers a helper action). The finally block still
+    # restores whatever value was here on entry.
+    ephemeral_token = ephemeral_run.set(is_ephemeral or ephemeral_run.get())
+    try:
+        return await _execute_action_impl(
+            integration_id=integration_id,
+            action_id=action_id,
+            config_overrides=config_overrides,
+            data=data,
+            metadata=metadata,
+            triggered_by=triggered_by,
+            integration_state=integration_state,
+            is_ephemeral=is_ephemeral,
+        )
+    finally:
+        ephemeral_run.reset(ephemeral_token)
+
+
+async def _execute_action_impl(
+        integration_id: Optional[str], action_id: Optional[str], config_overrides: Optional[dict],
+        data: Optional[dict], metadata: Optional[dict], triggered_by: Optional[str],
+        integration_state: Optional[IntegrationState], is_ephemeral: bool,
+):
+    if is_ephemeral:
+        try:
+            integration = _build_synthetic_integration(integration_state)
+        except Exception as e:
+            return await _handle_error(
+                e, integration_id=None, action_id=action_id,
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
+    elif integration_id is None:
+        return await _handle_error(
+            ValueError("Either integration_id or integration_state must be provided"),
+            integration_id, action_id,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
+    else:
+        try:  # Get the integration details to pass it to the action handler
+            integration = await config_manager.get_integration_details(integration_id)
+        except Exception as e:
+            return await _handle_error(e, integration_id, action_id)
 
     # Find the action handler based on the action ID or data type
     if action_id:
@@ -221,7 +336,24 @@ async def execute_action(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
         )
 
-    logger.info(f"Executing action '{action_id}' for integration '{integration_id}'...")
+    # Ephemeral execution is only safe for read-only reference actions —
+    # anything else would move data through Gundi on behalf of an integration
+    # that doesn't exist. cdip enforces the same rule independently.
+    if is_ephemeral:
+        is_reference_action = isinstance(config_model, type) and issubclass(
+            config_model, ReferenceActionConfiguration
+        )
+        if not is_reference_action:
+            return await _handle_error(
+                ValueError(
+                    f"Action '{action_id}' is not a reference action; "
+                    "ephemeral execution is only supported for reference actions."
+                ),
+                integration_id=None, action_id=action_id,
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
+
+    logger.info(f"Executing action '{action_id}' for integration '{integration_id or '(ephemeral)'}'...")
 
     # Pull actions are scheduled type-wide, so the portal fires them for every
     # integration of this type — including destination-only ones that never get
@@ -236,8 +368,19 @@ async def execute_action(
     skippable_pull = is_pull_action and not is_manual
 
     # Get the configuration needed to execute the action
-    action_config = await config_manager.get_action_configuration(integration_id, action_id)
-    if not action_config and not config_overrides:
+    if is_ephemeral:
+        action_config = find_config_for_action(integration.configurations, action_id)
+    else:
+        action_config = await config_manager.get_action_configuration(integration_id, action_id)
+    # Ephemeral runs skip the missing-config 404 entirely: reference actions
+    # are frequently parameter-less (ER's list_event_types /
+    # list_event_categories both declare `params: {}`), and the wizard only
+    # forwards `configurations` for the sections the user edited (auth) —
+    # never a config row for the reference action itself. `config_model
+    # .parse_obj({})` below already decides whether params are required and
+    # raises ValidationError → 422 if they are, so the 404 branch was pure
+    # feature-blocking noise on this path.
+    if not is_ephemeral and not action_config and not config_overrides:
         if skippable_pull:
             return _skip_quietly(
                 integration_id, action_id,
@@ -249,7 +392,7 @@ async def execute_action(
         logger.error(message)
         return await _handle_error(
             ValueError(message), integration_id, action_id,
-            config_data={"configurations": [i.dict() for i in integration.configurations]},
+            config_data=None if is_ephemeral else {"configurations": [i.dict() for i in integration.configurations]},
             status_code=status.HTTP_404_NOT_FOUND
         )
 
@@ -265,7 +408,11 @@ async def execute_action(
         # noticeable without spamming a warning on every tick.
         if skippable_pull:
             return await _skip_invalid_config(integration_id, action_id, error=e)
-        return await _handle_error(e, integration_id, action_id, config_data, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        return await _handle_error(
+            e, integration_id, action_id,
+            config_data=None if is_ephemeral else config_data,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
 
     # Respect the operator's explicit pause toggle — only for scheduled runs.
     if skippable_pull and not getattr(parsed_config, "run_on_schedule", True):
@@ -301,19 +448,21 @@ async def execute_action(
         return await _handle_error(
             asyncio.TimeoutError(f"Action '{action_id}' timed out"),
             integration_id, action_id,
-            config_data={"configurations": [c.dict() for c in integration.configurations]},
+            config_data=None if is_ephemeral else {"configurations": [c.dict() for c in integration.configurations]},
             status_code=status.HTTP_504_GATEWAY_TIMEOUT,
             classify_heuristics=True,
         )
     except Exception as e:
-        return await _handle_error(e, integration_id, action_id,
-                                   config_data={"configurations": [c.dict() for c in integration.configurations]},
-                                   classify_heuristics=True)
+        return await _handle_error(
+            e, integration_id, action_id,
+            config_data=None if is_ephemeral else {"configurations": [c.dict() for c in integration.configurations]},
+            classify_heuristics=True,
+        )
 
     # Success. Log the execution time and return the result
     end_time = time.monotonic()
     execution_time = end_time - start_time
     logger.debug(
-        f"Action '{action_id}' executed successfully for integration {integration_id} in {execution_time:.2f} seconds."
+        f"Action '{action_id}' executed successfully for integration {integration_id or '(ephemeral)'} in {execution_time:.2f} seconds."
     )
     return result

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -6,6 +6,7 @@ import uuid
 from enum import Enum
 from typing import Optional
 
+import aiohttp
 import httpx
 import pydantic
 import stamina
@@ -112,15 +113,83 @@ def _build_synthetic_integration(state: IntegrationState) -> Integration:
     })
 
 
+def _request_error_response(action_id: Optional[str], message: str,
+                            status_code: int = status.HTTP_422_UNPROCESSABLE_ENTITY) -> JSONResponse:
+    """The one error shape shared by router-level and runner-level rejections
+    that must not publish an activity event: {"detail": {"action_id", "error"}}."""
+    return JSONResponse(
+        status_code=status_code,
+        content=jsonable_encoder({"detail": {"action_id": action_id, "error": message}}),
+    )
+
+
+def _ephemeral_error_text(exc: Exception, *, expose_message: bool) -> str:
+    """Portal-facing text for a failure on the ephemeral path.
+
+    Redaction is by provenance, not by path. Runner-authored errors
+    (expose_message=True) keep their message: the runner built it, so it
+    cannot contain draft credentials. A pydantic ValidationError exposes
+    field location and message only; pydantic 1.x never echoes the offending
+    input there. Anything raised by a handler is reduced to the curated
+    classification title plus the HTTP status, never str(exc), which can
+    embed our outgoing request (auth headers) or the source's response body.
+    """
+    if isinstance(exc, pydantic.ValidationError):
+        fields = "; ".join(
+            f"{'.'.join(str(part) for part in err['loc'])}: {err['msg']}" for err in exc.errors()
+        )
+        return f"{type(exc).__name__}: {fields}" if fields else type(exc).__name__
+    if expose_message:
+        message = exc.args[0] if exc.args else str(exc)
+        return f"{type(exc).__name__}: {message}"
+    classified = classify_error(exc)
+    if classified:
+        text = classified.title
+        if classified.status_code:
+            text = f"{text} (HTTP {classified.status_code})"
+        return text
+    return type(exc).__name__
+
+
+def _ephemeral_status_for(exc: Exception) -> int:
+    """HTTP status for a handler failure on the ephemeral path.
+
+    Forward the source system's verdict so cdip's upstream_status matches it
+    and the portal can tell bad credentials from a broken source. Three
+    shapes carry it: httpx.HTTPStatusError.response.status_code,
+    aiohttp.ClientResponseError.status, and IntegrationError.status_code
+    (an auth error with no explicit code is still a 401). Statuses below 400
+    are not failures the portal can classify (a redirect surfaced by
+    raise_for_status with redirects off is the common one) and fall back to
+    500 rather than becoming the runner's own response status.
+    """
+    source_status = None
+    if isinstance(exc, httpx.HTTPStatusError) and exc.response is not None:
+        source_status = exc.response.status_code
+    elif isinstance(exc, aiohttp.ClientResponseError):
+        source_status = exc.status
+    elif isinstance(exc, IntegrationError):
+        source_status = getattr(exc, "status_code", None)
+        if not source_status and exc.error_type == "auth":
+            source_status = status.HTTP_401_UNAUTHORIZED
+    if source_status is not None and source_status >= 400:
+        return source_status
+    return status.HTTP_500_INTERNAL_SERVER_ERROR
+
+
 async def _handle_error(
         exc: Exception, integration_id: Optional[str], action_id: Optional[str] = None,
         config_data=None, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        *, classify_heuristics: bool = False,
+        *, classify_heuristics: bool = False, expose_message: bool = False,
 ):
     """
     Log the error and return a JSON response with details. On non-ephemeral
     runs, also publishes an IntegrationActionFailed event for the activity
     feed; ephemeral runs skip the publish (no integration to log against).
+
+    expose_message marks an exception the runner itself constructed (unknown
+    action, whitelist rejection, ...). Only the ephemeral branch reads it:
+    saved-integration runs always report the full message.
     """
     is_ephemeral = ephemeral_run.get()
 
@@ -128,16 +197,10 @@ async def _handle_error(
     logger.exception(log_message)
 
     if is_ephemeral:
-        # Third-party exceptions may embed our outgoing request (with auth
-        # headers) or the source's response body. Return only the exception
-        # class name to the caller — full details stay in the server log
-        # above — and skip the activity-log publish entirely.
-        return JSONResponse(
-            status_code=status_code,
-            content=jsonable_encoder({"detail": {
-                "action_id": action_id,
-                "error": type(exc).__name__,
-            }}),
+        # No integration to log against, and draft credentials must not reach
+        # PubSub: skip the publish. Full details stay in the server log above.
+        return _request_error_response(
+            action_id, _ephemeral_error_text(exc, expose_message=expose_message), status_code,
         )
 
     # Classified errors (auth, connectivity, rate limit, bad response) get
@@ -332,7 +395,7 @@ async def _execute_action_impl(
             return await _handle_error(
                 KeyError(f"Action '{action_id}' is not supported"),
                 integration_id, action_id,
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, expose_message=True,
             )
     elif data and (data_type := data.get("event_type")):  # Push data actions
         try:  # Get the action handler by data type
@@ -341,13 +404,13 @@ async def _execute_action_impl(
             return await _handle_error(
                 ValueError(f"Data type '{data_type}' is not supported"),
                 integration_id, action_id,
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, expose_message=True,
             )
     else:
         return await _handle_error(
             ValueError("No action handler found by action ID or data type"),
             integration_id, action_id,
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, expose_message=True,
         )
 
     # Only read-only actions allowed ephemerally. cdip enforces independently.
@@ -362,7 +425,7 @@ async def _execute_action_impl(
                     "only reference and auth actions are supported."
                 ),
                 integration_id=None, action_id=action_id,
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, expose_message=True,
             )
 
     logger.info(f"Executing action '{action_id}' for integration '{integration_id or '(ephemeral)'}'...")
@@ -488,25 +551,12 @@ async def _execute_action_impl(
             classify_heuristics=True,
         )
     except Exception as e:
-        # On the ephemeral path only: forward the source system's HTTP status
-        # so cdip's upstream_status reflects what the source returned. Two
-        # shapes surface it: httpx.HTTPStatusError.response.status_code (the
-        # common raise_for_status path) and IntegrationError.status_code (a
-        # handler wrapping the source error semantically). Other exception
-        # types with a stray .response.status_code attribute do NOT propagate.
-        if is_ephemeral:
-            if isinstance(e, httpx.HTTPStatusError) and e.response is not None:
-                ephemeral_status = e.response.status_code
-            elif isinstance(e, IntegrationError) and getattr(e, "status_code", None):
-                ephemeral_status = e.status_code
-            else:
-                ephemeral_status = status.HTTP_500_INTERNAL_SERVER_ERROR
-        else:
-            ephemeral_status = status.HTTP_500_INTERNAL_SERVER_ERROR
+        # Saved-integration runs keep the historical 500; the ephemeral path
+        # forwards the source system's verdict (see _ephemeral_status_for).
         return await _handle_error(
             e, integration_id, action_id,
             config_data=handler_error_config_data,
-            status_code=ephemeral_status,
+            status_code=_ephemeral_status_for(e) if is_ephemeral else status.HTTP_500_INTERNAL_SERVER_ERROR,
             classify_heuristics=True,
         )
 

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -336,18 +336,7 @@ async def _execute_action_impl(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
         )
 
-    # Ephemeral execution is only safe for read-only actions — reference
-    # lookups (fetch options against source-system credentials) and auth checks
-    # (verify credentials, no writes). Pull/push/generic move data through
-    # Gundi on behalf of an integration that doesn't exist and stay rejected.
-    # cdip enforces the same rule independently.
-    #
-    # Auth handlers must be side-effect-free by contract: they GET /me,
-    # /status, or the equivalent and report back valid_credentials. A rogue
-    # integration that writes from its auth handler would leak from the
-    # ephemeral path (no ActivityLog row) — the runner's test suite is where
-    # that contract is enforced per integration (see the AuthActionConfiguration
-    # section in each integration fork's test_actions_side_effects.py).
+    # Only read-only actions allowed ephemerally. cdip enforces independently.
     if is_ephemeral:
         is_ephemerally_safe = isinstance(config_model, type) and issubclass(
             config_model, (ReferenceActionConfiguration, AuthActionConfiguration),

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -129,14 +129,18 @@ def _ephemeral_error_text(exc: Exception, *, expose_message: bool) -> str:
     Redaction is by provenance, not by path. Runner-authored errors
     (expose_message=True) keep their message: the runner built it, so it
     cannot contain draft credentials. A pydantic ValidationError exposes
-    field location and message only; pydantic 1.x never echoes the offending
-    input there. Anything raised by a handler is reduced to the curated
+    field locations, and the message only for pydantic's own errors
+    (dotted types such as value_error.missing, whose templates never embed
+    the input); a connector validator's ValueError text is arbitrary and is
+    replaced. Anything raised by a handler is reduced to the curated
     classification title plus the HTTP status, never str(exc), which can
     embed our outgoing request (auth headers) or the source's response body.
     """
     if isinstance(exc, pydantic.ValidationError):
         fields = "; ".join(
-            f"{'.'.join(str(part) for part in err['loc'])}: {err['msg']}" for err in exc.errors()
+            f"{'.'.join(str(part) for part in err['loc'])}: "
+            f"{err['msg'] if '.' in err.get('type', '') else 'invalid value'}"
+            for err in exc.errors()
         )
         return f"{type(exc).__name__}: {fields}" if fields else type(exc).__name__
     if expose_message:
@@ -193,15 +197,20 @@ async def _handle_error(
     """
     is_ephemeral = ephemeral_run.get()
 
+    if is_ephemeral:
+        # Draft credentials must reach neither PubSub nor the application log,
+        # which outlives and outreaches the request. Log the same redacted
+        # text the caller gets plus the traceback frames (source locations,
+        # no values); str(exc) and the traceback's final line stay out.
+        safe_text = _ephemeral_error_text(exc, expose_message=expose_message)
+        frames = "".join(traceback.format_tb(exc.__traceback__)) if exc.__traceback__ else ""
+        logger.error(
+            f"Error in ephemeral action '{action_id}': {type(exc).__name__}: {safe_text}\n{frames}".rstrip()
+        )
+        return _request_error_response(action_id, safe_text, status_code)
+
     log_message = f"Error in action '{action_id}' for integration '{integration_id}': {type(exc).__name__}: {exc}"
     logger.exception(log_message)
-
-    if is_ephemeral:
-        # No integration to log against, and draft credentials must not reach
-        # PubSub: skip the publish. Full details stay in the server log above.
-        return _request_error_response(
-            action_id, _ephemeral_error_text(exc, expose_message=expose_message), status_code,
-        )
 
     # Classified errors (auth, connectivity, rate limit, bad response) get
     # short human-first text — the portal prepends "Error running action

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -335,13 +335,22 @@ async def _skip_invalid_config(integration_id, action_id, *, error):
         )
         first_in_window = True
     if first_in_window:
-        await log_action_activity(
-            integration_id=integration_id,
-            action_id=action_id,
-            title=f"Skipping '{action_id}': configuration is missing or invalid.",
-            level=LogLevel.WARNING,
-            data={"validation_error": str(error)},
-        )
+        try:
+            await log_action_activity(
+                integration_id=integration_id,
+                action_id=action_id,
+                title=f"Skipping '{action_id}': configuration is missing or invalid.",
+                level=LogLevel.WARNING,
+                data={"validation_error": str(error)},
+            )
+        except Exception as log_error:
+            # Best-effort, like the throttle above. If the event publisher is
+            # unavailable, don't turn a benign skip into an unhandled error
+            # (500 / PubSub redelivery) -- the warning is already in the logs.
+            logger.warning(
+                f"Could not publish the skip warning for '{action_id}' "
+                f"(integration '{integration_id}'): {log_error}"
+            )
     return {"skipped": True, "reason": "invalid_configuration"}
 
 

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -25,6 +25,7 @@ from .state import IntegrationStateManager
 from .utils import find_config_for_action
 from .activity_logger import publish_event, log_action_activity, ephemeral_run
 from .errors import classify_error, format_classified_error, source_status_code, IntegrationError, IntegrationConfigurationError
+from .url_policy import validate_outbound_url
 from .gundi import EphemeralWriteBlocked
 
 _portal = GundiClient()
@@ -403,6 +404,23 @@ async def _execute_action_impl(
                 e, integration_id=None, action_id=action_id,
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
+        if settings.EPHEMERAL_BASE_URL_BLOCK_PRIVATE_ADDRESSES and integration_state.base_url:
+            # The draft base_url reaches the connector's HTTP client unchanged;
+            # with the policy on, refuse one that points the runner at a
+            # private or reserved address before any handler runs. An empty
+            # base_url is left to the connector's own guard.
+            try:
+                await validate_outbound_url(
+                    integration_state.base_url,
+                    allowlist=settings.EPHEMERAL_BASE_URL_ALLOWLIST, what="draft base_url",
+                )
+            except ValueError as e:
+                # Runner-authored: the text names the host and the resolved
+                # address, never the URL's userinfo, path or query.
+                return await _handle_error(
+                    e, integration_id=None, action_id=action_id,
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, expose_message=True,
+                )
     elif integration_id is None:
         # Request-shape error, not an action failure: reachable from the PubSub
         # route, which forwards whatever the message carried. Don't publish a

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -430,8 +430,8 @@ async def _execute_action_impl(
     # or auth handler that calls execute_action(integration_id=...) for a push
     # action gets a nested run whose is_ephemeral is False, and the whitelist
     # must still apply to it. This is the runner's own check; cdip can enforce
-    # it too once reference actions register with the "reference" type (see
-    # self_registration and REGISTER_REFERENCE_ACTIONS).
+    # it too, since reference actions register with the "reference" type (see
+    # self_registration).
     if ephemeral_run.get():
         is_ephemerally_safe = isinstance(config_model, type) and issubclass(
             config_model, (ReferenceActionConfiguration, AuthActionConfiguration),

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -161,14 +161,15 @@ def _ephemeral_error_text(exc: Exception, *, classified, expose_message: bool) -
     if expose_message or isinstance(exc, EphemeralWriteBlocked):
         message = exc.args[0] if exc.args else str(exc)
         return f"{type(exc).__name__}: {message}"
+    if isinstance(exc, IntegrationConfigurationError):
+        # The connector vouches for this message (see the class docstring),
+        # and the response is the runner's 422 regardless of any status the
+        # connector attached, so no "(HTTP n)" suffix that would contradict it.
+        return format_classified_error(classified._replace(status_code=None))
     if classified:
         # One renderer with the activity log (errors.format_classified_error),
-        # minus the message: it may hold str(exc) from the source. The one
-        # exception is IntegrationConfigurationError, whose message the
-        # connector vouches for (see its docstring).
-        return format_classified_error(
-            classified, include_message=isinstance(exc, IntegrationConfigurationError),
-        )
+        # minus the message: it may hold str(exc) from the source.
+        return format_classified_error(classified, include_message=False)
     return type(exc).__name__
 
 

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -260,10 +260,16 @@ async def execute_action(
         integration_state: Optional[IntegrationState] = None,
 ):
     if integration_id is not None and integration_state is not None:
-        return await _handle_error(
-            ValueError("Provide either integration_id or integration_state, not both"),
-            integration_id, action_id,
+        # Same reasoning as the "neither provided" branch below — request-shape
+        # error, so return a direct 422 rather than publishing an
+        # IntegrationActionFailed event against a real integration_id for what
+        # is really a malformed caller payload.
+        return JSONResponse(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content=jsonable_encoder({"detail": {
+                "action_id": action_id,
+                "error": "Provide either integration_id or integration_state, not both",
+            }}),
         )
     is_ephemeral = integration_id is None and integration_state is not None
     # OR-fold the contextvar so a nested saved-integration call inside an
@@ -300,10 +306,16 @@ async def _execute_action_impl(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
     elif integration_id is None:
-        return await _handle_error(
-            ValueError("Either integration_id or integration_state must be provided"),
-            integration_id, action_id,
+        # Request-shape error, not an action failure. Return a direct 422
+        # instead of routing through _handle_error so we don't publish a
+        # phantom IntegrationActionFailed event with integration_id=None
+        # to the activity feed for what is really a malformed caller payload.
+        return JSONResponse(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content=jsonable_encoder({"detail": {
+                "action_id": action_id,
+                "error": "Either integration_id or integration_state must be provided",
+            }}),
         )
     else:
         try:  # Get the integration details to pass it to the action handler

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -6,8 +6,6 @@ import uuid
 from enum import Enum
 from typing import Optional
 
-import aiohttp
-import httpx
 import pydantic
 import stamina
 from gundi_client_v2 import GundiClient
@@ -26,7 +24,8 @@ from .config_manager import IntegrationConfigurationManager
 from .state import IntegrationStateManager
 from .utils import find_config_for_action
 from .activity_logger import publish_event, log_action_activity, ephemeral_run
-from .errors import classify_error, format_classified_error, IntegrationError
+from .errors import classify_error, format_classified_error, source_status_code, IntegrationError
+from .gundi import EphemeralWriteBlocked
 
 _portal = GundiClient()
 config_manager = IntegrationConfigurationManager()
@@ -134,17 +133,22 @@ _SAFE_VALIDATION_MESSAGES = {
 }
 
 
-def _ephemeral_error_text(exc: Exception, *, expose_message: bool) -> str:
+def _ephemeral_error_text(exc: Exception, *, classified, expose_message: bool) -> str:
     """Portal-facing text for a failure on the ephemeral path.
 
-    Redaction is by provenance, not by path. Runner-authored errors
-    (expose_message=True) keep their message: the runner built it, so it
-    cannot contain draft credentials. A pydantic ValidationError exposes
-    field locations plus server-owned text from _SAFE_VALIDATION_MESSAGES;
-    any other message, connector-authored or not, is replaced, since
-    validators run on draft credentials. Anything raised by a handler is reduced to the curated
-    classification title plus the HTTP status, never str(exc), which can
-    embed our outgoing request (auth headers) or the source's response body.
+    Redaction is by provenance, not by path. Runner-authored errors keep
+    their message: the runner built it, so it cannot contain draft
+    credentials. That covers expose_message=True (unknown action, whitelist
+    rejection, ...) and EphemeralWriteBlocked, which is raised inside the
+    handler frame but names only the blocked operation. A pydantic
+    ValidationError exposes field locations plus server-owned text from
+    _SAFE_VALIDATION_MESSAGES; any other message, connector-authored or
+    not, is replaced, since validators run on draft credentials. Anything
+    else raised by a handler is reduced to the curated classification
+    title plus the HTTP status, never str(exc), which can embed our
+    outgoing request (auth headers) or the source's response body.
+    `classified` is the caller's classify_error verdict, or None when the
+    failure is not the handler's (see _handle_error).
     """
     if isinstance(exc, pydantic.ValidationError):
         fields = "; ".join(
@@ -153,10 +157,9 @@ def _ephemeral_error_text(exc: Exception, *, expose_message: bool) -> str:
             for err in exc.errors()
         )
         return f"{type(exc).__name__}: {fields}" if fields else type(exc).__name__
-    if expose_message:
+    if expose_message or isinstance(exc, EphemeralWriteBlocked):
         message = exc.args[0] if exc.args else str(exc)
         return f"{type(exc).__name__}: {message}"
-    classified = classify_error(exc)
     if classified:
         text = classified.title
         if classified.status_code:
@@ -165,30 +168,26 @@ def _ephemeral_error_text(exc: Exception, *, expose_message: bool) -> str:
     return type(exc).__name__
 
 
-def _ephemeral_status_for(exc: Exception) -> int:
+def _ephemeral_status_for(exc: Exception, fallback: int) -> int:
     """HTTP status for a handler failure on the ephemeral path.
 
     Forward the source system's verdict so cdip's upstream_status matches it
-    and the portal can tell bad credentials from a broken source. Three
-    shapes carry it: httpx.HTTPStatusError.response.status_code,
-    aiohttp.ClientResponseError.status, and IntegrationError.status_code
-    (an auth error with no explicit code is still a 401). Statuses below 400
-    are not failures the portal can classify (a redirect surfaced by
-    raise_for_status with redirects off is the common one) and fall back to
-    500 rather than becoming the runner's own response status.
+    and the portal can tell bad credentials from a broken source. The status
+    is read by errors.source_status_code, the same reader the classifier
+    uses, so the body text and the response status always agree; an
+    IntegrationAuthError with no explicit code is still a 401. Only 4xx/5xx
+    are forwarded: statuses below 400 are not failures the portal can
+    classify (a redirect surfaced by raise_for_status with redirects off is
+    the common one), and anything outside the HTTP range is a connector bug,
+    not a status the runner should answer with. Everything else keeps the
+    caller's `fallback` (500 for a handler exception, 504 for a timeout).
     """
-    source_status = None
-    if isinstance(exc, httpx.HTTPStatusError) and exc.response is not None:
-        source_status = exc.response.status_code
-    elif isinstance(exc, aiohttp.ClientResponseError):
-        source_status = exc.status
-    elif isinstance(exc, IntegrationError):
-        source_status = getattr(exc, "status_code", None)
-        if not source_status and exc.error_type == "auth":
-            source_status = status.HTTP_401_UNAUTHORIZED
-    if source_status is not None and source_status >= 400:
+    source_status = source_status_code(exc)
+    if source_status is None and isinstance(exc, IntegrationError) and exc.error_type == "auth":
+        return status.HTTP_401_UNAUTHORIZED
+    if source_status is not None and 400 <= source_status <= 599:
         return source_status
-    return status.HTTP_500_INTERNAL_SERVER_ERROR
+    return fallback
 
 
 async def _handle_error(
@@ -207,16 +206,35 @@ async def _handle_error(
     """
     is_ephemeral = ephemeral_run.get()
 
+    # Explicit IntegrationError subclasses classify everywhere — they're
+    # unambiguous. Heuristic classification (status codes / connection
+    # exception types) is scoped to action-handler execution failures only
+    # (classify_heuristics=True), because the same signals mean something
+    # different elsewhere — e.g. a 401 from the Gundi portal's own
+    # get_integration_details call is a portal auth problem, not a
+    # third-party provider one, and must not render as "Authentication
+    # failed" (which would misdirect operators at the provider). The same
+    # scoping applies on both branches below: a nested saved-integration
+    # call under an ephemeral context reaches the ephemeral branch with
+    # classify_heuristics=False and must not get the provider wording either.
+    classified = classify_error(exc) if (classify_heuristics or isinstance(exc, IntegrationError)) else None
+
     if is_ephemeral:
         # Draft credentials must reach neither PubSub nor the application log,
         # which outlives and outreaches the request. Log the same redacted
         # text the caller gets plus the traceback frames (source locations,
         # no values); str(exc) and the traceback's final line stay out.
-        safe_text = _ephemeral_error_text(exc, expose_message=expose_message)
+        # config_data is dropped here regardless of what the caller passed.
+        safe_text = _ephemeral_error_text(exc, classified=classified, expose_message=expose_message)
+        if classify_heuristics:
+            # A handler failure: forward the source system's verdict instead
+            # of the caller's generic status.
+            status_code = _ephemeral_status_for(exc, fallback=status_code)
+        type_name = type(exc).__name__
+        # Runner-authored and validation texts already lead with the type name.
+        logged = safe_text if safe_text.startswith(type_name) else f"{type_name}: {safe_text}"
         frames = "".join(traceback.format_tb(exc.__traceback__)) if exc.__traceback__ else ""
-        logger.error(
-            f"Error in ephemeral action '{action_id}': {type(exc).__name__}: {safe_text}\n{frames}".rstrip()
-        )
+        logger.error(f"Error in ephemeral action '{action_id}': {logged}\n{frames}".rstrip())
         return _request_error_response(action_id, safe_text, status_code)
 
     log_message = f"Error in action '{action_id}' for integration '{integration_id}': {type(exc).__name__}: {exc}"
@@ -227,16 +245,6 @@ async def _handle_error(
     # '<id>': " and truncates, so the useful part must come first. Anything
     # unclassified keeps the verbose format. Full details always remain in
     # error_traceback and the request/response fields below.
-    #
-    # Explicit IntegrationError subclasses classify everywhere — they're
-    # unambiguous. Heuristic classification (status codes / connection
-    # exception types) is scoped to action-handler execution failures only
-    # (classify_heuristics=True), because the same signals mean something
-    # different elsewhere — e.g. a 401 from the Gundi portal's own
-    # get_integration_details call is a portal auth problem, not a
-    # third-party provider one, and must not render as "Authentication
-    # failed" (which would misdirect operators at the provider).
-    classified = classify_error(exc) if (classify_heuristics or isinstance(exc, IntegrationError)) else None
     message = format_classified_error(classified) if classified else log_message
 
     error_details = {
@@ -507,9 +515,10 @@ async def _execute_action_impl(
         # noticeable without spamming a warning on every tick.
         if skippable_pull:
             return await _skip_invalid_config(integration_id, action_id, error=e)
+        # _handle_error drops config_data on the ephemeral path itself.
         return await _handle_error(
             e, integration_id, action_id,
-            config_data=None if is_ephemeral else config_data,
+            config_data=config_data,
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         )
 
@@ -529,14 +538,18 @@ async def _execute_action_impl(
         except pydantic.ValidationError as e:
             return await _handle_error(e, integration_id, action_id, data, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
-    # Reference actions are portal-invoked at interactive-fetch frequency (every
-    # dropdown open), so a handler failure is routine rather than exceptional.
-    # Like every ephemeral error, theirs must not carry the integration's
-    # configurations — which include raw auth secrets — into the published
-    # IntegrationActionFailed event or the JSON error response.
-    handler_error_config_data = None if (is_ephemeral or is_reference_action) else {
-        "configurations": [c.dict() for c in integration.configurations]
-    }
+    def handler_error_config_data():
+        # Built only on failure: serializing every configuration row on each
+        # successful run would be wasted work on the hot path. Reference
+        # actions are portal-invoked at interactive-fetch frequency (every
+        # dropdown open), so a handler failure is routine rather than
+        # exceptional, and like every ephemeral error theirs must not carry
+        # the integration's configurations — which include raw auth secrets —
+        # into the published IntegrationActionFailed event or the JSON error
+        # response. (_handle_error drops config_data on the ephemeral path.)
+        if is_reference_action:
+            return None
+        return {"configurations": [c.dict() for c in integration.configurations]}
 
     try:  # Execute the action handler with a timeout
         start_time = time.monotonic()
@@ -556,17 +569,18 @@ async def _execute_action_impl(
         return await _handle_error(
             asyncio.TimeoutError(f"Action '{action_id}' timed out"),
             integration_id, action_id,
-            config_data=handler_error_config_data,
+            config_data=handler_error_config_data(),
             status_code=status.HTTP_504_GATEWAY_TIMEOUT,
             classify_heuristics=True,
         )
     except Exception as e:
         # Saved-integration runs keep the historical 500; the ephemeral path
-        # forwards the source system's verdict (see _ephemeral_status_for).
+        # forwards the source system's verdict instead (_handle_error applies
+        # _ephemeral_status_for to handler failures).
         return await _handle_error(
             e, integration_id, action_id,
-            config_data=handler_error_config_data,
-            status_code=_ephemeral_status_for(e) if is_ephemeral else status.HTTP_500_INTERNAL_SERVER_ERROR,
+            config_data=handler_error_config_data(),
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             classify_heuristics=True,
         )
 

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -401,7 +401,9 @@ async def _execute_action_impl(
         logger.error(message)
         return await _handle_error(
             ValueError(message), integration_id, action_id,
-            config_data=None if is_ephemeral else {"configurations": [i.dict() for i in integration.configurations]},
+            # Reached only for non-ephemeral runs (see the guard above), so
+            # dumping the saved integration's configurations here is safe.
+            config_data={"configurations": [i.dict() for i in integration.configurations]},
             status_code=status.HTTP_404_NOT_FOUND
         )
 

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -6,6 +6,7 @@ import uuid
 from enum import Enum
 from typing import Optional
 
+import httpx
 import pydantic
 import stamina
 from gundi_client_v2 import GundiClient
@@ -453,15 +454,25 @@ async def _execute_action_impl(
             classify_heuristics=True,
         )
     except Exception as e:
-        # On the ephemeral path only: forward httpx.HTTPStatusError's source
-        # status so cdip's upstream_status reflects what the source returned
-        # (401/403 = bad creds vs 5xx = source-side). Saved-integration runs
-        # keep the historical 500 shape.
-        upstream_status = getattr(getattr(e, "response", None), "status_code", None)
+        # On the ephemeral path only: forward the source system's HTTP status
+        # so cdip's upstream_status reflects what the source returned. Two
+        # shapes surface it: httpx.HTTPStatusError.response.status_code (the
+        # common raise_for_status path) and IntegrationError.status_code (a
+        # handler wrapping the source error semantically). Other exception
+        # types with a stray .response.status_code attribute do NOT propagate.
+        if is_ephemeral:
+            if isinstance(e, httpx.HTTPStatusError) and e.response is not None:
+                ephemeral_status = e.response.status_code
+            elif isinstance(e, IntegrationError) and getattr(e, "status_code", None):
+                ephemeral_status = e.status_code
+            else:
+                ephemeral_status = status.HTTP_500_INTERNAL_SERVER_ERROR
+        else:
+            ephemeral_status = status.HTTP_500_INTERNAL_SERVER_ERROR
         return await _handle_error(
             e, integration_id, action_id,
             config_data=None if is_ephemeral else {"configurations": [c.dict() for c in integration.configurations]},
-            status_code=(upstream_status or status.HTTP_500_INTERNAL_SERVER_ERROR) if is_ephemeral else status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=ephemeral_status,
             classify_heuristics=True,
         )
 

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -398,7 +398,9 @@ async def _execute_action_impl(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, expose_message=True,
         )
 
-    # Only read-only actions allowed ephemerally. cdip enforces independently.
+    # Only read-only actions run ephemerally. This is the runner's own check;
+    # cdip can enforce it too once reference actions register with the
+    # "reference" type (see self_registration and REGISTER_REFERENCE_ACTIONS).
     if is_ephemeral:
         is_ephemerally_safe = isinstance(config_model, type) and issubclass(
             config_model, (ReferenceActionConfiguration, AuthActionConfiguration),

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -450,6 +450,15 @@ async def _execute_action_impl(
         except pydantic.ValidationError as e:
             return await _handle_error(e, integration_id, action_id, data, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
+    # Reference actions are portal-invoked at interactive-fetch frequency (every
+    # dropdown open), so a handler failure is routine rather than exceptional.
+    # Like every ephemeral error, theirs must not carry the integration's
+    # configurations — which include raw auth secrets — into the published
+    # IntegrationActionFailed event or the JSON error response.
+    handler_error_config_data = None if (is_ephemeral or is_reference_action) else {
+        "configurations": [c.dict() for c in integration.configurations]
+    }
+
     try:  # Execute the action handler with a timeout
         start_time = time.monotonic()
         handler_kwargs = {
@@ -468,7 +477,7 @@ async def _execute_action_impl(
         return await _handle_error(
             asyncio.TimeoutError(f"Action '{action_id}' timed out"),
             integration_id, action_id,
-            config_data=None if is_ephemeral else {"configurations": [c.dict() for c in integration.configurations]},
+            config_data=handler_error_config_data,
             status_code=status.HTTP_504_GATEWAY_TIMEOUT,
             classify_heuristics=True,
         )
@@ -490,7 +499,7 @@ async def _execute_action_impl(
             ephemeral_status = status.HTTP_500_INTERNAL_SERVER_ERROR
         return await _handle_error(
             e, integration_id, action_id,
-            config_data=None if is_ephemeral else {"configurations": [c.dict() for c in integration.configurations]},
+            config_data=handler_error_config_data,
             status_code=ephemeral_status,
             classify_heuristics=True,
         )

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -395,6 +395,12 @@ async def _execute_action_impl(
     # Get the configuration needed to execute the action
     if is_ephemeral:
         action_config = find_config_for_action(integration.configurations, action_id)
+    elif is_reference_action:
+        # Stateless by contract, so there is no row to find. Looking one up
+        # anyway would miss redis every time, and get_action_configuration
+        # reloads the integration from the portal on a miss: a portal call on
+        # every dropdown open.
+        action_config = None
     else:
         action_config = await config_manager.get_action_configuration(integration_id, action_id)
     if not skip_missing_config and not action_config and not config_overrides:
@@ -410,8 +416,8 @@ async def _execute_action_impl(
         return await _handle_error(
             ValueError(message), integration_id, action_id,
             # Reached only for non-ephemeral, non-reference runs (see the
-            # guard above), so dumping the saved integration's configurations
-            # here is safe.
+            # guard above). Those keep the pre-existing activity-log contract
+            # of attaching the saved configurations to the failure event.
             config_data={"configurations": [i.dict() for i in integration.configurations]},
             status_code=status.HTTP_404_NOT_FOUND
         )

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -404,7 +404,11 @@ async def _execute_action_impl(
         return _request_error_response(action_id, "Provide either integration_id or integration_state.")
     else:
         try:  # Get the integration details to pass it to the action handler
-            integration = await config_manager.get_integration_details(integration_id)
+            # Actions never read the webhook config; skipping it keeps a warm
+            # action run off the portal (see get_integration_details).
+            integration = await config_manager.get_integration_details(
+                integration_id, include_webhook_config=False,
+            )
         except Exception as e:
             return await _handle_error(e, integration_id, action_id)
 

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -18,7 +18,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from gundi_core.events import IntegrationActionFailed, ActionExecutionFailed, LogLevel
 
-from app.actions.core import PullActionConfiguration, ReferenceActionConfiguration
+from app.actions.core import AuthActionConfiguration, PullActionConfiguration, ReferenceActionConfiguration
 from app.api_schemas import IntegrationState
 from .config_manager import IntegrationConfigurationManager
 from .state import IntegrationStateManager
@@ -336,18 +336,27 @@ async def _execute_action_impl(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
         )
 
-    # Ephemeral execution is only safe for read-only reference actions —
-    # anything else would move data through Gundi on behalf of an integration
-    # that doesn't exist. cdip enforces the same rule independently.
+    # Ephemeral execution is only safe for read-only actions — reference
+    # lookups (fetch options against source-system credentials) and auth checks
+    # (verify credentials, no writes). Pull/push/generic move data through
+    # Gundi on behalf of an integration that doesn't exist and stay rejected.
+    # cdip enforces the same rule independently.
+    #
+    # Auth handlers must be side-effect-free by contract: they GET /me,
+    # /status, or the equivalent and report back valid_credentials. A rogue
+    # integration that writes from its auth handler would leak from the
+    # ephemeral path (no ActivityLog row) — the runner's test suite is where
+    # that contract is enforced per integration (see the AuthActionConfiguration
+    # section in each integration fork's test_actions_side_effects.py).
     if is_ephemeral:
-        is_reference_action = isinstance(config_model, type) and issubclass(
-            config_model, ReferenceActionConfiguration
+        is_ephemerally_safe = isinstance(config_model, type) and issubclass(
+            config_model, (ReferenceActionConfiguration, AuthActionConfiguration),
         )
-        if not is_reference_action:
+        if not is_ephemerally_safe:
             return await _handle_error(
                 ValueError(
-                    f"Action '{action_id}' is not a reference action; "
-                    "ephemeral execution is only supported for reference actions."
+                    f"Action '{action_id}' cannot be executed ephemerally; "
+                    "only reference and auth actions are supported."
                 ),
                 integration_id=None, action_id=action_id,
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -398,10 +398,14 @@ async def _execute_action_impl(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, expose_message=True,
         )
 
-    # Only read-only actions run ephemerally. This is the runner's own check;
-    # cdip can enforce it too once reference actions register with the
-    # "reference" type (see self_registration and REGISTER_REFERENCE_ACTIONS).
-    if is_ephemeral:
+    # Only read-only actions run under an ephemeral context. Key on the
+    # effective (OR-folded) contextvar, not this call's own flag: a reference
+    # or auth handler that calls execute_action(integration_id=...) for a push
+    # action gets a nested run whose is_ephemeral is False, and the whitelist
+    # must still apply to it. This is the runner's own check; cdip can enforce
+    # it too once reference actions register with the "reference" type (see
+    # self_registration and REGISTER_REFERENCE_ACTIONS).
+    if ephemeral_run.get():
         is_ephemerally_safe = isinstance(config_model, type) and issubclass(
             config_model, (ReferenceActionConfiguration, AuthActionConfiguration),
         )
@@ -411,7 +415,7 @@ async def _execute_action_impl(
                     f"Action '{action_id}' cannot be executed ephemerally; "
                     "only reference and auth actions are supported."
                 ),
-                integration_id=None, action_id=action_id,
+                integration_id, action_id,
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, expose_message=True,
             )
 

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -323,18 +323,8 @@ async def execute_action(
         data: dict = None, metadata: dict = None, triggered_by: Optional[str] = None,
         integration_state: Optional[IntegrationState] = None,
 ):
-    if integration_id is not None and integration_state is not None:
-        # Same reasoning as the "neither provided" branch below — request-shape
-        # error, so return a direct 422 rather than publishing an
-        # IntegrationActionFailed event against a real integration_id for what
-        # is really a malformed caller payload.
-        return JSONResponse(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            content=jsonable_encoder({"detail": {
-                "action_id": action_id,
-                "error": "Provide either integration_id or integration_state, not both",
-            }}),
-        )
+    # The router already rejects "both provided"; no other caller passes
+    # integration_state, so a saved integration_id wins here by construction.
     is_ephemeral = integration_id is None and integration_state is not None
     # OR-fold the contextvar so a nested saved-integration call inside an
     # ephemeral outer run doesn't re-enable publishing (e.g. a reference
@@ -370,17 +360,12 @@ async def _execute_action_impl(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
     elif integration_id is None:
-        # Request-shape error, not an action failure. Return a direct 422
-        # instead of routing through _handle_error so we don't publish a
-        # phantom IntegrationActionFailed event with integration_id=None
-        # to the activity feed for what is really a malformed caller payload.
-        return JSONResponse(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            content=jsonable_encoder({"detail": {
-                "action_id": action_id,
-                "error": "Either integration_id or integration_state must be provided",
-            }}),
-        )
+        # Request-shape error, not an action failure: reachable from the PubSub
+        # route, which forwards whatever the message carried. Don't publish a
+        # phantom IntegrationActionFailed with integration_id=None, but do
+        # leave a trace, since main.py acks the message regardless.
+        logger.error(f"Cannot execute action '{action_id}': no integration_id or integration_state provided.")
+        return _request_error_response(action_id, "Provide either integration_id or integration_state.")
     else:
         try:  # Get the integration details to pass it to the action handler
             integration = await config_manager.get_integration_details(integration_id)

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -453,9 +453,15 @@ async def _execute_action_impl(
             classify_heuristics=True,
         )
     except Exception as e:
+        # On the ephemeral path only: forward httpx.HTTPStatusError's source
+        # status so cdip's upstream_status reflects what the source returned
+        # (401/403 = bad creds vs 5xx = source-side). Saved-integration runs
+        # keep the historical 500 shape.
+        upstream_status = getattr(getattr(e, "response", None), "status_code", None)
         return await _handle_error(
             e, integration_id, action_id,
             config_data=None if is_ephemeral else {"configurations": [c.dict() for c in integration.configurations]},
+            status_code=(upstream_status or status.HTTP_500_INTERNAL_SERVER_ERROR) if is_ephemeral else status.HTTP_500_INTERNAL_SERVER_ERROR,
             classify_heuristics=True,
         )
 

--- a/app/services/action_scheduler.py
+++ b/app/services/action_scheduler.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional, Union, List, Annotated
 from gundi_core.commands import RunIntegrationAction
 from app import settings
 from .activity_logger import publish_event
+from .gundi import _block_if_ephemeral
 
 
 async def trigger_action(integration_id: str, action_id: str, config=None):
@@ -17,6 +18,10 @@ async def trigger_action(integration_id: str, action_id: str, config=None):
     :param config: configuration model
     :return:
     """
+    # A reference/auth handler on the ephemeral path has no saved integration
+    # to trigger against: async mode would drop the command silently and sync
+    # mode would run a portal lookup that fails. Raise instead.
+    _block_if_ephemeral("trigger_action")
     run_action_command = RunIntegrationAction(
         integration_id=integration_id,
         action_id=action_id,

--- a/app/services/activity_logger.py
+++ b/app/services/activity_logger.py
@@ -33,9 +33,9 @@ from app.services.errors import format_error_message
 logger = logging.getLogger(__name__)
 
 
-# Set for the duration of an ephemeral reference run. Every publish path
-# checks it and short-circuits — no integration to log against, and draft
-# credentials must never touch PubSub.
+# Set for the duration of an ephemeral run (reference or auth). Every publish
+# path checks it and short-circuits — no integration to log against, and
+# draft credentials must never touch PubSub.
 ephemeral_run: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "ephemeral_run", default=False
 )

--- a/app/services/activity_logger.py
+++ b/app/services/activity_logger.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import json
 import logging
 
@@ -32,6 +33,14 @@ from app.services.errors import format_error_message
 logger = logging.getLogger(__name__)
 
 
+# Set for the duration of an ephemeral reference run. Every publish path
+# checks it and short-circuits — no integration to log against, and draft
+# credentials must never touch PubSub.
+ephemeral_run: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "ephemeral_run", default=False
+)
+
+
 # Publish events for other services or system components
 @stamina.retry(
     on=(aiohttp.ClientError, asyncio.TimeoutError),
@@ -41,6 +50,8 @@ logger = logging.getLogger(__name__)
     wait_jitter=5.0
 )
 async def publish_event(event: SystemEventBaseModel, topic_name: str):
+    if ephemeral_run.get():
+        return None
     timeout_settings = aiohttp.ClientTimeout(total=20.0)
     async with aiohttp.ClientSession(
         raise_for_status=True, timeout=timeout_settings

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -52,6 +52,20 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
         integration_id=integration_id,
         action_id=action_id
     )
+    if action_config is None:
+        # The cache records this action as absent, so the lookup above did not
+        # go to the portal. An Updated event for it means the Created event
+        # was lost or arrived out of order; the portal has the row, so reload
+        # rather than apply the changes to nothing (an AttributeError here is
+        # logged and acked by process_config_event, and the change is gone).
+        integration = await config_manager._reload_integration_from_gundi(integration_id)
+        action_config = integration.get_action_config(action_id)
+    if action_config is None:
+        logger.warning(
+            f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
+            f"'{integration_id}': the portal has no configuration for it."
+        )
+        return
     for key, value in event_data.changes.items():
         setattr(action_config, key, value)
     await config_manager.set_action_configuration(

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -60,9 +60,9 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
         # One read of the cache, never a reload: every write below compares-and-
         # sets against exactly what this read saw. A second read could observe
         # a fresh tombstone written by a concurrent ActionConfigDeleted in
-        # between, and the full reload's unconditional SETs of configured
-        # actions could overwrite such a tombstone written after the reload's
-        # own fetch.
+        # between, and a reload rewrites the cache from a snapshot before
+        # returning, leaving this handler holding a token for a value that is
+        # gone.
         action_config, observed = await config_manager.read_cached_action_configuration(
             integration_id=integration_id,
             action_id=action_id

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -48,7 +48,12 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
     event_data = event.payload
     integration_id = event_data.integration_id
     action_id = event_data.alt_id
-    action_config = await config_manager.get_action_configuration(
+    # One read yields the config, or the exact sentinel that records its
+    # absence: the recovery below compares-and-sets against that sentinel, and
+    # a second read to pick it up could observe a fresh tombstone written by a
+    # concurrent ActionConfigDeleted in between and compare against the wrong
+    # generation.
+    action_config, observed = await config_manager.get_action_configuration_and_sentinel(
         integration_id=integration_id,
         action_id=action_id
     )
@@ -58,13 +63,11 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
         # was lost or arrived out of order; the portal has the row, so fetch it
         # rather than apply the changes to nothing (an AttributeError here is
         # logged and acked by process_config_event, and the change is gone).
-        # Note the exact sentinel generation first: the replacement below
-        # compares against it, so a fresh tombstone from a concurrent
-        # ActionConfigDeleted (or a newer real config) is never overwritten.
-        # Fetch only: a full reload SETs every action's config from one
-        # snapshot and would overwrite a newer value another event cached
-        # while the fetch was in flight.
-        observed = await config_manager.read_absence_sentinel(integration_id, action_id)
+        # The replacement compares against the sentinel generation observed
+        # above, so a fresh tombstone from a concurrent ActionConfigDeleted (or
+        # a newer real config) is never overwritten. Fetch only: a full reload
+        # SETs every action's config from one snapshot and would overwrite a
+        # newer value another event cached while the fetch was in flight.
         if observed is not None:
             integration = await config_manager._fetch_integration_from_gundi(integration_id)
             action_config = integration.get_action_config(action_id)
@@ -81,7 +84,7 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
                 return
         # The sentinel changed under us (a newer value, a newer tombstone, or
         # it expired): re-read and treat this like any ordinary update.
-        action_config = await config_manager.get_action_configuration(
+        action_config, _ = await config_manager.get_action_configuration_and_sentinel(
             integration_id=integration_id,
             action_id=action_id
         )

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -44,63 +44,71 @@ async def handle_action_config_created_event(event: ActionConfigCreated):
     )
 
 
+# Deliveries run concurrently, so an update is a compare-and-set loop: read,
+# apply, write only if the key still holds what was read; on a lost race,
+# re-read and apply to the value that won. Bounded so a pathological stream
+# cannot spin; a lost event is the failure mode this handler is built for, so
+# giving up is logged loudly.
+UPDATE_ATTEMPTS = 3
+
+
 async def handle_action_config_updated_event(event: ActionConfigUpdated):
     event_data = event.payload
     integration_id = event_data.integration_id
     action_id = event_data.alt_id
-    # One read of the cache, never a reload: the recovery below compares-and-
-    # sets against exactly what this read saw. A second read could observe a
-    # fresh tombstone written by a concurrent ActionConfigDeleted in between,
-    # and the full reload's unconditional SETs of configured actions could
-    # overwrite such a tombstone written after the reload's own fetch.
-    action_config, observed = await config_manager.read_cached_action_configuration(
-        integration_id=integration_id,
-        action_id=action_id
-    )
-    if action_config is None:
-        # Nothing usable cached: a recorded absence (`observed` is the exact
-        # sentinel) or nothing at all (cold cache, or an expired sentinel). An
-        # Updated event still arriving means the portal has the row and its
-        # Created event was lost or delivered out of order; fetch the row
-        # without touching the cache (a full reload would SET every action from
-        # one snapshot) and install it conditionally, so anything that landed
-        # meanwhile, a newer config or a newer tombstone, wins.
-        integration = await config_manager._fetch_integration_from_gundi(integration_id)
-        action_config = integration.get_action_config(action_id)
-        if action_config is None:
-            logger.warning(
-                f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
-                f"'{integration_id}': the portal has no configuration for it."
-            )
-            return
-        _apply_changes(action_config, event_data.changes)
-        if observed is not None:
-            installed = await config_manager.replace_absence_sentinel(
-                integration_id, action_id, config=action_config, observed=observed,
-            )
-        else:
-            installed = await config_manager.install_action_configuration_if_missing(
-                integration_id, action_id, config=action_config,
-            )
-        if installed:
-            return
-        # The key changed under us: re-read (still without reloading) and treat
-        # this like any ordinary update, or stop if it now records an absence.
-        action_config, _ = await config_manager.read_cached_action_configuration(
+    recovered_from_absence = False
+    for _ in range(UPDATE_ATTEMPTS):
+        # One read of the cache, never a reload: every write below compares-and-
+        # sets against exactly what this read saw. A second read could observe
+        # a fresh tombstone written by a concurrent ActionConfigDeleted in
+        # between, and the full reload's unconditional SETs of configured
+        # actions could overwrite such a tombstone written after the reload's
+        # own fetch.
+        action_config, observed = await config_manager.read_cached_action_configuration(
             integration_id=integration_id,
             action_id=action_id
         )
         if action_config is None:
-            logger.warning(
-                f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
-                f"'{integration_id}': it was deleted while the update was being recovered."
+            if recovered_from_absence:
+                # A tombstone (or nothing) after we already recovered once means
+                # a newer delete, or the sentinel expired under us: stop rather
+                # than fetch again and risk installing over a newer delete.
+                logger.warning(
+                    f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
+                    f"'{integration_id}': its cached configuration went away while the update was being applied."
+                )
+                return
+            # Nothing usable cached: a recorded absence (`observed` is the exact
+            # sentinel) or nothing at all (cold cache, or an expired sentinel).
+            # An Updated event still arriving means the portal has the row and
+            # its Created event was lost or delivered out of order; fetch the
+            # row without touching the cache (a full reload would SET every
+            # action from one snapshot) and install it conditionally below.
+            recovered_from_absence = True
+            integration = await config_manager._fetch_integration_from_gundi(integration_id)
+            action_config = integration.get_action_config(action_id)
+            if action_config is None:
+                logger.warning(
+                    f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
+                    f"'{integration_id}': the portal has no configuration for it."
+                )
+                return
+        _apply_changes(action_config, event_data.changes)
+        if observed is None:
+            written = await config_manager.install_action_configuration_if_missing(
+                integration_id, action_id, config=action_config,
             )
+        else:
+            written = await config_manager.replace_cached_entry(
+                integration_id, action_id, config=action_config, observed=observed,
+            )
+        if written:
             return
-    _apply_changes(action_config, event_data.changes)
-    await config_manager.set_action_configuration(
-        integration_id=integration_id,
-        action_id=action_id,
-        config=action_config
+        # The key changed under us (a newer value, a newer tombstone, or it
+        # expired): go round and apply this event's changes to what is there now.
+    logger.warning(
+        f"Gave up applying ActionConfigUpdated for action '{action_id}' of integration "
+        f"'{integration_id}' after {UPDATE_ATTEMPTS} attempts: the cached configuration kept changing underneath it."
     )
 
 

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -60,22 +60,43 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
         # logged and acked by process_config_event, and the change is gone).
         # Fetch only: a full reload SETs every action's config from one
         # snapshot and would overwrite a newer value another event cached
-        # while the fetch was in flight. The set below writes just this key.
+        # while the fetch was in flight.
         integration = await config_manager._fetch_integration_from_gundi(integration_id)
         action_config = integration.get_action_config(action_id)
-    if action_config is None:
-        logger.warning(
-            f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
-            f"'{integration_id}': the portal has no configuration for it."
+        if action_config is None:
+            logger.warning(
+                f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
+                f"'{integration_id}': the portal has no configuration for it."
+            )
+            return
+        _apply_changes(action_config, event_data.changes)
+        # Replace the sentinel only if it is still there. Deliveries run
+        # concurrently, so a second recovery for this action may have written
+        # a newer value while this one was fetching; if so, fall through and
+        # apply this event's changes to that value like any ordinary update.
+        if await config_manager.replace_absence_sentinel(integration_id, action_id, config=action_config):
+            return
+        action_config = await config_manager.get_action_configuration(
+            integration_id=integration_id,
+            action_id=action_id
         )
-        return
-    for key, value in event_data.changes.items():
-        setattr(action_config, key, value)
+        if action_config is None:
+            logger.warning(
+                f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
+                f"'{integration_id}': its configuration disappeared while recovering it."
+            )
+            return
+    _apply_changes(action_config, event_data.changes)
     await config_manager.set_action_configuration(
         integration_id=integration_id,
         action_id=action_id,
         config=action_config
     )
+
+
+def _apply_changes(action_config, changes: dict) -> None:
+    for key, value in changes.items():
+        setattr(action_config, key, value)
 
 
 async def handle_action_config_deleted_event(event: ActionConfigDeleted):

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -47,8 +47,8 @@ async def handle_action_config_created_event(event: ActionConfigCreated):
 # Deliveries run concurrently, so an update is a compare-and-set loop: read,
 # apply, write only if the key still holds what was read; on a lost race,
 # re-read and apply to the value that won. Bounded so a pathological stream
-# cannot spin; a lost event is the failure mode this handler is built for, so
-# giving up is logged loudly.
+# cannot spin. Giving up drops the key (the next lookup rebuilds it from the
+# portal) rather than leaving a stale permanent config behind an acked event.
 UPDATE_ATTEMPTS = 3
 
 
@@ -56,8 +56,7 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
     event_data = event.payload
     integration_id = event_data.integration_id
     action_id = event_data.alt_id
-    recovered_from_absence = False
-    for _ in range(UPDATE_ATTEMPTS):
+    for attempt in range(UPDATE_ATTEMPTS):
         # One read of the cache, never a reload: every write below compares-and-
         # sets against exactly what this read saw. A second read could observe
         # a fresh tombstone written by a concurrent ActionConfigDeleted in
@@ -69,10 +68,12 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
             action_id=action_id
         )
         if action_config is None:
-            if recovered_from_absence:
-                # A tombstone (or nothing) after we already recovered once means
-                # a newer delete, or the sentinel expired under us: stop rather
-                # than fetch again and risk installing over a newer delete.
+            if attempt > 0:
+                # An absence seen after a failed write (a tombstone, or nothing)
+                # means a newer delete, or the sentinel expired under us. Stop:
+                # fetching the portal now and installing over that tombstone is
+                # exactly the delete race this handler exists to prevent. Only
+                # an absence on the first read is a recovery.
                 logger.warning(
                     f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
                     f"'{integration_id}': its cached configuration went away while the update was being applied."
@@ -84,7 +85,6 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
             # its Created event was lost or delivered out of order; fetch the
             # row without touching the cache (a full reload would SET every
             # action from one snapshot) and install it conditionally below.
-            recovered_from_absence = True
             integration = await config_manager._fetch_integration_from_gundi(integration_id)
             action_config = integration.get_action_config(action_id)
             if action_config is None:
@@ -106,9 +106,15 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
             return
         # The key changed under us (a newer value, a newer tombstone, or it
         # expired): go round and apply this event's changes to what is there now.
+    # process_config_event acks the event whatever happens here, so a stale
+    # permanent config left behind would never self-heal. Drop the key instead:
+    # the next lookup misses and rebuilds it from the portal, which holds the
+    # truth about whatever won the race.
+    await config_manager.invalidate_action_configuration(integration_id, action_id)
     logger.warning(
         f"Gave up applying ActionConfigUpdated for action '{action_id}' of integration "
-        f"'{integration_id}' after {UPDATE_ATTEMPTS} attempts: the cached configuration kept changing underneath it."
+        f"'{integration_id}' after {UPDATE_ATTEMPTS} attempts: the cached configuration kept changing "
+        "underneath it. Dropped the cached entry; the next lookup rebuilds it from the portal."
     )
 
 

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -58,24 +58,29 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
         # was lost or arrived out of order; the portal has the row, so fetch it
         # rather than apply the changes to nothing (an AttributeError here is
         # logged and acked by process_config_event, and the change is gone).
+        # Note the exact sentinel generation first: the replacement below
+        # compares against it, so a fresh tombstone from a concurrent
+        # ActionConfigDeleted (or a newer real config) is never overwritten.
         # Fetch only: a full reload SETs every action's config from one
         # snapshot and would overwrite a newer value another event cached
         # while the fetch was in flight.
-        integration = await config_manager._fetch_integration_from_gundi(integration_id)
-        action_config = integration.get_action_config(action_id)
-        if action_config is None:
-            logger.warning(
-                f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
-                f"'{integration_id}': the portal has no configuration for it."
-            )
-            return
-        _apply_changes(action_config, event_data.changes)
-        # Replace the sentinel only if it is still there. Deliveries run
-        # concurrently, so a second recovery for this action may have written
-        # a newer value while this one was fetching; if so, fall through and
-        # apply this event's changes to that value like any ordinary update.
-        if await config_manager.replace_absence_sentinel(integration_id, action_id, config=action_config):
-            return
+        observed = await config_manager.read_absence_sentinel(integration_id, action_id)
+        if observed is not None:
+            integration = await config_manager._fetch_integration_from_gundi(integration_id)
+            action_config = integration.get_action_config(action_id)
+            if action_config is None:
+                logger.warning(
+                    f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
+                    f"'{integration_id}': the portal has no configuration for it."
+                )
+                return
+            _apply_changes(action_config, event_data.changes)
+            if await config_manager.replace_absence_sentinel(
+                    integration_id, action_id, config=action_config, observed=observed,
+            ):
+                return
+        # The sentinel changed under us (a newer value, a newer tombstone, or
+        # it expired): re-read and treat this like any ordinary update.
         action_config = await config_manager.get_action_configuration(
             integration_id=integration_id,
             action_id=action_id
@@ -83,7 +88,7 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
         if action_config is None:
             logger.warning(
                 f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
-                f"'{integration_id}': its configuration disappeared while recovering it."
+                f"'{integration_id}': it was deleted while the update was being recovered."
             )
             return
     _apply_changes(action_config, event_data.changes)

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -61,10 +61,16 @@ async def handle_action_config_created_event(event: ActionConfigCreated):
     else:
         written = await config_manager.replace_cached_entry(integration_id, action_id, config=row, observed=observed)
     if not written:
-        logger.info(
+        # The winner is later in cache time, not necessarily newer portal state
+        # (a delayed older Updated can land after the read above). Reconcile the
+        # way the Updated handler does: fresh portal row over the newest token,
+        # bounded, stopping if the winner is a tombstone.
+        reconciled, outcome = await _reconcile_from_portal(integration_id, action_id)
+        message = (
             f"ActionConfigCreated for action '{action_id}' of integration '{integration_id}' "
-            "found a newer cached value and left it in place."
+            f"lost to a concurrent write; {outcome}."
         )
+        (logger.info if reconciled else logger.error)(message)
 
 
 # Deliveries run concurrently, so an update is a compare-and-set loop: read,
@@ -157,9 +163,10 @@ async def _reconcile_from_portal(integration_id, action_id):
     """Write the portal's truth over exactly what the cache holds, retrying
     against the newest token when a competing write lands in between (that
     write is later in cache time, not necessarily newer portal state), for
-    up to UPDATE_ATTEMPTS. The portal row is read once: it is final. Returns
-    (reconciled, description) for the log."""
-    integration = None
+    up to UPDATE_ATTEMPTS. The portal is re-read on every retry: the write
+    that won may have come from a newer event whose row is also in the portal
+    now, and reusing the first snapshot would write stale state over it.
+    Returns (reconciled, description) for the log."""
     for _ in range(UPDATE_ATTEMPTS):
         action_config, observed = await config_manager.read_cached_action_configuration(
             integration_id=integration_id,
@@ -171,8 +178,7 @@ async def _reconcile_from_portal(integration_id, action_id):
             # a possibly stale portal row and installing it over that tombstone
             # is the delete race this handler exists to prevent, so stop here.
             return True, "the cache now records no configuration for it, so it was left alone"
-        if integration is None:
-            integration = await config_manager._fetch_integration_from_gundi(integration_id)
+        integration = await config_manager._fetch_integration_from_gundi(integration_id)
         row = integration.get_action_config(action_id)
         if row is None:
             written = await config_manager.replace_cached_entry_with_absence(integration_id, action_id, observed=observed)

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -136,36 +136,54 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
     # concurrent delete wrote a moment ago, and a later reload whose fetch
     # predates that delete would then resurrect the config. If this write
     # loses too, the cache holds a value newer than everything we saw; leave it.
-    outcome = await _reconcile_from_portal(integration_id, action_id)
-    logger.warning(
+    reconciled, outcome = await _reconcile_from_portal(integration_id, action_id)
+    message = (
         f"Gave up applying ActionConfigUpdated for action '{action_id}' of integration "
         f"'{integration_id}' after {UPDATE_ATTEMPTS} attempts: the cached configuration kept changing "
         f"underneath it; {outcome}."
     )
-
-
-async def _reconcile_from_portal(integration_id, action_id) -> str:
-    """One conditional write of the portal's truth over exactly what the cache
-    holds now. Returns a short description of what happened, for the log."""
-    action_config, observed = await config_manager.read_cached_action_configuration(
-        integration_id=integration_id,
-        action_id=action_id
-    )
-    if action_config is None:
-        # The same rule as inside the loop: no cached configuration after a
-        # failed write means a newer delete (or an expired entry). Fetching a
-        # possibly stale portal row and installing it over that tombstone is
-        # the delete race this handler exists to prevent, so stop here.
-        return "the cache now records no configuration for it, so it was left alone"
-    integration = await config_manager._fetch_integration_from_gundi(integration_id)
-    row = integration.get_action_config(action_id)
-    if row is None:
-        written = await config_manager.replace_cached_entry_with_absence(integration_id, action_id, observed=observed)
+    if reconciled:
+        logger.warning(message)
     else:
-        written = await config_manager.replace_cached_entry(integration_id, action_id, config=row, observed=observed)
-    if written:
-        return "reconciled it from the portal instead"
-    return "the reconciling write from the portal lost as well, leaving the newer cached value in place"
+        # A competing write that beat the reconciliation is only later in cache
+        # time, not necessarily newer portal state (a delayed older Updated can
+        # land after the final portal row was fetched), and the endpoint acks
+        # this event regardless. Nothing later repairs a stale permanent key,
+        # so say so where it will be seen.
+        logger.error(message)
+
+
+async def _reconcile_from_portal(integration_id, action_id):
+    """Write the portal's truth over exactly what the cache holds, retrying
+    against the newest token when a competing write lands in between (that
+    write is later in cache time, not necessarily newer portal state), for
+    up to UPDATE_ATTEMPTS. The portal row is read once: it is final. Returns
+    (reconciled, description) for the log."""
+    integration = None
+    for _ in range(UPDATE_ATTEMPTS):
+        action_config, observed = await config_manager.read_cached_action_configuration(
+            integration_id=integration_id,
+            action_id=action_id
+        )
+        if action_config is None:
+            # The same rule as inside the loop: no cached configuration after a
+            # failed write means a newer delete (or an expired entry). Fetching
+            # a possibly stale portal row and installing it over that tombstone
+            # is the delete race this handler exists to prevent, so stop here.
+            return True, "the cache now records no configuration for it, so it was left alone"
+        if integration is None:
+            integration = await config_manager._fetch_integration_from_gundi(integration_id)
+        row = integration.get_action_config(action_id)
+        if row is None:
+            written = await config_manager.replace_cached_entry_with_absence(integration_id, action_id, observed=observed)
+        else:
+            written = await config_manager.replace_cached_entry(integration_id, action_id, config=row, observed=observed)
+        if written:
+            return True, "reconciled it from the portal instead"
+    return False, (
+        f"the reconciling write from the portal lost {UPDATE_ATTEMPTS} times as well, so the cached "
+        "configuration may be stale until the next event for this action"
+    )
 
 
 def _apply_changes(action_config, changes: dict) -> None:

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -48,43 +48,45 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
     event_data = event.payload
     integration_id = event_data.integration_id
     action_id = event_data.alt_id
-    # One read yields the config, or the exact sentinel that records its
-    # absence: the recovery below compares-and-sets against that sentinel, and
-    # a second read to pick it up could observe a fresh tombstone written by a
-    # concurrent ActionConfigDeleted in between and compare against the wrong
-    # generation.
-    action_config, observed = await config_manager.get_action_configuration_and_sentinel(
+    # One read of the cache, never a reload: the recovery below compares-and-
+    # sets against exactly what this read saw. A second read could observe a
+    # fresh tombstone written by a concurrent ActionConfigDeleted in between,
+    # and the full reload's unconditional SETs of configured actions could
+    # overwrite such a tombstone written after the reload's own fetch.
+    action_config, observed = await config_manager.read_cached_action_configuration(
         integration_id=integration_id,
         action_id=action_id
     )
     if action_config is None:
-        # The cache records this action as absent, so the lookup above did not
-        # go to the portal. An Updated event for it means the Created event
-        # was lost or arrived out of order; the portal has the row, so fetch it
-        # rather than apply the changes to nothing (an AttributeError here is
-        # logged and acked by process_config_event, and the change is gone).
-        # The replacement compares against the sentinel generation observed
-        # above, so a fresh tombstone from a concurrent ActionConfigDeleted (or
-        # a newer real config) is never overwritten. Fetch only: a full reload
-        # SETs every action's config from one snapshot and would overwrite a
-        # newer value another event cached while the fetch was in flight.
+        # Nothing usable cached: a recorded absence (`observed` is the exact
+        # sentinel) or nothing at all (cold cache, or an expired sentinel). An
+        # Updated event still arriving means the portal has the row and its
+        # Created event was lost or delivered out of order; fetch the row
+        # without touching the cache (a full reload would SET every action from
+        # one snapshot) and install it conditionally, so anything that landed
+        # meanwhile, a newer config or a newer tombstone, wins.
+        integration = await config_manager._fetch_integration_from_gundi(integration_id)
+        action_config = integration.get_action_config(action_id)
+        if action_config is None:
+            logger.warning(
+                f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
+                f"'{integration_id}': the portal has no configuration for it."
+            )
+            return
+        _apply_changes(action_config, event_data.changes)
         if observed is not None:
-            integration = await config_manager._fetch_integration_from_gundi(integration_id)
-            action_config = integration.get_action_config(action_id)
-            if action_config is None:
-                logger.warning(
-                    f"Ignoring ActionConfigUpdated for action '{action_id}' of integration "
-                    f"'{integration_id}': the portal has no configuration for it."
-                )
-                return
-            _apply_changes(action_config, event_data.changes)
-            if await config_manager.replace_absence_sentinel(
-                    integration_id, action_id, config=action_config, observed=observed,
-            ):
-                return
-        # The sentinel changed under us (a newer value, a newer tombstone, or
-        # it expired): re-read and treat this like any ordinary update.
-        action_config, _ = await config_manager.get_action_configuration_and_sentinel(
+            installed = await config_manager.replace_absence_sentinel(
+                integration_id, action_id, config=action_config, observed=observed,
+            )
+        else:
+            installed = await config_manager.install_action_configuration_if_missing(
+                integration_id, action_id, config=action_config,
+            )
+        if installed:
+            return
+        # The key changed under us: re-read (still without reloading) and treat
+        # this like any ordinary update, or stop if it now records an absence.
+        action_config, _ = await config_manager.read_cached_action_configuration(
             integration_id=integration_id,
             action_id=action_id
         )

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -36,12 +36,35 @@ async def handle_integration_deleted_event(event: IntegrationDeleted):
 
 
 async def handle_action_config_created_event(event: ActionConfigCreated):
-    action_config = event.payload
-    await config_manager.set_action_configuration(
-        integration_id=action_config.integration,
-        action_id=action_config.action.value,
-        config=action_config
+    # Not the payload, and not unconditionally: a delayed Created can arrive
+    # after an ActionConfigDeleted installed a fresh tombstone, and a plain SET
+    # of the payload would resurrect the deleted row permanently. The portal is
+    # read after everything, so its row (or its absence) is the truth, and it
+    # is installed only over exactly what the cache held when we looked.
+    integration_id = event.payload.integration
+    action_id = event.payload.action.value
+    _, observed = await config_manager.read_cached_action_configuration(
+        integration_id=integration_id,
+        action_id=action_id
     )
+    integration = await config_manager._fetch_integration_from_gundi(integration_id)
+    row = integration.get_action_config(action_id)
+    if row is None:
+        # Deleted again already; the cache holds (or will get) the tombstone.
+        logger.info(
+            f"Ignoring ActionConfigCreated for action '{action_id}' of integration "
+            f"'{integration_id}': the portal no longer has a configuration for it."
+        )
+        return
+    if observed is None:
+        written = await config_manager.install_action_configuration_if_missing(integration_id, action_id, config=row)
+    else:
+        written = await config_manager.replace_cached_entry(integration_id, action_id, config=row, observed=observed)
+    if not written:
+        logger.info(
+            f"ActionConfigCreated for action '{action_id}' of integration '{integration_id}' "
+            "found a newer cached value and left it in place."
+        )
 
 
 # Deliveries run concurrently, so an update is a compare-and-set loop: read,

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -47,8 +47,8 @@ async def handle_action_config_created_event(event: ActionConfigCreated):
 # Deliveries run concurrently, so an update is a compare-and-set loop: read,
 # apply, write only if the key still holds what was read; on a lost race,
 # re-read and apply to the value that won. Bounded so a pathological stream
-# cannot spin. Giving up drops the key (the next lookup rebuilds it from the
-# portal) rather than leaving a stale permanent config behind an acked event.
+# cannot spin. Giving up reconciles from the portal, still conditionally,
+# rather than leaving a stale permanent config behind an acked event.
 UPDATE_ATTEMPTS = 3
 
 
@@ -107,15 +107,35 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
         # The key changed under us (a newer value, a newer tombstone, or it
         # expired): go round and apply this event's changes to what is there now.
     # process_config_event acks the event whatever happens here, so a stale
-    # permanent config left behind would never self-heal. Drop the key instead:
-    # the next lookup misses and rebuilds it from the portal, which holds the
-    # truth about whatever won the race.
-    await config_manager.invalidate_action_configuration(integration_id, action_id)
+    # permanent config left behind would never self-heal. Reconcile from the
+    # portal, which holds the truth about whatever won the race, but still
+    # conditionally: a blind write or a DEL could clobber a tombstone a
+    # concurrent delete wrote a moment ago, and a later reload whose fetch
+    # predates that delete would then resurrect the config. If this write
+    # loses too, the cache holds a value newer than everything we saw; leave it.
+    reconciled = await _reconcile_from_portal(integration_id, action_id)
     logger.warning(
         f"Gave up applying ActionConfigUpdated for action '{action_id}' of integration "
         f"'{integration_id}' after {UPDATE_ATTEMPTS} attempts: the cached configuration kept changing "
-        "underneath it. Dropped the cached entry; the next lookup rebuilds it from the portal."
+        f"underneath it. Reconciled the cache from the portal instead"
+        + ("." if reconciled else "; that write lost as well, leaving the newer cached value in place.")
     )
+
+
+async def _reconcile_from_portal(integration_id, action_id) -> bool:
+    _, observed = await config_manager.read_cached_action_configuration(
+        integration_id=integration_id,
+        action_id=action_id
+    )
+    integration = await config_manager._fetch_integration_from_gundi(integration_id)
+    row = integration.get_action_config(action_id)
+    if row is None:
+        if observed is None:
+            return True  # nothing cached and nothing in the portal: already reconciled
+        return await config_manager.replace_cached_entry_with_absence(integration_id, action_id, observed=observed)
+    if observed is None:
+        return await config_manager.install_action_configuration_if_missing(integration_id, action_id, config=row)
+    return await config_manager.replace_cached_entry(integration_id, action_id, config=row, observed=observed)
 
 
 def _apply_changes(action_config, changes: dict) -> None:

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -113,29 +113,36 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
     # concurrent delete wrote a moment ago, and a later reload whose fetch
     # predates that delete would then resurrect the config. If this write
     # loses too, the cache holds a value newer than everything we saw; leave it.
-    reconciled = await _reconcile_from_portal(integration_id, action_id)
+    outcome = await _reconcile_from_portal(integration_id, action_id)
     logger.warning(
         f"Gave up applying ActionConfigUpdated for action '{action_id}' of integration "
         f"'{integration_id}' after {UPDATE_ATTEMPTS} attempts: the cached configuration kept changing "
-        f"underneath it. Reconciled the cache from the portal instead"
-        + ("." if reconciled else "; that write lost as well, leaving the newer cached value in place.")
+        f"underneath it; {outcome}."
     )
 
 
-async def _reconcile_from_portal(integration_id, action_id) -> bool:
-    _, observed = await config_manager.read_cached_action_configuration(
+async def _reconcile_from_portal(integration_id, action_id) -> str:
+    """One conditional write of the portal's truth over exactly what the cache
+    holds now. Returns a short description of what happened, for the log."""
+    action_config, observed = await config_manager.read_cached_action_configuration(
         integration_id=integration_id,
         action_id=action_id
     )
+    if action_config is None:
+        # The same rule as inside the loop: no cached configuration after a
+        # failed write means a newer delete (or an expired entry). Fetching a
+        # possibly stale portal row and installing it over that tombstone is
+        # the delete race this handler exists to prevent, so stop here.
+        return "the cache now records no configuration for it, so it was left alone"
     integration = await config_manager._fetch_integration_from_gundi(integration_id)
     row = integration.get_action_config(action_id)
     if row is None:
-        if observed is None:
-            return True  # nothing cached and nothing in the portal: already reconciled
-        return await config_manager.replace_cached_entry_with_absence(integration_id, action_id, observed=observed)
-    if observed is None:
-        return await config_manager.install_action_configuration_if_missing(integration_id, action_id, config=row)
-    return await config_manager.replace_cached_entry(integration_id, action_id, config=row, observed=observed)
+        written = await config_manager.replace_cached_entry_with_absence(integration_id, action_id, observed=observed)
+    else:
+        written = await config_manager.replace_cached_entry(integration_id, action_id, config=row, observed=observed)
+    if written:
+        return "reconciled it from the portal instead"
+    return "the reconciling write from the portal lost as well, leaving the newer cached value in place"
 
 
 def _apply_changes(action_config, changes: dict) -> None:

--- a/app/services/config_events_consumer.py
+++ b/app/services/config_events_consumer.py
@@ -55,10 +55,13 @@ async def handle_action_config_updated_event(event: ActionConfigUpdated):
     if action_config is None:
         # The cache records this action as absent, so the lookup above did not
         # go to the portal. An Updated event for it means the Created event
-        # was lost or arrived out of order; the portal has the row, so reload
+        # was lost or arrived out of order; the portal has the row, so fetch it
         # rather than apply the changes to nothing (an AttributeError here is
         # logged and acked by process_config_event, and the change is gone).
-        integration = await config_manager._reload_integration_from_gundi(integration_id)
+        # Fetch only: a full reload SETs every action's config from one
+        # snapshot and would overwrite a newer value another event cached
+        # while the fetch was in flight. The set below writes just this key.
+        integration = await config_manager._fetch_integration_from_gundi(integration_id)
         action_config = integration.get_action_config(action_id)
     if action_config is None:
         logger.warning(

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -144,11 +144,24 @@ class IntegrationConfigurationManager:
                 data = await self.db_client.get(key)
         if data:
             if data in (_ABSENCE_SENTINEL, _ABSENCE_SENTINEL.encode()):
+                await self._expire_legacy_sentinel(key)
                 return None  # cached absence: the portal has no config for this action
             return IntegrationActionConfiguration.parse_raw(data)
         # If not found in the redis db, try reloading data from Gundi API
         integration_details = await self._reload_integration_from_gundi(integration_id, ttl)
         return integration_details.get_action_config(action_id)
+
+    async def _expire_legacy_sentinel(self, key: str) -> None:
+        # Sentinels written before they carried a TTL are permanent, and the
+        # reload's NX write never touches an existing key, so an integration
+        # already hit by the lost-event bug would stay "unconfigured" after
+        # rollout. Attach the TTL on a hit instead: one TTL round trip per
+        # sentinel hit, and a write only on the first hit after rollout. Can
+        # go once every deployment has run a release with sentinel TTLs.
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
+            with attempt:
+                if await self.db_client.ttl(key) == -1:
+                    await self.db_client.expire(key, ACTION_ABSENCE_SENTINEL_TTL_SECONDS)
 
     async def get_webhook_configuration(self, integration_id: str, ttl=None) -> Optional[WebhookConfiguration]:
         key = self._get_webhook_config_key(integration_id)

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -166,10 +166,14 @@ return 1
 # to overwrite an absence sentinel from another epoch, or from this epoch with a
 # generation above the one the reload took before its fetch: that is a
 # concurrent ActionConfigDeleted's tombstone, newer than the snapshot, and an
-# unconditional SET would resurrect the deleted config permanently. Anything
-# else (a real config, an older sentinel, nothing) is replaced by the snapshot,
-# which is the portal's truth as of the fetch. ARGV[2] is the reload's
-# "<epoch>:<n>" token.
+# unconditional SET would resurrect the deleted config permanently. While
+# generations are enabled (ARGV[4] == '1') a bare "null" is preserved as well:
+# enabling the setting is itself a rolling restart, and a not-yet-enabled
+# replica writes bare tombstones that cannot be ordered against the reload's
+# generation; a bare sentinel that merely predates the fetch expires on its
+# TTL and the next miss reloads. Anything else (a real config, an older
+# generated sentinel, nothing) is replaced by the snapshot, which is the
+# portal's truth as of the fetch. ARGV[2] is the reload's "<epoch>:<n>" token.
 _WRITE_SNAPSHOT_CONFIG_SCRIPT = """
 local current = redis.call('GET', KEYS[1])
 if current then
@@ -179,6 +183,8 @@ if current then
         if epoch ~= fetch_epoch or tonumber(generation) > tonumber(fetch_generation) then
             return 0
         end
+    elseif ARGV[4] == '1' and string.sub(current, 1, 4) == 'null' then
+        return 0
     end
 end
 if ARGV[3] == '' then
@@ -252,7 +258,8 @@ class IntegrationConfigurationManager:
             configured.add(config.action.value)
             config_key = self._get_action_config_key(integration_id, config.action.value)
             await self.db_client.eval(
-                _WRITE_SNAPSHOT_CONFIG_SCRIPT, 1, config_key, config.json(), fetch_generation, ttl if ttl is not None else "",
+                _WRITE_SNAPSHOT_CONFIG_SCRIPT, 1, config_key, config.json(), fetch_generation,
+                ttl if ttl is not None else "", "1" if settings.CONFIG_CACHE_SENTINEL_GENERATIONS else "0",
             )
         # Sentinels are written only if the key is missing, so they never
         # replace a key that is already there. A reload reads the portal, then
@@ -309,14 +316,12 @@ class IntegrationConfigurationManager:
         # Answer from the cache, not from the snapshot: a delete that landed
         # during the reload's fetch left a tombstone the snapshot write
         # preserved, and returning the fetched row anyway would have the
-        # runner execute the deleted action once.
+        # runner execute the deleted action once. Nothing cached at all right
+        # after the reload means the key changed under it (an IntegrationDeleted
+        # dropped every action key, or a tombstone expired); the snapshot is
+        # stale either way, so that reads as absent too.
         config, _ = await self.read_cached_action_configuration(integration_id, action_id)
-        if config is not None:
-            return config
-        cached_absence = _ is not None
-        # Nothing cached at all (the reload's own write raced with something
-        # that removed the key): the snapshot is the best answer left.
-        return None if cached_absence else integration_details.get_action_config(action_id)
+        return config
 
     async def read_cached_action_configuration(
             self, integration_id: str, action_id: str,

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -306,7 +306,17 @@ class IntegrationConfigurationManager:
             return config  # a cached config, or a cached absence
         # If not found in the redis db, try reloading data from Gundi API
         integration_details = await self._reload_integration_from_gundi(integration_id, ttl)
-        return integration_details.get_action_config(action_id)
+        # Answer from the cache, not from the snapshot: a delete that landed
+        # during the reload's fetch left a tombstone the snapshot write
+        # preserved, and returning the fetched row anyway would have the
+        # runner execute the deleted action once.
+        config, _ = await self.read_cached_action_configuration(integration_id, action_id)
+        if config is not None:
+            return config
+        cached_absence = _ is not None
+        # Nothing cached at all (the reload's own write raced with something
+        # that removed the key): the snapshot is the best answer left.
+        return None if cached_absence else integration_details.get_action_config(action_id)
 
     async def read_cached_action_configuration(
             self, integration_id: str, action_id: str,
@@ -320,9 +330,9 @@ class IntegrationConfigurationManager:
         saw (replace_cached_entry / install_action_configuration_if_missing).
         The token must come from the very read that established the state,
         since a second read could observe a fresh tombstone from a concurrent
-        ActionConfigDeleted; and the full reload is off limits here because its
-        unconditional SETs of configured actions would overwrite a tombstone
-        written after the reload's own fetch."""
+        ActionConfigDeleted; and the full reload is off limits here because it
+        rewrites the cache from a snapshot before returning, so the token this
+        caller holds would no longer describe what the key contains."""
         key = self._get_action_config_key(integration_id, action_id)
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -72,9 +72,18 @@ class IntegrationConfigurationManager:
                 configured.add(config.action.value)
                 config_key = self._get_action_config_key(integration_id, config.action.value)
                 await self.db_client.set(config_key, config.json(), ttl)
+            # Sentinels are written with NX so they never replace a key that is
+            # already there. A reload reads the portal, then writes; if an
+            # ActionConfigCreated event for one of these actions lands in
+            # between, its config would otherwise be overwritten with a
+            # permanent "null" that no later event corrects. With NX the event's
+            # write wins in either order: written first, it is left alone;
+            # written after, it replaces the sentinel as a plain SET.
             for action in integration_details.type.actions or []:
                 if action.value not in configured:
-                    await self.db_client.set(self._get_action_config_key(integration_id, action.value), _ABSENCE_SENTINEL, ttl)
+                    await self.db_client.set(
+                        self._get_action_config_key(integration_id, action.value), _ABSENCE_SENTINEL, ttl, nx=True,
+                    )
             await self._cache_webhook_configuration(integration_id, integration_details.webhook_configuration, ttl)
             return integration_details
 

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -4,20 +4,27 @@ from typing import Optional
 
 import pydantic
 import stamina
-import httpx
 import redis.asyncio as redis
+# Imported by name, not as `redis.RedisError`: tests replace the `redis` module
+# attribute with a mock, and an except clause naming a mock attribute would
+# raise TypeError instead of catching.
 from redis.exceptions import RedisError
 from gundi_core.schemas.v2 import Integration, IntegrationSummary, IntegrationActionConfiguration, WebhookConfiguration
 from gundi_client_v2 import GundiClient
 from app import settings
 from .gundi import GUNDI_API_RETRY
+from .retry_policies import REDIS_RETRY
 
 logger = logging.getLogger(__name__)
 
 
-# Cached marker meaning "this integration has no webhook configuration", so a
-# cold cache doesn't trigger a Gundi API reload on every webhook-config lookup.
-_NO_WEBHOOK_CONFIG_SENTINEL = "null"
+# Cached marker meaning "this integration has no configuration for this
+# action" / "no webhook configuration", so a cold cache doesn't trigger a
+# Gundi API reload on every lookup of something the portal says is absent.
+# Action-config sentinels are invalidated by the same ActionConfig* events as
+# real configs; the webhook sentinel has no event and relies on its TTL.
+_ABSENCE_SENTINEL = "null"
+_NO_WEBHOOK_CONFIG_SENTINEL = _ABSENCE_SENTINEL
 # Default expiry for the webhook key (the config itself or the absence
 # sentinel) when the caller asks for no TTL, which the action path does. There
 # is no WebhookConfig* event to invalidate that key on, no consumer handler
@@ -27,11 +34,6 @@ _NO_WEBHOOK_CONFIG_SENTINEL = "null"
 # config change can take to reach a connector that is not also receiving
 # webhooks (the webhook path caches for 60 s on its own).
 WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS = 300
-
-# Retry policy for every Redis call in this module. Iterated with `async for`:
-# stamina's synchronous iterator sleeps with time.sleep, which inside a
-# coroutine stalls the whole event loop for the length of the back-off.
-REDIS_RETRY = dict(on=RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0)
 
 
 class IntegrationConfigurationManager:
@@ -60,23 +62,52 @@ class IntegrationConfigurationManager:
                     integration_details = await gundi.get_integration_details(integration_id)
             integration = IntegrationSummary.from_integration(integration_details)
             await self.db_client.set(key, integration.json(), ttl)
-            # Save configurations for individual actions
+            # Save configurations for individual actions, and a sentinel for each
+            # action of the type that has none: otherwise every lookup of an
+            # unconfigured action misses and reloads from the Gundi API, so an
+            # integration configured for two of its type's three actions would
+            # hit the portal on every single run.
+            configured = set()
             for config in integration_details.configurations:
+                configured.add(config.action.value)
                 config_key = self._get_action_config_key(integration_id, config.action.value)
                 await self.db_client.set(config_key, config.json(), ttl)
-            # Save the webhook configuration — or a sentinel marking its absence, so
-            # integrations without one don't reload from the Gundi API on every lookup
-            # Both the config and the sentinel always expire, even when the
-            # caller asked for no TTL (see WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS).
-            # A plain SET also clears any TTL the webhook path had put on the
-            # same key, so an unbounded write here would undo its 60 s cache.
-            webhook_key = self._get_webhook_config_key(integration_id)
-            webhook_ttl = ttl if ttl is not None else WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS
-            if webhook_configuration := integration_details.webhook_configuration:
-                await self.db_client.set(webhook_key, webhook_configuration.json(), webhook_ttl)
-            else:
-                await self.db_client.set(webhook_key, _NO_WEBHOOK_CONFIG_SENTINEL, webhook_ttl)
+            for action in integration_details.type.actions or []:
+                if action.value not in configured:
+                    await self.db_client.set(self._get_action_config_key(integration_id, action.value), _ABSENCE_SENTINEL, ttl)
+            await self._cache_webhook_configuration(integration_id, integration_details.webhook_configuration, ttl)
             return integration_details
+
+    async def _cache_webhook_configuration(self, integration_id: str, webhook_configuration, ttl=None):
+        # Save the webhook configuration, or a sentinel marking its absence, so
+        # integrations without one don't reload from the Gundi API on every
+        # lookup. Both always expire, even when the caller asked for no TTL
+        # (see WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS). A plain SET also clears any
+        # TTL the webhook path had put on the same key, so an unbounded write
+        # here would undo its 60 s cache.
+        webhook_key = self._get_webhook_config_key(integration_id)
+        webhook_ttl = ttl if ttl is not None else WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS
+        if webhook_configuration:
+            await self.db_client.set(webhook_key, webhook_configuration.json(), webhook_ttl)
+        else:
+            await self.db_client.set(webhook_key, _NO_WEBHOOK_CONFIG_SENTINEL, webhook_ttl)
+
+    async def _reload_webhook_configuration_from_gundi(self, integration_id: str, ttl=None) -> Optional[WebhookConfiguration]:
+        """Refresh only the webhook key from the Gundi API.
+
+        The webhook key is the one entry that expires on its own, so it misses
+        while the summary and action keys are still warm. Refreshing it through
+        the full reload would rewrite those keys with this caller's ttl, and the
+        webhook path calls with ttl=60: the action path's permanent,
+        event-invalidated keys would be downgraded to a 60 s expiry and the next
+        action run would go back to the portal.
+        """
+        async with GundiClient() as gundi:
+            async for attempt in stamina.retry_context(**GUNDI_API_RETRY):
+                with attempt:
+                    integration_details = await gundi.get_integration_details(integration_id)
+        await self._cache_webhook_configuration(integration_id, integration_details.webhook_configuration, ttl)
+        return integration_details.webhook_configuration
 
     async def get_action_configuration(self, integration_id: str, action_id: str, ttl=None) -> Optional[IntegrationActionConfiguration]:
         key = self._get_action_config_key(integration_id, action_id)
@@ -84,6 +115,8 @@ class IntegrationConfigurationManager:
             with attempt:
                 data = await self.db_client.get(key)
         if data:
+            if data in (_ABSENCE_SENTINEL, _ABSENCE_SENTINEL.encode()):
+                return None  # cached absence: the portal has no config for this action
             return IntegrationActionConfiguration.parse_raw(data)
         # If not found in the redis db, try reloading data from Gundi API
         integration_details = await self._reload_integration_from_gundi(integration_id, ttl)
@@ -98,9 +131,8 @@ class IntegrationConfigurationManager:
             if data in (_NO_WEBHOOK_CONFIG_SENTINEL, _NO_WEBHOOK_CONFIG_SENTINEL.encode()):
                 return None  # cached absence — this integration has no webhook config
             return WebhookConfiguration.parse_raw(data)
-        # If not found in the redis db, try reloading data from Gundi API
-        integration_details = await self._reload_integration_from_gundi(integration_id, ttl)
-        return integration_details.webhook_configuration
+        # Missing or expired: refresh this key only (see the method's docstring).
+        return await self._reload_webhook_configuration_from_gundi(integration_id, ttl)
 
 
     async def set_action_configuration(self, integration_id: str, action_id: str, config: IntegrationActionConfiguration, ttl=None):
@@ -110,10 +142,13 @@ class IntegrationConfigurationManager:
                 await self.db_client.set(key, config.json(), ttl)
 
     async def delete_action_configuration(self, integration_id: str, action_id: str):
+        # Record the absence rather than dropping the key: a deleted key misses on
+        # the next lookup and reloads the whole integration from the Gundi API,
+        # which would then report the same absence.
         key = self._get_action_config_key(integration_id, action_id)
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
-                return await self.db_client.delete(key)
+                await self.db_client.set(key, _ABSENCE_SENTINEL)
 
     async def get_integration(self, integration_id: str, ttl=None) -> IntegrationSummary:
         key = self._get_integration_key(integration_id)

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -44,6 +44,16 @@ WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS = 300
 # whatever the portal now says. It also lets an orphan sentinel (a cascade
 # ActionConfigDeleted arriving after IntegrationDeleted) age out on its own.
 ACTION_ABSENCE_SENTINEL_TTL_SECONDS = 300
+# Attach a TTL to a key only while it still holds the absence sentinel with no
+# expiry (TTL == -1). One server-side step on purpose: a client-side TTL check
+# followed by EXPIRE could race an ActionConfigCreated write in between and
+# put the TTL on the real configuration, which must stay permanent.
+_EXPIRE_LEGACY_SENTINEL_SCRIPT = """
+if redis.call('GET', KEYS[1]) == ARGV[1] and redis.call('TTL', KEYS[1]) == -1 then
+    return redis.call('EXPIRE', KEYS[1], ARGV[2])
+end
+return 0
+"""
 
 
 class IntegrationConfigurationManager:
@@ -155,13 +165,15 @@ class IntegrationConfigurationManager:
         # Sentinels written before they carried a TTL are permanent, and the
         # reload's NX write never touches an existing key, so an integration
         # already hit by the lost-event bug would stay "unconfigured" after
-        # rollout. Attach the TTL on a hit instead: one TTL round trip per
-        # sentinel hit, and a write only on the first hit after rollout. Can
-        # go once every deployment has run a release with sentinel TTLs.
+        # rollout. Attach the TTL on a hit instead: one round trip per sentinel
+        # hit (the compare-and-expire script), and a write only on the first
+        # hit after rollout. Can go once every deployment has run a release
+        # with sentinel TTLs.
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
-                if await self.db_client.ttl(key) == -1:
-                    await self.db_client.expire(key, ACTION_ABSENCE_SENTINEL_TTL_SECONDS)
+                await self.db_client.eval(
+                    _EXPIRE_LEGACY_SENTINEL_SCRIPT, 1, key, _ABSENCE_SENTINEL, ACTION_ABSENCE_SENTINEL_TTL_SECONDS,
+                )
 
     async def get_webhook_configuration(self, integration_id: str, ttl=None) -> Optional[WebhookConfiguration]:
         key = self._get_webhook_config_key(integration_id)

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -44,8 +44,16 @@ logger = logging.getLogger(__name__)
 # it (a fresh tombstone numbered 1 would look older than an in-flight reload's
 # 100). So a generation is qualified by an epoch (_GENERATION_EPOCH_KEY), minted
 # whenever the counter or the epoch is found missing, and the reload preserves
-# any tombstone from an epoch other than its own. Sentinels written before
-# generations existed are the bare value and still read as absence.
+# any tombstone from an epoch other than its own.
+#
+# Generated tombstones are opt-in (settings.CONFIG_CACHE_SENTINEL_GENERATIONS).
+# A rolling deployment runs old and new replicas side by side, and a replica on
+# a release without this reader parses anything but the bare "null" as a
+# configuration, failing every lookup of that action; so the reader ships
+# first and the writer is turned on once every replica has it. Until then, and
+# for sentinels written before generations existed, the value is the bare
+# "null", which still reads as absence; the reload's ordering guard simply has
+# nothing to compare and behaves as before.
 _ABSENCE_SENTINEL_PREFIX = "null"
 _NO_WEBHOOK_CONFIG_SENTINEL = "null"
 _GENERATION_KEY = "integrationconfig.generation"
@@ -132,12 +140,13 @@ end
 _NEXT_GENERATION_SCRIPT = _NEXT_GENERATION_LUA + """
 return next_generation(KEYS[1], KEYS[2], ARGV[1])
 """
-# Write an absence sentinel with a fresh generation, atomically with the INCR
-# that issues it (a generation taken separately could be written after a higher
-# one, breaking the ordering the reload relies on). KEYS[1] is the action key,
-# KEYS[2] the counter, KEYS[3] the epoch key; ARGV[1] a hex nonce, ARGV[2] the
-# TTL in seconds, ARGV[3] the precondition ('any', 'missing', or 'equals' the
-# value in ARGV[4]), ARGV[5] a candidate epoch.
+# Write an absence sentinel, atomically with the INCR that issues its generation
+# (a generation taken separately could be written after a higher one, breaking
+# the ordering the reload relies on). KEYS[1] is the action key, KEYS[2] the
+# counter, KEYS[3] the epoch key; ARGV[1] a hex nonce, ARGV[2] the TTL in
+# seconds, ARGV[3] the precondition ('any', 'missing', or 'equals' the value in
+# ARGV[4]), ARGV[5] a candidate epoch, ARGV[6] '1' to write a generated
+# tombstone or '0' for the bare value (CONFIG_CACHE_SENTINEL_GENERATIONS).
 _WRITE_TOMBSTONE_SCRIPT = _NEXT_GENERATION_LUA + """
 local current = redis.call('GET', KEYS[1])
 if ARGV[3] == 'missing' and current then
@@ -146,8 +155,11 @@ end
 if ARGV[3] == 'equals' and current ~= ARGV[4] then
     return 0
 end
-local generation = next_generation(KEYS[2], KEYS[3], ARGV[5])
-redis.call('SET', KEYS[1], 'null:' .. generation .. ':' .. ARGV[1], 'EX', ARGV[2])
+local value = 'null'
+if ARGV[6] == '1' then
+    value = 'null:' .. next_generation(KEYS[2], KEYS[3], ARGV[5]) .. ':' .. ARGV[1]
+end
+redis.call('SET', KEYS[1], value, 'EX', ARGV[2])
 return 1
 """
 # The reload's write of one configured action from its portal snapshot. Refuses
@@ -214,6 +226,7 @@ class IntegrationConfigurationManager:
                 written = await self.db_client.eval(
                     _WRITE_TOMBSTONE_SCRIPT, 3, key, _GENERATION_KEY, _GENERATION_EPOCH_KEY,
                     uuid.uuid4().hex, ttl, mode, expected, uuid.uuid4().hex,
+                    "1" if settings.CONFIG_CACHE_SENTINEL_GENERATIONS else "0",
                 )
         return bool(written)
 

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -84,14 +84,14 @@ if redis.call('TTL', KEYS[1]) == -1 then
 end
 return 0
 """
-# Replace the exact absence sentinel the caller observed with a real
-# configuration, but never anything that landed in between: a newer
-# configuration, a newer sentinel generation from a concurrent
-# ActionConfigDeleted, or nothing at all. A missing key is not a match either:
-# a tombstone written during a slow portal fetch can itself have expired by the
-# time this runs, and installing over "missing" would resurrect the deleted
-# config. Used by the consumer's Updated-after-sentinel recovery.
-_REPLACE_ABSENCE_SENTINEL_SCRIPT = """
+# Replace exactly the value the caller read (a sentinel generation or a
+# config's raw JSON) with a real configuration, but never anything that landed
+# in between: a newer configuration, a newer sentinel generation from a
+# concurrent ActionConfigDeleted, or nothing at all. A missing key is not a
+# match either: a tombstone written during a slow portal fetch can itself have
+# expired by the time this runs, and installing over "missing" would resurrect
+# the deleted config. Every consumer write of an action config goes through it.
+_REPLACE_CACHED_ENTRY_SCRIPT = """
 if redis.call('GET', KEYS[1]) == ARGV[1] then
     redis.call('SET', KEYS[1], ARGV[2])
     return 1
@@ -203,12 +203,13 @@ class IntegrationConfigurationManager:
             self, integration_id: str, action_id: str,
     ) -> Tuple[Optional[IntegrationActionConfiguration], Optional[str]]:
         """What the cache holds for this action, from one read and without ever
-        reloading from the portal: (config, None), (None, sentinel) for a
-        recorded absence, or (None, None) when nothing is cached.
+        reloading from the portal, with the exact stored value as a token:
+        (config, raw_json), (None, sentinel) for a recorded absence, or
+        (None, None) when nothing is cached.
 
-        For the consumer's recovery, which then compares-and-sets against what
-        it saw (replace_absence_sentinel / install_action_configuration_if_missing).
-        The sentinel must come from the very read that established the absence,
+        For the consumer, which then compares-and-sets against the token it
+        saw (replace_cached_entry / install_action_configuration_if_missing).
+        The token must come from the very read that established the state,
         since a second read could observe a fresh tombstone from a concurrent
         ActionConfigDeleted; and the full reload is off limits here because its
         unconditional SETs of configured actions would overwrite a tombstone
@@ -219,10 +220,11 @@ class IntegrationConfigurationManager:
                 data = await self.db_client.get(key)
         if not data:
             return None, None
+        raw = data.decode() if isinstance(data, bytes) else data
         if _is_absence_sentinel(data):
             await self._expire_legacy_sentinel(key, data)
-            return None, (data.decode() if isinstance(data, bytes) else data)
-        return IntegrationActionConfiguration.parse_raw(data), None
+            return None, raw
+        return IntegrationActionConfiguration.parse_raw(data), raw
 
     async def _expire_legacy_sentinel(self, key: str, observed) -> None:
         # Sentinels written before they carried a TTL are permanent, and the
@@ -272,19 +274,20 @@ class IntegrationConfigurationManager:
             with attempt:
                 await self.db_client.set(key, config.json(), ttl)
 
-    async def replace_absence_sentinel(
+    async def replace_cached_entry(
             self, integration_id: str, action_id: str, *, config: IntegrationActionConfiguration, observed: str,
     ) -> bool:
         """Write `config` only while the key still holds `observed`, the exact
-        sentinel the caller read (see read_cached_action_configuration).
-        Returns whether the write happened; False means the key changed, to a
-        real configuration, a fresh tombstone from a concurrent
-        ActionConfigDeleted, or nothing, and the caller must not overwrite it.
-        Permanent, like every real configuration."""
+        token the caller read (see read_cached_action_configuration): a
+        sentinel generation or a config's raw JSON. Returns whether the write
+        happened; False means the key changed, to a newer configuration, a
+        fresh tombstone from a concurrent ActionConfigDeleted, or nothing, and
+        the caller must not overwrite it. Permanent, like every real
+        configuration."""
         key = self._get_action_config_key(integration_id, action_id)
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
-                written = await self.db_client.eval(_REPLACE_ABSENCE_SENTINEL_SCRIPT, 1, key, observed, config.json())
+                written = await self.db_client.eval(_REPLACE_CACHED_ENTRY_SCRIPT, 1, key, observed, config.json())
         return bool(written)
 
     async def install_action_configuration_if_missing(

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -54,6 +54,16 @@ if redis.call('GET', KEYS[1]) == ARGV[1] and redis.call('TTL', KEYS[1]) == -1 th
 end
 return 0
 """
+# Attach a TTL to a key that has none, whatever it holds. Used for webhook
+# entries written before the key carried a TTL (see _expire_legacy_webhook_entry).
+# One server-side step: a client-side TTL check followed by EXPIRE could race a
+# fresh write and replace the expiry it came with.
+_EXPIRE_IF_PERMANENT_SCRIPT = """
+if redis.call('TTL', KEYS[1]) == -1 then
+    return redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return 0
+"""
 # Replace the absence sentinel (or a key that has since expired) with a real
 # configuration, but never a configuration that landed in between. Used by the
 # consumer's Updated-after-sentinel recovery, which reads the portal and then
@@ -194,11 +204,25 @@ class IntegrationConfigurationManager:
             with attempt:
                 data = await self.db_client.get(key)
         if data:
+            await self._expire_legacy_webhook_entry(key, ttl)
             if data in (_NO_WEBHOOK_CONFIG_SENTINEL, _NO_WEBHOOK_CONFIG_SENTINEL.encode()):
                 return None  # cached absence — this integration has no webhook config
             return WebhookConfiguration.parse_raw(data)
         # Missing or expired: refresh this key only (see the method's docstring).
         return await self._reload_webhook_configuration_from_gundi(integration_id, ttl)
+
+    async def _expire_legacy_webhook_entry(self, key: str, ttl=None) -> None:
+        # Before the webhook key always carried a TTL, the action path's reload
+        # (ttl=None) wrote both real configs and the absence sentinel
+        # permanently, and a hit never refreshes the key, so such an entry
+        # would serve a stale or missing webhook config indefinitely. Attach
+        # the bounded TTL on a hit to an entry that has none; a real config
+        # that then expires is simply refreshed from the portal. Can go once
+        # every deployment has run a release with webhook TTLs.
+        webhook_ttl = ttl if ttl is not None else WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
+            with attempt:
+                await self.db_client.eval(_EXPIRE_IF_PERMANENT_SCRIPT, 1, key, webhook_ttl)
 
 
     async def set_action_configuration(self, integration_id: str, action_id: str, config: IntegrationActionConfiguration, ttl=None):

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -64,6 +64,18 @@ def _is_absence_sentinel(data) -> bool:
     if isinstance(data, bytes):
         data = data.decode()
     return data == _ABSENCE_SENTINEL_PREFIX or data.startswith(_ABSENCE_SENTINEL_PREFIX + ":")
+
+
+def _is_unorderable_token(observed: str) -> bool:
+    """A bare "null" while generations are enabled. During the rolling restart
+    that enables them, a not-yet-enabled replica can still write a bare "null"
+    for a delete, and a compare-and-set that observed a bare "null" earlier
+    cannot tell that fresh delete from the one it saw; equality would resurrect
+    it. So while the setting is on, a bare sentinel is not a token anyone may
+    write over: the caller's re-read treats it as an absence and stops, and the
+    sentinel's TTL takes it from there. With the setting off every replica
+    writes bare sentinels and there is nothing to tell apart."""
+    return settings.CONFIG_CACHE_SENTINEL_GENERATIONS and observed == _ABSENCE_SENTINEL_PREFIX
 # Default expiry for the webhook key (the config itself or the absence
 # sentinel) when the caller asks for no TTL, which the action path does. There
 # is no WebhookConfig* event to invalidate that key on, no consumer handler
@@ -408,6 +420,8 @@ class IntegrationConfigurationManager:
         fresh tombstone from a concurrent ActionConfigDeleted, or nothing, and
         the caller must not overwrite it. Permanent, like every real
         configuration."""
+        if _is_unorderable_token(observed):
+            return False
         key = self._get_action_config_key(integration_id, action_id)
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
@@ -419,6 +433,8 @@ class IntegrationConfigurationManager:
         still holds `observed`. The consumer's reconciliation uses it when the
         portal says the row is gone; the same exactness rule as
         replace_cached_entry applies."""
+        if _is_unorderable_token(observed):
+            return False
         key = self._get_action_config_key(integration_id, action_id)
         return await self._write_absence_sentinel(
             key, ttl=ACTION_ABSENCE_SENTINEL_TTL_SECONDS, mode="equals", expected=observed,

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import uuid
 from typing import Optional
 
 import pydantic
@@ -24,8 +25,26 @@ logger = logging.getLogger(__name__)
 # Action-config sentinels are replaced by the ActionConfig* events for that
 # action and, as a backstop, expire (see ACTION_ABSENCE_SENTINEL_TTL_SECONDS);
 # the webhook sentinel has no event and relies on its TTL alone.
-_ABSENCE_SENTINEL = "null"
-_NO_WEBHOOK_CONFIG_SENTINEL = _ABSENCE_SENTINEL
+#
+# Every action sentinel write carries its own generation ("null:<hex>"). The
+# consumer's Updated-after-sentinel recovery reads the sentinel, fetches the
+# portal, then replaces the sentinel only if it is still the one it observed;
+# were every sentinel the same bare value, a concurrent ActionConfigDeleted's
+# fresh tombstone would compare equal and the recovery would resurrect the
+# deleted config as a permanent key. Sentinels written before generations
+# existed are the bare value and still read as absence.
+_ABSENCE_SENTINEL_PREFIX = "null"
+_NO_WEBHOOK_CONFIG_SENTINEL = "null"
+
+
+def _new_absence_sentinel() -> str:
+    return f"{_ABSENCE_SENTINEL_PREFIX}:{uuid.uuid4().hex}"
+
+
+def _is_absence_sentinel(data) -> bool:
+    if isinstance(data, bytes):
+        data = data.decode()
+    return data == _ABSENCE_SENTINEL_PREFIX or data.startswith(_ABSENCE_SENTINEL_PREFIX + ":")
 # Default expiry for the webhook key (the config itself or the absence
 # sentinel) when the caller asks for no TTL, which the action path does. There
 # is no WebhookConfig* event to invalidate that key on, no consumer handler
@@ -44,10 +63,11 @@ WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS = 300
 # whatever the portal now says. It also lets an orphan sentinel (a cascade
 # ActionConfigDeleted arriving after IntegrationDeleted) age out on its own.
 ACTION_ABSENCE_SENTINEL_TTL_SECONDS = 300
-# Attach a TTL to a key only while it still holds the absence sentinel with no
-# expiry (TTL == -1). One server-side step on purpose: a client-side TTL check
-# followed by EXPIRE could race an ActionConfigCreated write in between and
-# put the TTL on the real configuration, which must stay permanent.
+# Attach a TTL to a key only while it still holds the exact sentinel the read
+# observed and has no expiry (TTL == -1). One server-side step on purpose: a
+# client-side TTL check followed by EXPIRE could race an ActionConfigCreated
+# write in between and put the TTL on the real configuration, which must stay
+# permanent.
 _EXPIRE_LEGACY_SENTINEL_SCRIPT = """
 if redis.call('GET', KEYS[1]) == ARGV[1] and redis.call('TTL', KEYS[1]) == -1 then
     return redis.call('EXPIRE', KEYS[1], ARGV[2])
@@ -64,11 +84,11 @@ if redis.call('TTL', KEYS[1]) == -1 then
 end
 return 0
 """
-# Replace the absence sentinel (or a key that has since expired) with a real
-# configuration, but never a configuration that landed in between. Used by the
-# consumer's Updated-after-sentinel recovery, which reads the portal and then
-# writes: two such recoveries for one action can race, and the slower one's
-# plain SET would restore its stale snapshot over the newer value.
+# Replace the exact absence sentinel the caller observed (or a key that has
+# since expired) with a real configuration, but never anything that landed in
+# between: a newer configuration, or a newer sentinel generation from a
+# concurrent ActionConfigDeleted. Used by the consumer's Updated-after-sentinel
+# recovery, which reads the portal and then writes.
 _REPLACE_ABSENCE_SENTINEL_SCRIPT = """
 local current = redis.call('GET', KEYS[1])
 if current == false or current == ARGV[1] then
@@ -137,7 +157,7 @@ class IntegrationConfigurationManager:
         for action in integration_details.type.actions or []:
             if action.value not in configured:
                 await self.db_client.set(
-                    self._get_action_config_key(integration_id, action.value), _ABSENCE_SENTINEL, sentinel_ttl, nx=True,
+                    self._get_action_config_key(integration_id, action.value), _new_absence_sentinel(), sentinel_ttl, nx=True,
                 )
         await self._cache_webhook_configuration(integration_id, integration_details.webhook_configuration, ttl)
         return integration_details
@@ -176,15 +196,28 @@ class IntegrationConfigurationManager:
             with attempt:
                 data = await self.db_client.get(key)
         if data:
-            if data in (_ABSENCE_SENTINEL, _ABSENCE_SENTINEL.encode()):
-                await self._expire_legacy_sentinel(key)
+            if _is_absence_sentinel(data):
+                await self._expire_legacy_sentinel(key, data)
                 return None  # cached absence: the portal has no config for this action
             return IntegrationActionConfiguration.parse_raw(data)
         # If not found in the redis db, try reloading data from Gundi API
         integration_details = await self._reload_integration_from_gundi(integration_id, ttl)
         return integration_details.get_action_config(action_id)
 
-    async def _expire_legacy_sentinel(self, key: str) -> None:
+    async def read_absence_sentinel(self, integration_id: str, action_id: str) -> Optional[str]:
+        """The exact absence sentinel currently cached for this action, or None
+        when the key holds a real configuration or nothing. For callers that
+        will later replace the sentinel and must name the generation they saw
+        (see replace_absence_sentinel). Never reloads from the portal."""
+        key = self._get_action_config_key(integration_id, action_id)
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
+            with attempt:
+                data = await self.db_client.get(key)
+        if data and _is_absence_sentinel(data):
+            return data.decode() if isinstance(data, bytes) else data
+        return None
+
+    async def _expire_legacy_sentinel(self, key: str, observed) -> None:
         # Sentinels written before they carried a TTL are permanent, and the
         # reload's NX write never touches an existing key, so an integration
         # already hit by the lost-event bug would stay "unconfigured" after
@@ -192,10 +225,11 @@ class IntegrationConfigurationManager:
         # hit (the compare-and-expire script), and a write only on the first
         # hit after rollout. Can go once every deployment has run a release
         # with sentinel TTLs.
+        observed = observed.decode() if isinstance(observed, bytes) else observed
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 await self.db_client.eval(
-                    _EXPIRE_LEGACY_SENTINEL_SCRIPT, 1, key, _ABSENCE_SENTINEL, ACTION_ABSENCE_SENTINEL_TTL_SECONDS,
+                    _EXPIRE_LEGACY_SENTINEL_SCRIPT, 1, key, observed, ACTION_ABSENCE_SENTINEL_TTL_SECONDS,
                 )
 
     async def get_webhook_configuration(self, integration_id: str, ttl=None) -> Optional[WebhookConfiguration]:
@@ -232,16 +266,18 @@ class IntegrationConfigurationManager:
                 await self.db_client.set(key, config.json(), ttl)
 
     async def replace_absence_sentinel(
-            self, integration_id: str, action_id: str, *, config: IntegrationActionConfiguration,
+            self, integration_id: str, action_id: str, *, config: IntegrationActionConfiguration, observed: str,
     ) -> bool:
-        """Write `config` only while the key still holds the absence sentinel
-        (or has expired). Returns whether the write happened; False means a
-        newer value is already there and the caller must not overwrite it.
-        Permanent, like every real configuration."""
+        """Write `config` only while the key still holds `observed`, the exact
+        sentinel the caller read (see read_absence_sentinel), or has expired.
+        Returns whether the write happened; False means something newer is
+        there, a real configuration or a fresh tombstone from a concurrent
+        ActionConfigDeleted, and the caller must not overwrite it. Permanent,
+        like every real configuration."""
         key = self._get_action_config_key(integration_id, action_id)
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
-                written = await self.db_client.eval(_REPLACE_ABSENCE_SENTINEL_SCRIPT, 1, key, _ABSENCE_SENTINEL, config.json())
+                written = await self.db_client.eval(_REPLACE_ABSENCE_SENTINEL_SCRIPT, 1, key, observed, config.json())
         return bool(written)
 
     async def delete_action_configuration(self, integration_id: str, action_id: str):
@@ -252,7 +288,7 @@ class IntegrationConfigurationManager:
         key = self._get_action_config_key(integration_id, action_id)
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
-                await self.db_client.set(key, _ABSENCE_SENTINEL, ACTION_ABSENCE_SENTINEL_TTL_SECONDS)
+                await self.db_client.set(key, _new_absence_sentinel(), ACTION_ABSENCE_SENTINEL_TTL_SECONDS)
 
     async def get_integration(self, integration_id: str, ttl=None) -> IntegrationSummary:
         key = self._get_integration_key(integration_id)

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -84,14 +84,15 @@ if redis.call('TTL', KEYS[1]) == -1 then
 end
 return 0
 """
-# Replace the exact absence sentinel the caller observed (or a key that has
-# since expired) with a real configuration, but never anything that landed in
-# between: a newer configuration, or a newer sentinel generation from a
-# concurrent ActionConfigDeleted. Used by the consumer's Updated-after-sentinel
-# recovery, which reads the portal and then writes.
+# Replace the exact absence sentinel the caller observed with a real
+# configuration, but never anything that landed in between: a newer
+# configuration, a newer sentinel generation from a concurrent
+# ActionConfigDeleted, or nothing at all. A missing key is not a match either:
+# a tombstone written during a slow portal fetch can itself have expired by the
+# time this runs, and installing over "missing" would resurrect the deleted
+# config. Used by the consumer's Updated-after-sentinel recovery.
 _REPLACE_ABSENCE_SENTINEL_SCRIPT = """
-local current = redis.call('GET', KEYS[1])
-if current == false or current == ARGV[1] then
+if redis.call('GET', KEYS[1]) == ARGV[1] then
     redis.call('SET', KEYS[1], ARGV[2])
     return 1
 end
@@ -191,31 +192,37 @@ class IntegrationConfigurationManager:
         return integration_details.webhook_configuration
 
     async def get_action_configuration(self, integration_id: str, action_id: str, ttl=None) -> Optional[IntegrationActionConfiguration]:
-        config, _ = await self.get_action_configuration_and_sentinel(integration_id, action_id, ttl)
-        return config
+        config, sentinel = await self.read_cached_action_configuration(integration_id, action_id)
+        if config is not None or sentinel is not None:
+            return config  # a cached config, or a cached absence
+        # If not found in the redis db, try reloading data from Gundi API
+        integration_details = await self._reload_integration_from_gundi(integration_id, ttl)
+        return integration_details.get_action_config(action_id)
 
-    async def get_action_configuration_and_sentinel(
-            self, integration_id: str, action_id: str, ttl=None,
+    async def read_cached_action_configuration(
+            self, integration_id: str, action_id: str,
     ) -> Tuple[Optional[IntegrationActionConfiguration], Optional[str]]:
-        """get_action_configuration, plus the exact absence sentinel when the
-        cache recorded the absence (None otherwise, including after a portal
-        reload). For a caller that will later compare-and-set against that
-        sentinel (replace_absence_sentinel): the value must come from the very
-        read that established the absence, since a second read could observe
-        a fresh tombstone written by a concurrent ActionConfigDeleted."""
+        """What the cache holds for this action, from one read and without ever
+        reloading from the portal: (config, None), (None, sentinel) for a
+        recorded absence, or (None, None) when nothing is cached.
+
+        For the consumer's recovery, which then compares-and-sets against what
+        it saw (replace_absence_sentinel / install_action_configuration_if_missing).
+        The sentinel must come from the very read that established the absence,
+        since a second read could observe a fresh tombstone from a concurrent
+        ActionConfigDeleted; and the full reload is off limits here because its
+        unconditional SETs of configured actions would overwrite a tombstone
+        written after the reload's own fetch."""
         key = self._get_action_config_key(integration_id, action_id)
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 data = await self.db_client.get(key)
-        if data:
-            if _is_absence_sentinel(data):
-                await self._expire_legacy_sentinel(key, data)
-                observed = data.decode() if isinstance(data, bytes) else data
-                return None, observed  # cached absence: the portal has no config for this action
-            return IntegrationActionConfiguration.parse_raw(data), None
-        # If not found in the redis db, try reloading data from Gundi API
-        integration_details = await self._reload_integration_from_gundi(integration_id, ttl)
-        return integration_details.get_action_config(action_id), None
+        if not data:
+            return None, None
+        if _is_absence_sentinel(data):
+            await self._expire_legacy_sentinel(key, data)
+            return None, (data.decode() if isinstance(data, bytes) else data)
+        return IntegrationActionConfiguration.parse_raw(data), None
 
     async def _expire_legacy_sentinel(self, key: str, observed) -> None:
         # Sentinels written before they carried a TTL are permanent, and the
@@ -269,16 +276,28 @@ class IntegrationConfigurationManager:
             self, integration_id: str, action_id: str, *, config: IntegrationActionConfiguration, observed: str,
     ) -> bool:
         """Write `config` only while the key still holds `observed`, the exact
-        sentinel the caller read (see get_action_configuration_and_sentinel),
-        or has expired.
-        Returns whether the write happened; False means something newer is
-        there, a real configuration or a fresh tombstone from a concurrent
-        ActionConfigDeleted, and the caller must not overwrite it. Permanent,
-        like every real configuration."""
+        sentinel the caller read (see read_cached_action_configuration).
+        Returns whether the write happened; False means the key changed, to a
+        real configuration, a fresh tombstone from a concurrent
+        ActionConfigDeleted, or nothing, and the caller must not overwrite it.
+        Permanent, like every real configuration."""
         key = self._get_action_config_key(integration_id, action_id)
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 written = await self.db_client.eval(_REPLACE_ABSENCE_SENTINEL_SCRIPT, 1, key, observed, config.json())
+        return bool(written)
+
+    async def install_action_configuration_if_missing(
+            self, integration_id: str, action_id: str, *, config: IntegrationActionConfiguration,
+    ) -> bool:
+        """Write `config` only if nothing is cached for this action (SET NX),
+        for a recovery that saw a cold cache, fetched the portal row, and must
+        not overwrite whatever landed meanwhile. Returns whether it was written.
+        Permanent, like every real configuration."""
+        key = self._get_action_config_key(integration_id, action_id)
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
+            with attempt:
+                written = await self.db_client.set(key, config.json(), None, nx=True)
         return bool(written)
 
     async def delete_action_configuration(self, integration_id: str, action_id: str):

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -26,22 +26,30 @@ logger = logging.getLogger(__name__)
 # action and, as a backstop, expire (see ACTION_ABSENCE_SENTINEL_TTL_SECONDS);
 # the webhook sentinel has no event and relies on its TTL alone.
 #
-# Every action sentinel write carries its own generation ("null:<n>:<hex>"),
-# issued by one Redis counter (_GENERATION_KEY) inside the write itself. Two
-# readers depend on it. The consumer's recovery reads the sentinel, fetches
-# the portal, then replaces the sentinel only if it is still the one it
-# observed; were every sentinel the same bare value, a concurrent
-# ActionConfigDeleted's fresh tombstone would compare equal and the recovery
-# would resurrect the deleted config as a permanent key. The reload takes a
-# generation before its portal fetch and refuses to overwrite a tombstone with
-# a higher one: that tombstone was written while the fetch was in flight, so
-# it is newer than the snapshot (see _WRITE_SNAPSHOT_CONFIG_SCRIPT). Redis
-# hands out the numbers, so the ordering holds across runner instances
-# whatever their clocks say. Sentinels written before generations existed are
-# the bare value and still read as absence.
+# Every action sentinel write carries its own generation
+# ("null:<epoch>:<n>:<hex>"), issued by one Redis counter (_GENERATION_KEY)
+# inside the write itself. Two readers depend on it. The consumer's recovery
+# reads the sentinel, fetches the portal, then replaces the sentinel only if it
+# is still the one it observed; were every sentinel the same bare value, a
+# concurrent ActionConfigDeleted's fresh tombstone would compare equal and the
+# recovery would resurrect the deleted config as a permanent key. The reload
+# takes a generation before its portal fetch and refuses to overwrite a
+# tombstone with a higher one: that tombstone was written while the fetch was
+# in flight, so it is newer than the snapshot (see
+# _WRITE_SNAPSHOT_CONFIG_SCRIPT). Redis hands out the numbers, so the ordering
+# holds across runner instances whatever their clocks say.
+#
+# The counter is an ordinary key: a flush or an eviction restarts it, and
+# numbers from after a restart must never be compared with numbers from before
+# it (a fresh tombstone numbered 1 would look older than an in-flight reload's
+# 100). So a generation is qualified by an epoch (_GENERATION_EPOCH_KEY), minted
+# whenever the counter or the epoch is found missing, and the reload preserves
+# any tombstone from an epoch other than its own. Sentinels written before
+# generations existed are the bare value and still read as absence.
 _ABSENCE_SENTINEL_PREFIX = "null"
 _NO_WEBHOOK_CONFIG_SENTINEL = "null"
 _GENERATION_KEY = "integrationconfig.generation"
+_GENERATION_EPOCH_KEY = "integrationconfig.generation.epoch"
 
 
 def _is_absence_sentinel(data) -> bool:
@@ -105,17 +113,32 @@ if redis.call('GET', KEYS[1]) == ARGV[1] then
 end
 return 0
 """
-# The next generation number. The reload takes one before its portal fetch so
-# every tombstone written during the fetch compares higher.
-_NEXT_GENERATION_SCRIPT = """
-return redis.call('INCR', KEYS[1])
+# Shared by the two scripts below: the current epoch, minting a new one (the
+# caller's candidate) when the counter or the epoch key is missing, then the
+# next number. Returns "<epoch>:<n>".
+_NEXT_GENERATION_LUA = """
+local function next_generation(counter_key, epoch_key, candidate_epoch)
+    local epoch = redis.call('GET', epoch_key)
+    if not epoch or redis.call('EXISTS', counter_key) == 0 then
+        epoch = candidate_epoch
+        redis.call('SET', epoch_key, epoch)
+    end
+    return epoch .. ':' .. redis.call('INCR', counter_key)
+end
+"""
+# The reload's generation, taken before its portal fetch so every tombstone
+# written during the fetch compares higher (within the same epoch). KEYS[1] the
+# counter, KEYS[2] the epoch key; ARGV[1] a candidate epoch.
+_NEXT_GENERATION_SCRIPT = _NEXT_GENERATION_LUA + """
+return next_generation(KEYS[1], KEYS[2], ARGV[1])
 """
 # Write an absence sentinel with a fresh generation, atomically with the INCR
 # that issues it (a generation taken separately could be written after a higher
 # one, breaking the ordering the reload relies on). KEYS[1] is the action key,
-# KEYS[2] the counter; ARGV[1] a hex nonce, ARGV[2] the TTL in seconds, ARGV[3]
-# the precondition ('any', 'missing', or 'equals' the value in ARGV[4]).
-_WRITE_TOMBSTONE_SCRIPT = """
+# KEYS[2] the counter, KEYS[3] the epoch key; ARGV[1] a hex nonce, ARGV[2] the
+# TTL in seconds, ARGV[3] the precondition ('any', 'missing', or 'equals' the
+# value in ARGV[4]), ARGV[5] a candidate epoch.
+_WRITE_TOMBSTONE_SCRIPT = _NEXT_GENERATION_LUA + """
 local current = redis.call('GET', KEYS[1])
 if ARGV[3] == 'missing' and current then
     return 0
@@ -123,22 +146,27 @@ end
 if ARGV[3] == 'equals' and current ~= ARGV[4] then
     return 0
 end
-local generation = redis.call('INCR', KEYS[2])
+local generation = next_generation(KEYS[2], KEYS[3], ARGV[5])
 redis.call('SET', KEYS[1], 'null:' .. generation .. ':' .. ARGV[1], 'EX', ARGV[2])
 return 1
 """
 # The reload's write of one configured action from its portal snapshot. Refuses
-# to overwrite an absence sentinel whose generation is above the one the reload
-# took before its fetch: that is a concurrent ActionConfigDeleted's tombstone,
-# newer than the snapshot, and an unconditional SET would resurrect the deleted
-# config permanently. Anything else (a real config, an older sentinel, nothing)
-# is replaced by the snapshot, which is the portal's truth as of the fetch.
+# to overwrite an absence sentinel from another epoch, or from this epoch with a
+# generation above the one the reload took before its fetch: that is a
+# concurrent ActionConfigDeleted's tombstone, newer than the snapshot, and an
+# unconditional SET would resurrect the deleted config permanently. Anything
+# else (a real config, an older sentinel, nothing) is replaced by the snapshot,
+# which is the portal's truth as of the fetch. ARGV[2] is the reload's
+# "<epoch>:<n>" token.
 _WRITE_SNAPSHOT_CONFIG_SCRIPT = """
 local current = redis.call('GET', KEYS[1])
 if current then
-    local generation = string.match(current, '^null:(%d+):')
-    if generation and tonumber(generation) > tonumber(ARGV[2]) then
-        return 0
+    local epoch, generation = string.match(current, '^null:([^:]+):(%d+):')
+    if epoch then
+        local fetch_epoch, fetch_generation = string.match(ARGV[2], '^([^:]+):(%d+)$')
+        if epoch ~= fetch_epoch or tonumber(generation) > tonumber(fetch_generation) then
+            return 0
+        end
     end
 end
 if ARGV[3] == '' then
@@ -184,7 +212,8 @@ class IntegrationConfigurationManager:
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 written = await self.db_client.eval(
-                    _WRITE_TOMBSTONE_SCRIPT, 2, key, _GENERATION_KEY, uuid.uuid4().hex, ttl, mode, expected,
+                    _WRITE_TOMBSTONE_SCRIPT, 3, key, _GENERATION_KEY, _GENERATION_EPOCH_KEY,
+                    uuid.uuid4().hex, ttl, mode, expected, uuid.uuid4().hex,
                 )
         return bool(written)
 
@@ -192,7 +221,9 @@ class IntegrationConfigurationManager:
         key = self._get_integration_key(integration_id)
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
-                fetch_generation = await self.db_client.eval(_NEXT_GENERATION_SCRIPT, 1, _GENERATION_KEY)
+                fetch_generation = await self.db_client.eval(
+                    _NEXT_GENERATION_SCRIPT, 2, _GENERATION_KEY, _GENERATION_EPOCH_KEY, uuid.uuid4().hex,
+                )
         integration_details = await self._fetch_integration_from_gundi(integration_id)
         integration = IntegrationSummary.from_integration(integration_details)
         await self.db_client.set(key, integration.json(), ttl)

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import time
 import uuid
 from typing import Optional, Tuple
 
@@ -27,22 +26,22 @@ logger = logging.getLogger(__name__)
 # action and, as a backstop, expire (see ACTION_ABSENCE_SENTINEL_TTL_SECONDS);
 # the webhook sentinel has no event and relies on its TTL alone.
 #
-# Every action sentinel write carries its own generation
-# ("null:<write time, ns>:<hex>"). Two readers depend on it. The consumer's
-# recovery reads the sentinel, fetches the portal, then replaces the sentinel
-# only if it is still the one it observed; were every sentinel the same bare
-# value, a concurrent ActionConfigDeleted's fresh tombstone would compare equal
-# and the recovery would resurrect the deleted config as a permanent key. The
-# reload compares the write time with the start of its own portal fetch, so a
-# tombstone written while the fetch was in flight is preserved over the stale
-# snapshot (see _WRITE_SNAPSHOT_CONFIG_SCRIPT). Sentinels written before
-# generations existed are the bare value and still read as absence.
+# Every action sentinel write carries its own generation ("null:<n>:<hex>"),
+# issued by one Redis counter (_GENERATION_KEY) inside the write itself. Two
+# readers depend on it. The consumer's recovery reads the sentinel, fetches
+# the portal, then replaces the sentinel only if it is still the one it
+# observed; were every sentinel the same bare value, a concurrent
+# ActionConfigDeleted's fresh tombstone would compare equal and the recovery
+# would resurrect the deleted config as a permanent key. The reload takes a
+# generation before its portal fetch and refuses to overwrite a tombstone with
+# a higher one: that tombstone was written while the fetch was in flight, so
+# it is newer than the snapshot (see _WRITE_SNAPSHOT_CONFIG_SCRIPT). Redis
+# hands out the numbers, so the ordering holds across runner instances
+# whatever their clocks say. Sentinels written before generations existed are
+# the bare value and still read as absence.
 _ABSENCE_SENTINEL_PREFIX = "null"
 _NO_WEBHOOK_CONFIG_SENTINEL = "null"
-
-
-def _new_absence_sentinel() -> str:
-    return f"{_ABSENCE_SENTINEL_PREFIX}:{time.time_ns()}:{uuid.uuid4().hex}"
+_GENERATION_KEY = "integrationconfig.generation"
 
 
 def _is_absence_sentinel(data) -> bool:
@@ -106,18 +105,39 @@ if redis.call('GET', KEYS[1]) == ARGV[1] then
 end
 return 0
 """
+# The next generation number. The reload takes one before its portal fetch so
+# every tombstone written during the fetch compares higher.
+_NEXT_GENERATION_SCRIPT = """
+return redis.call('INCR', KEYS[1])
+"""
+# Write an absence sentinel with a fresh generation, atomically with the INCR
+# that issues it (a generation taken separately could be written after a higher
+# one, breaking the ordering the reload relies on). KEYS[1] is the action key,
+# KEYS[2] the counter; ARGV[1] a hex nonce, ARGV[2] the TTL in seconds, ARGV[3]
+# the precondition ('any', 'missing', or 'equals' the value in ARGV[4]).
+_WRITE_TOMBSTONE_SCRIPT = """
+local current = redis.call('GET', KEYS[1])
+if ARGV[3] == 'missing' and current then
+    return 0
+end
+if ARGV[3] == 'equals' and current ~= ARGV[4] then
+    return 0
+end
+local generation = redis.call('INCR', KEYS[2])
+redis.call('SET', KEYS[1], 'null:' .. generation .. ':' .. ARGV[1], 'EX', ARGV[2])
+return 1
+"""
 # The reload's write of one configured action from its portal snapshot. Refuses
-# to overwrite an absence sentinel written at or after the fetch began: that is
-# a concurrent ActionConfigDeleted's tombstone, newer than the snapshot, and an
-# unconditional SET would resurrect the deleted config permanently. Anything
-# else (a real config, an older sentinel, nothing) is replaced by the snapshot,
-# which is the portal's truth as of the fetch. Clocks across runner instances
-# are assumed close relative to the length of a portal round trip.
+# to overwrite an absence sentinel whose generation is above the one the reload
+# took before its fetch: that is a concurrent ActionConfigDeleted's tombstone,
+# newer than the snapshot, and an unconditional SET would resurrect the deleted
+# config permanently. Anything else (a real config, an older sentinel, nothing)
+# is replaced by the snapshot, which is the portal's truth as of the fetch.
 _WRITE_SNAPSHOT_CONFIG_SCRIPT = """
 local current = redis.call('GET', KEYS[1])
 if current then
-    local written_ns = string.match(current, '^null:(%d+):')
-    if written_ns and tonumber(written_ns) >= tonumber(ARGV[2]) then
+    local generation = string.match(current, '^null:(%d+):')
+    if generation and tonumber(generation) > tonumber(ARGV[2]) then
         return 0
     end
 end
@@ -160,9 +180,19 @@ class IntegrationConfigurationManager:
                     integration_details = await gundi.get_integration_details(integration_id)
         return integration_details
 
+    async def _write_absence_sentinel(self, key: str, *, ttl: int, mode: str, expected: str = "") -> bool:
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
+            with attempt:
+                written = await self.db_client.eval(
+                    _WRITE_TOMBSTONE_SCRIPT, 2, key, _GENERATION_KEY, uuid.uuid4().hex, ttl, mode, expected,
+                )
+        return bool(written)
+
     async def _reload_integration_from_gundi(self, integration_id: str, ttl=None) -> Integration:
         key = self._get_integration_key(integration_id)
-        fetch_started_ns = time.time_ns()
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
+            with attempt:
+                fetch_generation = await self.db_client.eval(_NEXT_GENERATION_SCRIPT, 1, _GENERATION_KEY)
         integration_details = await self._fetch_integration_from_gundi(integration_id)
         integration = IntegrationSummary.from_integration(integration_details)
         await self.db_client.set(key, integration.json(), ttl)
@@ -178,22 +208,22 @@ class IntegrationConfigurationManager:
             configured.add(config.action.value)
             config_key = self._get_action_config_key(integration_id, config.action.value)
             await self.db_client.eval(
-                _WRITE_SNAPSHOT_CONFIG_SCRIPT, 1, config_key, config.json(), fetch_started_ns, ttl if ttl is not None else "",
+                _WRITE_SNAPSHOT_CONFIG_SCRIPT, 1, config_key, config.json(), fetch_generation, ttl if ttl is not None else "",
             )
-        # Sentinels are written with NX so they never replace a key that is
-        # already there. A reload reads the portal, then writes; if an
-        # ActionConfigCreated event for one of these actions lands in
-        # between, its config would otherwise be overwritten with a "null"
-        # that no later event corrects. With NX the event's write wins in
-        # either order: written first, it is left alone; written after, it
-        # replaces the sentinel as a plain SET. The sentinel also expires
+        # Sentinels are written only if the key is missing, so they never
+        # replace a key that is already there. A reload reads the portal, then
+        # writes; if an ActionConfigCreated event for one of these actions
+        # lands in between, its config would otherwise be overwritten with a
+        # "null" that no later event corrects. This way the event's write wins
+        # in either order: written first, it is left alone; written after, it
+        # replaces the sentinel. The sentinel also expires
         # (ACTION_ABSENCE_SENTINEL_TTL_SECONDS) for the case where that event
         # never arrives at all.
         sentinel_ttl = ttl if ttl is not None else ACTION_ABSENCE_SENTINEL_TTL_SECONDS
         for action in integration_details.type.actions or []:
             if action.value not in configured:
-                await self.db_client.set(
-                    self._get_action_config_key(integration_id, action.value), _new_absence_sentinel(), sentinel_ttl, nx=True,
+                await self._write_absence_sentinel(
+                    self._get_action_config_key(integration_id, action.value), ttl=sentinel_ttl, mode="missing",
                 )
         await self._cache_webhook_configuration(integration_id, integration_details.webhook_configuration, ttl)
         return integration_details
@@ -331,12 +361,9 @@ class IntegrationConfigurationManager:
         portal says the row is gone; the same exactness rule as
         replace_cached_entry applies."""
         key = self._get_action_config_key(integration_id, action_id)
-        async for attempt in stamina.retry_context(**REDIS_RETRY):
-            with attempt:
-                written = await self.db_client.eval(
-                    _REPLACE_CACHED_ENTRY_SCRIPT, 1, key, observed, _new_absence_sentinel(), ACTION_ABSENCE_SENTINEL_TTL_SECONDS,
-                )
-        return bool(written)
+        return await self._write_absence_sentinel(
+            key, ttl=ACTION_ABSENCE_SENTINEL_TTL_SECONDS, mode="equals", expected=observed,
+        )
 
     async def install_action_configuration_if_missing(
             self, integration_id: str, action_id: str, *, config: IntegrationActionConfiguration,
@@ -357,9 +384,7 @@ class IntegrationConfigurationManager:
         # which would then report the same absence. Bounded like the reload's
         # sentinels, so a Deleted that outlives its integration ages out.
         key = self._get_action_config_key(integration_id, action_id)
-        async for attempt in stamina.retry_context(**REDIS_RETRY):
-            with attempt:
-                await self.db_client.set(key, _new_absence_sentinel(), ACTION_ABSENCE_SENTINEL_TTL_SECONDS)
+        await self._write_absence_sentinel(key, ttl=ACTION_ABSENCE_SENTINEL_TTL_SECONDS, mode="any")
 
     async def get_integration(self, integration_id: str, ttl=None) -> IntegrationSummary:
         key = self._get_integration_key(integration_id)

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -54,6 +54,19 @@ if redis.call('GET', KEYS[1]) == ARGV[1] and redis.call('TTL', KEYS[1]) == -1 th
 end
 return 0
 """
+# Replace the absence sentinel (or a key that has since expired) with a real
+# configuration, but never a configuration that landed in between. Used by the
+# consumer's Updated-after-sentinel recovery, which reads the portal and then
+# writes: two such recoveries for one action can race, and the slower one's
+# plain SET would restore its stale snapshot over the newer value.
+_REPLACE_ABSENCE_SENTINEL_SCRIPT = """
+local current = redis.call('GET', KEYS[1])
+if current == false or current == ARGV[1] then
+    redis.call('SET', KEYS[1], ARGV[2])
+    return 1
+end
+return 0
+"""
 
 
 class IntegrationConfigurationManager:
@@ -193,6 +206,19 @@ class IntegrationConfigurationManager:
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 await self.db_client.set(key, config.json(), ttl)
+
+    async def replace_absence_sentinel(
+            self, integration_id: str, action_id: str, *, config: IntegrationActionConfiguration,
+    ) -> bool:
+        """Write `config` only while the key still holds the absence sentinel
+        (or has expired). Returns whether the write happened; False means a
+        newer value is already there and the caller must not overwrite it.
+        Permanent, like every real configuration."""
+        key = self._get_action_config_key(integration_id, action_id)
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
+            with attempt:
+                written = await self.db_client.eval(_REPLACE_ABSENCE_SENTINEL_SCRIPT, 1, key, _ABSENCE_SENTINEL, config.json())
+        return bool(written)
 
     async def delete_action_configuration(self, integration_id: str, action_id: str):
         # Record the absence rather than dropping the key: a deleted key misses on

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -12,7 +12,7 @@ from redis.exceptions import RedisError
 from gundi_core.schemas.v2 import Integration, IntegrationSummary, IntegrationActionConfiguration, WebhookConfiguration
 from gundi_client_v2 import GundiClient
 from app import settings
-from .gundi import GUNDI_API_RETRY
+from .gundi import GUNDI_API_RETRY, _block_if_ephemeral
 from .retry_policies import REDIS_RETRY
 
 logger = logging.getLogger(__name__)
@@ -21,8 +21,9 @@ logger = logging.getLogger(__name__)
 # Cached marker meaning "this integration has no configuration for this
 # action" / "no webhook configuration", so a cold cache doesn't trigger a
 # Gundi API reload on every lookup of something the portal says is absent.
-# Action-config sentinels are invalidated by the same ActionConfig* events as
-# real configs; the webhook sentinel has no event and relies on its TTL.
+# Action-config sentinels are replaced by the ActionConfig* events for that
+# action and, as a backstop, expire (see ACTION_ABSENCE_SENTINEL_TTL_SECONDS);
+# the webhook sentinel has no event and relies on its TTL alone.
 _ABSENCE_SENTINEL = "null"
 _NO_WEBHOOK_CONFIG_SENTINEL = _ABSENCE_SENTINEL
 # Default expiry for the webhook key (the config itself or the absence
@@ -34,6 +35,15 @@ _NO_WEBHOOK_CONFIG_SENTINEL = _ABSENCE_SENTINEL
 # config change can take to reach a connector that is not also receiving
 # webhooks (the webhook path caches for 60 s on its own).
 WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS = 300
+# Expiry for an action absence sentinel when the caller asks for no TTL (the
+# action path). Real configs stay permanent because every change to them
+# arrives as an event; a sentinel's only correction is the ActionConfigCreated
+# event for that action, and the consumer acks a failed or lost delivery, so a
+# permanent "null" would keep the action "unconfigured" until someone flushed
+# redis. Bounded, the next lookup after expiry misses and the reload writes
+# whatever the portal now says. It also lets an orphan sentinel (a cascade
+# ActionConfigDeleted arriving after IntegrationDeleted) age out on its own.
+ACTION_ABSENCE_SENTINEL_TTL_SECONDS = 300
 
 
 class IntegrationConfigurationManager:
@@ -54,38 +64,50 @@ class IntegrationConfigurationManager:
     def _get_webhook_config_key(self, integration_id: str) -> str:
         return f"integrationconfig.{integration_id}.webhook"
 
-    async def _reload_integration_from_gundi(self, integration_id: str, ttl=None) -> Integration:
-        key = self._get_integration_key(integration_id)
+    async def _fetch_integration_from_gundi(self, integration_id: str) -> Integration:
+        # The one portal read both reloads share. Blocked on the ephemeral
+        # path: a draft integration has no portal row, so the read would 404
+        # and spin GUNDI_API_RETRY for up to two minutes on the request (the
+        # same guard, for the same reason, as gundi._get_gundi_api_key).
+        _block_if_ephemeral("IntegrationConfigurationManager reload")
         async with GundiClient() as gundi:
             async for attempt in stamina.retry_context(**GUNDI_API_RETRY):
                 with attempt:
                     integration_details = await gundi.get_integration_details(integration_id)
-            integration = IntegrationSummary.from_integration(integration_details)
-            await self.db_client.set(key, integration.json(), ttl)
-            # Save configurations for individual actions, and a sentinel for each
-            # action of the type that has none: otherwise every lookup of an
-            # unconfigured action misses and reloads from the Gundi API, so an
-            # integration configured for two of its type's three actions would
-            # hit the portal on every single run.
-            configured = set()
-            for config in integration_details.configurations:
-                configured.add(config.action.value)
-                config_key = self._get_action_config_key(integration_id, config.action.value)
-                await self.db_client.set(config_key, config.json(), ttl)
-            # Sentinels are written with NX so they never replace a key that is
-            # already there. A reload reads the portal, then writes; if an
-            # ActionConfigCreated event for one of these actions lands in
-            # between, its config would otherwise be overwritten with a
-            # permanent "null" that no later event corrects. With NX the event's
-            # write wins in either order: written first, it is left alone;
-            # written after, it replaces the sentinel as a plain SET.
-            for action in integration_details.type.actions or []:
-                if action.value not in configured:
-                    await self.db_client.set(
-                        self._get_action_config_key(integration_id, action.value), _ABSENCE_SENTINEL, ttl, nx=True,
-                    )
-            await self._cache_webhook_configuration(integration_id, integration_details.webhook_configuration, ttl)
-            return integration_details
+        return integration_details
+
+    async def _reload_integration_from_gundi(self, integration_id: str, ttl=None) -> Integration:
+        key = self._get_integration_key(integration_id)
+        integration_details = await self._fetch_integration_from_gundi(integration_id)
+        integration = IntegrationSummary.from_integration(integration_details)
+        await self.db_client.set(key, integration.json(), ttl)
+        # Save configurations for individual actions, and a sentinel for each
+        # action of the type that has none: otherwise every lookup of an
+        # unconfigured action misses and reloads from the Gundi API, so an
+        # integration configured for two of its type's three actions would
+        # hit the portal on every single run.
+        configured = set()
+        for config in integration_details.configurations:
+            configured.add(config.action.value)
+            config_key = self._get_action_config_key(integration_id, config.action.value)
+            await self.db_client.set(config_key, config.json(), ttl)
+        # Sentinels are written with NX so they never replace a key that is
+        # already there. A reload reads the portal, then writes; if an
+        # ActionConfigCreated event for one of these actions lands in
+        # between, its config would otherwise be overwritten with a "null"
+        # that no later event corrects. With NX the event's write wins in
+        # either order: written first, it is left alone; written after, it
+        # replaces the sentinel as a plain SET. The sentinel also expires
+        # (ACTION_ABSENCE_SENTINEL_TTL_SECONDS) for the case where that event
+        # never arrives at all.
+        sentinel_ttl = ttl if ttl is not None else ACTION_ABSENCE_SENTINEL_TTL_SECONDS
+        for action in integration_details.type.actions or []:
+            if action.value not in configured:
+                await self.db_client.set(
+                    self._get_action_config_key(integration_id, action.value), _ABSENCE_SENTINEL, sentinel_ttl, nx=True,
+                )
+        await self._cache_webhook_configuration(integration_id, integration_details.webhook_configuration, ttl)
+        return integration_details
 
     async def _cache_webhook_configuration(self, integration_id: str, webhook_configuration, ttl=None):
         # Save the webhook configuration, or a sentinel marking its absence, so
@@ -111,10 +133,7 @@ class IntegrationConfigurationManager:
         event-invalidated keys would be downgraded to a 60 s expiry and the next
         action run would go back to the portal.
         """
-        async with GundiClient() as gundi:
-            async for attempt in stamina.retry_context(**GUNDI_API_RETRY):
-                with attempt:
-                    integration_details = await gundi.get_integration_details(integration_id)
+        integration_details = await self._fetch_integration_from_gundi(integration_id)
         await self._cache_webhook_configuration(integration_id, integration_details.webhook_configuration, ttl)
         return integration_details.webhook_configuration
 
@@ -153,11 +172,12 @@ class IntegrationConfigurationManager:
     async def delete_action_configuration(self, integration_id: str, action_id: str):
         # Record the absence rather than dropping the key: a deleted key misses on
         # the next lookup and reloads the whole integration from the Gundi API,
-        # which would then report the same absence.
+        # which would then report the same absence. Bounded like the reload's
+        # sentinels, so a Deleted that outlives its integration ages out.
         key = self._get_action_config_key(integration_id, action_id)
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
-                await self.db_client.set(key, _ABSENCE_SENTINEL)
+                await self.db_client.set(key, _ABSENCE_SENTINEL, ACTION_ABSENCE_SENTINEL_TTL_SECONDS)
 
     async def get_integration(self, integration_id: str, ttl=None) -> IntegrationSummary:
         key = self._get_integration_key(integration_id)

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -2,9 +2,11 @@ import json
 import logging
 from typing import Optional
 
+import pydantic
 import stamina
 import httpx
 import redis.asyncio as redis
+from redis.exceptions import RedisError
 from gundi_core.schemas.v2 import Integration, IntegrationSummary, IntegrationActionConfiguration, WebhookConfiguration
 from gundi_client_v2 import GundiClient
 from app import settings
@@ -25,6 +27,11 @@ _NO_WEBHOOK_CONFIG_SENTINEL = "null"
 # config change can take to reach a connector that is not also receiving
 # webhooks (the webhook path caches for 60 s on its own).
 WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS = 300
+
+# Retry policy for every Redis call in this module. Iterated with `async for`:
+# stamina's synchronous iterator sleeps with time.sleep, which inside a
+# coroutine stalls the whole event loop for the length of the back-off.
+REDIS_RETRY = dict(on=RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0)
 
 
 class IntegrationConfigurationManager:
@@ -73,7 +80,7 @@ class IntegrationConfigurationManager:
 
     async def get_action_configuration(self, integration_id: str, action_id: str, ttl=None) -> Optional[IntegrationActionConfiguration]:
         key = self._get_action_config_key(integration_id, action_id)
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 data = await self.db_client.get(key)
         if data:
@@ -84,7 +91,7 @@ class IntegrationConfigurationManager:
 
     async def get_webhook_configuration(self, integration_id: str, ttl=None) -> Optional[WebhookConfiguration]:
         key = self._get_webhook_config_key(integration_id)
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 data = await self.db_client.get(key)
         if data:
@@ -98,19 +105,19 @@ class IntegrationConfigurationManager:
 
     async def set_action_configuration(self, integration_id: str, action_id: str, config: IntegrationActionConfiguration, ttl=None):
         key = self._get_action_config_key(integration_id, action_id)
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 await self.db_client.set(key, config.json(), ttl)
 
     async def delete_action_configuration(self, integration_id: str, action_id: str):
         key = self._get_action_config_key(integration_id, action_id)
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 return await self.db_client.delete(key)
 
     async def get_integration(self, integration_id: str, ttl=None) -> IntegrationSummary:
         key = self._get_integration_key(integration_id)
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 integration_data = await self.db_client.get(key)
         if integration_data:
@@ -122,7 +129,7 @@ class IntegrationConfigurationManager:
 
     async def set_integration(self, integration: IntegrationSummary, ttl=None):
         key = self._get_integration_key(integration.id)
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 await self.db_client.set(key, integration.json(), ttl)
 
@@ -136,27 +143,44 @@ class IntegrationConfigurationManager:
         # keys we can name still get deleted.
         integration_key = self._get_integration_key(integration_id)
         keys = [integration_key, self._get_webhook_config_key(integration_id)]
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
-            with attempt:
-                summary_data = await self.db_client.get(integration_key)
-        if summary_data:
-            try:
+        try:
+            async for attempt in stamina.retry_context(**REDIS_RETRY):
+                with attempt:
+                    summary_data = await self.db_client.get(integration_key)
+            if summary_data:
                 summary = IntegrationSummary.parse_raw(summary_data)
-                keys += [self._get_action_config_key(integration_id, a.value) for a in summary.type.actions]
-            except Exception as e:
-                logger.warning(f"Could not read cached summary for integration '{integration_id}' to drop its action keys: {e}")
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+                keys += [self._get_action_config_key(integration_id, a.value) for a in (summary.type.actions or [])]
+        except (RedisError, pydantic.ValidationError) as e:
+            logger.warning(
+                f"Could not read the cached summary for integration '{integration_id}' "
+                f"to drop its action keys ({type(e).__name__}); deleting the keys that can be named."
+            )
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 await self.db_client.delete(*keys)
 
-    async def get_integration_details(self, integration_id: str, ttl=None) -> Integration:
+    async def get_integration_details(
+            self, integration_id: str, ttl=None, *, include_webhook_config: bool = True,
+    ) -> Integration:
+        """Assemble an Integration from the cached summary, action configs and,
+        unless include_webhook_config is False, the webhook config.
+
+        The webhook key is the one piece of the cache that no config event
+        invalidates, so it carries a bounded TTL and reloads from the Gundi API
+        when it expires. The action runner never reads webhook_configuration,
+        so it opts out: otherwise every action run would go back to the portal
+        once per TTL, and a portal outage would fail actions whose own summary
+        and configs were still warm.
+        """
         integration_summary = await self.get_integration(integration_id, ttl)
         configurations = []
         for action in integration_summary.type.actions:
             config = await self.get_action_configuration(integration_id, action.value, ttl)
             if config:
                 configurations.append(config)
-        webhook_configuration = await self.get_webhook_configuration(integration_id, ttl)
+        webhook_configuration = (
+            await self.get_webhook_configuration(integration_id, ttl) if include_webhook_config else None
+        )
         return Integration(
             id=integration_summary.id,
             name=integration_summary.name,

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 import uuid
 from typing import Optional, Tuple
 
@@ -26,19 +27,22 @@ logger = logging.getLogger(__name__)
 # action and, as a backstop, expire (see ACTION_ABSENCE_SENTINEL_TTL_SECONDS);
 # the webhook sentinel has no event and relies on its TTL alone.
 #
-# Every action sentinel write carries its own generation ("null:<hex>"). The
-# consumer's Updated-after-sentinel recovery reads the sentinel, fetches the
-# portal, then replaces the sentinel only if it is still the one it observed;
-# were every sentinel the same bare value, a concurrent ActionConfigDeleted's
-# fresh tombstone would compare equal and the recovery would resurrect the
-# deleted config as a permanent key. Sentinels written before generations
-# existed are the bare value and still read as absence.
+# Every action sentinel write carries its own generation
+# ("null:<write time, ns>:<hex>"). Two readers depend on it. The consumer's
+# recovery reads the sentinel, fetches the portal, then replaces the sentinel
+# only if it is still the one it observed; were every sentinel the same bare
+# value, a concurrent ActionConfigDeleted's fresh tombstone would compare equal
+# and the recovery would resurrect the deleted config as a permanent key. The
+# reload compares the write time with the start of its own portal fetch, so a
+# tombstone written while the fetch was in flight is preserved over the stale
+# snapshot (see _WRITE_SNAPSHOT_CONFIG_SCRIPT). Sentinels written before
+# generations existed are the bare value and still read as absence.
 _ABSENCE_SENTINEL_PREFIX = "null"
 _NO_WEBHOOK_CONFIG_SENTINEL = "null"
 
 
 def _new_absence_sentinel() -> str:
-    return f"{_ABSENCE_SENTINEL_PREFIX}:{uuid.uuid4().hex}"
+    return f"{_ABSENCE_SENTINEL_PREFIX}:{time.time_ns()}:{uuid.uuid4().hex}"
 
 
 def _is_absence_sentinel(data) -> bool:
@@ -93,10 +97,36 @@ return 0
 # the deleted config. Every consumer write of an action config goes through it.
 _REPLACE_CACHED_ENTRY_SCRIPT = """
 if redis.call('GET', KEYS[1]) == ARGV[1] then
-    redis.call('SET', KEYS[1], ARGV[2])
+    if ARGV[3] == '' then
+        redis.call('SET', KEYS[1], ARGV[2])
+    else
+        redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3])
+    end
     return 1
 end
 return 0
+"""
+# The reload's write of one configured action from its portal snapshot. Refuses
+# to overwrite an absence sentinel written at or after the fetch began: that is
+# a concurrent ActionConfigDeleted's tombstone, newer than the snapshot, and an
+# unconditional SET would resurrect the deleted config permanently. Anything
+# else (a real config, an older sentinel, nothing) is replaced by the snapshot,
+# which is the portal's truth as of the fetch. Clocks across runner instances
+# are assumed close relative to the length of a portal round trip.
+_WRITE_SNAPSHOT_CONFIG_SCRIPT = """
+local current = redis.call('GET', KEYS[1])
+if current then
+    local written_ns = string.match(current, '^null:(%d+):')
+    if written_ns and tonumber(written_ns) >= tonumber(ARGV[2]) then
+        return 0
+    end
+end
+if ARGV[3] == '' then
+    redis.call('SET', KEYS[1], ARGV[1])
+else
+    redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[3])
+end
+return 1
 """
 
 
@@ -132,6 +162,7 @@ class IntegrationConfigurationManager:
 
     async def _reload_integration_from_gundi(self, integration_id: str, ttl=None) -> Integration:
         key = self._get_integration_key(integration_id)
+        fetch_started_ns = time.time_ns()
         integration_details = await self._fetch_integration_from_gundi(integration_id)
         integration = IntegrationSummary.from_integration(integration_details)
         await self.db_client.set(key, integration.json(), ttl)
@@ -139,12 +170,16 @@ class IntegrationConfigurationManager:
         # action of the type that has none: otherwise every lookup of an
         # unconfigured action misses and reloads from the Gundi API, so an
         # integration configured for two of its type's three actions would
-        # hit the portal on every single run.
+        # hit the portal on every single run. Configured actions are written
+        # through a script that preserves a tombstone newer than the fetch
+        # (see _WRITE_SNAPSHOT_CONFIG_SCRIPT).
         configured = set()
         for config in integration_details.configurations:
             configured.add(config.action.value)
             config_key = self._get_action_config_key(integration_id, config.action.value)
-            await self.db_client.set(config_key, config.json(), ttl)
+            await self.db_client.eval(
+                _WRITE_SNAPSHOT_CONFIG_SCRIPT, 1, config_key, config.json(), fetch_started_ns, ttl if ttl is not None else "",
+            )
         # Sentinels are written with NX so they never replace a key that is
         # already there. A reload reads the portal, then writes; if an
         # ActionConfigCreated event for one of these actions lands in
@@ -287,7 +322,20 @@ class IntegrationConfigurationManager:
         key = self._get_action_config_key(integration_id, action_id)
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
-                written = await self.db_client.eval(_REPLACE_CACHED_ENTRY_SCRIPT, 1, key, observed, config.json())
+                written = await self.db_client.eval(_REPLACE_CACHED_ENTRY_SCRIPT, 1, key, observed, config.json(), "")
+        return bool(written)
+
+    async def replace_cached_entry_with_absence(self, integration_id: str, action_id: str, *, observed: str) -> bool:
+        """Record an absence (a fresh, expiring sentinel) only while the key
+        still holds `observed`. The consumer's reconciliation uses it when the
+        portal says the row is gone; the same exactness rule as
+        replace_cached_entry applies."""
+        key = self._get_action_config_key(integration_id, action_id)
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
+            with attempt:
+                written = await self.db_client.eval(
+                    _REPLACE_CACHED_ENTRY_SCRIPT, 1, key, observed, _new_absence_sentinel(), ACTION_ABSENCE_SENTINEL_TTL_SECONDS,
+                )
         return bool(written)
 
     async def install_action_configuration_if_missing(
@@ -302,17 +350,6 @@ class IntegrationConfigurationManager:
             with attempt:
                 written = await self.db_client.set(key, config.json(), None, nx=True)
         return bool(written)
-
-    async def invalidate_action_configuration(self, integration_id: str, action_id: str) -> None:
-        """Drop the cached entry for this action, whatever it holds, so the next
-        lookup misses and rebuilds it from the portal. The consumer's last
-        resort after losing its compare-and-set race repeatedly: writing
-        anything could overwrite a newer value or tombstone, and leaving a
-        stale permanent config behind an acked event would never self-heal."""
-        key = self._get_action_config_key(integration_id, action_id)
-        async for attempt in stamina.retry_context(**REDIS_RETRY):
-            with attempt:
-                await self.db_client.delete(key)
 
     async def delete_action_configuration(self, integration_id: str, action_id: str):
         # Record the absence rather than dropping the key: a deleted key misses on

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Optional
 
 import stamina
@@ -7,14 +8,23 @@ import redis.asyncio as redis
 from gundi_core.schemas.v2 import Integration, IntegrationSummary, IntegrationActionConfiguration, WebhookConfiguration
 from gundi_client_v2 import GundiClient
 from app import settings
+from .gundi import GUNDI_API_RETRY
+
+logger = logging.getLogger(__name__)
 
 
 # Cached marker meaning "this integration has no webhook configuration", so a
 # cold cache doesn't trigger a Gundi API reload on every webhook-config lookup.
 _NO_WEBHOOK_CONFIG_SENTINEL = "null"
-# How long a cached "this integration has no webhook config" marker survives
-# when the caller specified no TTL. Bounded so it self-heals -- see below.
-NO_WEBHOOK_CONFIG_TTL_SECONDS = 3600
+# Default expiry for the webhook key (the config itself or the absence
+# sentinel) when the caller asks for no TTL, which the action path does. There
+# is no WebhookConfig* event to invalidate that key on, no consumer handler
+# touches it, and a cache hit never refreshes it, so a permanent entry would
+# serve a stale or missing webhook config until someone deleted it by hand.
+# Bounded so it self-heals; five minutes is the longest an operator's webhook
+# config change can take to reach a connector that is not also receiving
+# webhooks (the webhook path caches for 60 s on its own).
+WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS = 300
 
 
 class IntegrationConfigurationManager:
@@ -38,7 +48,7 @@ class IntegrationConfigurationManager:
     async def _reload_integration_from_gundi(self, integration_id: str, ttl=None) -> Integration:
         key = self._get_integration_key(integration_id)
         async with GundiClient() as gundi:
-            async for attempt in stamina.retry_context(on=httpx.HTTPError, wait_initial=1.0, wait_jitter=5.0,  wait_max=32.0):
+            async for attempt in stamina.retry_context(**GUNDI_API_RETRY):
                 with attempt:
                     integration_details = await gundi.get_integration_details(integration_id)
             integration = IntegrationSummary.from_integration(integration_details)
@@ -49,20 +59,16 @@ class IntegrationConfigurationManager:
                 await self.db_client.set(config_key, config.json(), ttl)
             # Save the webhook configuration — or a sentinel marking its absence, so
             # integrations without one don't reload from the Gundi API on every lookup
+            # Both the config and the sentinel always expire, even when the
+            # caller asked for no TTL (see WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS).
+            # A plain SET also clears any TTL the webhook path had put on the
+            # same key, so an unbounded write here would undo its 60 s cache.
             webhook_key = self._get_webhook_config_key(integration_id)
+            webhook_ttl = ttl if ttl is not None else WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS
             if webhook_configuration := integration_details.webhook_configuration:
-                await self.db_client.set(webhook_key, webhook_configuration.json(), ttl)
+                await self.db_client.set(webhook_key, webhook_configuration.json(), webhook_ttl)
             else:
-                # The absence sentinel always expires, even when the caller asked
-                # for no TTL. There is no WebhookConfigCreated event to invalidate
-                # it on, so a permanent sentinel would keep serving "no webhook"
-                # after an operator adds one in the portal — breaking every
-                # delivery until someone deleted the key by hand.
-                await self.db_client.set(
-                    webhook_key,
-                    _NO_WEBHOOK_CONFIG_SENTINEL,
-                    ttl if ttl is not None else NO_WEBHOOK_CONFIG_TTL_SECONDS,
-                )
+                await self.db_client.set(webhook_key, _NO_WEBHOOK_CONFIG_SENTINEL, webhook_ttl)
             return integration_details
 
     async def get_action_configuration(self, integration_id: str, action_id: str, ttl=None) -> Optional[IntegrationActionConfiguration]:
@@ -120,20 +126,28 @@ class IntegrationConfigurationManager:
             with attempt:
                 await self.db_client.set(key, integration.json(), ttl)
 
-    async def delete_webhook_configuration(self, integration_id: str):
-        key = self._get_webhook_config_key(integration_id)
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
-            with attempt:
-                await self.db_client.delete(key)
-
     async def delete_integration(self, integration_id: str):
-        key = self._get_integration_key(integration_id)
+        # Every key derived from this integration goes in one variadic DEL: the
+        # webhook key (config or absence sentinel) and the per-action config
+        # keys are addressed separately, so leaving them behind lets them
+        # outlive their owner, and a single round-trip has no partial-failure
+        # window between the keys. The action list lives in the summary that is
+        # about to go, so read it first; if it is gone or unreadable, the two
+        # keys we can name still get deleted.
+        integration_key = self._get_integration_key(integration_id)
+        keys = [integration_key, self._get_webhook_config_key(integration_id)]
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
-                await self.db_client.delete(key)
-        # The webhook key (config or absence sentinel) is addressed separately,
-        # so deleting the integration must drop it too or it outlives its owner.
-        await self.delete_webhook_configuration(integration_id)
+                summary_data = await self.db_client.get(integration_key)
+        if summary_data:
+            try:
+                summary = IntegrationSummary.parse_raw(summary_data)
+                keys += [self._get_action_config_key(integration_id, a.value) for a in summary.type.actions]
+            except Exception as e:
+                logger.warning(f"Could not read cached summary for integration '{integration_id}' to drop its action keys: {e}")
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+            with attempt:
+                await self.db_client.delete(*keys)
 
     async def get_integration_details(self, integration_id: str, ttl=None) -> Integration:
         integration_summary = await self.get_integration(integration_id, ttl)

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import uuid
-from typing import Optional
+from typing import Optional, Tuple
 
 import pydantic
 import stamina
@@ -191,6 +191,18 @@ class IntegrationConfigurationManager:
         return integration_details.webhook_configuration
 
     async def get_action_configuration(self, integration_id: str, action_id: str, ttl=None) -> Optional[IntegrationActionConfiguration]:
+        config, _ = await self.get_action_configuration_and_sentinel(integration_id, action_id, ttl)
+        return config
+
+    async def get_action_configuration_and_sentinel(
+            self, integration_id: str, action_id: str, ttl=None,
+    ) -> Tuple[Optional[IntegrationActionConfiguration], Optional[str]]:
+        """get_action_configuration, plus the exact absence sentinel when the
+        cache recorded the absence (None otherwise, including after a portal
+        reload). For a caller that will later compare-and-set against that
+        sentinel (replace_absence_sentinel): the value must come from the very
+        read that established the absence, since a second read could observe
+        a fresh tombstone written by a concurrent ActionConfigDeleted."""
         key = self._get_action_config_key(integration_id, action_id)
         async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
@@ -198,24 +210,12 @@ class IntegrationConfigurationManager:
         if data:
             if _is_absence_sentinel(data):
                 await self._expire_legacy_sentinel(key, data)
-                return None  # cached absence: the portal has no config for this action
-            return IntegrationActionConfiguration.parse_raw(data)
+                observed = data.decode() if isinstance(data, bytes) else data
+                return None, observed  # cached absence: the portal has no config for this action
+            return IntegrationActionConfiguration.parse_raw(data), None
         # If not found in the redis db, try reloading data from Gundi API
         integration_details = await self._reload_integration_from_gundi(integration_id, ttl)
-        return integration_details.get_action_config(action_id)
-
-    async def read_absence_sentinel(self, integration_id: str, action_id: str) -> Optional[str]:
-        """The exact absence sentinel currently cached for this action, or None
-        when the key holds a real configuration or nothing. For callers that
-        will later replace the sentinel and must name the generation they saw
-        (see replace_absence_sentinel). Never reloads from the portal."""
-        key = self._get_action_config_key(integration_id, action_id)
-        async for attempt in stamina.retry_context(**REDIS_RETRY):
-            with attempt:
-                data = await self.db_client.get(key)
-        if data and _is_absence_sentinel(data):
-            return data.decode() if isinstance(data, bytes) else data
-        return None
+        return integration_details.get_action_config(action_id), None
 
     async def _expire_legacy_sentinel(self, key: str, observed) -> None:
         # Sentinels written before they carried a TTL are permanent, and the
@@ -269,7 +269,8 @@ class IntegrationConfigurationManager:
             self, integration_id: str, action_id: str, *, config: IntegrationActionConfiguration, observed: str,
     ) -> bool:
         """Write `config` only while the key still holds `observed`, the exact
-        sentinel the caller read (see read_absence_sentinel), or has expired.
+        sentinel the caller read (see get_action_configuration_and_sentinel),
+        or has expired.
         Returns whether the write happened; False means something newer is
         there, a real configuration or a fresh tombstone from a concurrent
         ActionConfigDeleted, and the caller must not overwrite it. Permanent,

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -12,6 +12,9 @@ from app import settings
 # Cached marker meaning "this integration has no webhook configuration", so a
 # cold cache doesn't trigger a Gundi API reload on every webhook-config lookup.
 _NO_WEBHOOK_CONFIG_SENTINEL = "null"
+# How long a cached "this integration has no webhook config" marker survives
+# when the caller specified no TTL. Bounded so it self-heals -- see below.
+NO_WEBHOOK_CONFIG_TTL_SECONDS = 3600
 
 
 class IntegrationConfigurationManager:
@@ -50,7 +53,16 @@ class IntegrationConfigurationManager:
             if webhook_configuration := integration_details.webhook_configuration:
                 await self.db_client.set(webhook_key, webhook_configuration.json(), ttl)
             else:
-                await self.db_client.set(webhook_key, _NO_WEBHOOK_CONFIG_SENTINEL, ttl)
+                # The absence sentinel always expires, even when the caller asked
+                # for no TTL. There is no WebhookConfigCreated event to invalidate
+                # it on, so a permanent sentinel would keep serving "no webhook"
+                # after an operator adds one in the portal — breaking every
+                # delivery until someone deleted the key by hand.
+                await self.db_client.set(
+                    webhook_key,
+                    _NO_WEBHOOK_CONFIG_SENTINEL,
+                    ttl if ttl is not None else NO_WEBHOOK_CONFIG_TTL_SECONDS,
+                )
             return integration_details
 
     async def get_action_configuration(self, integration_id: str, action_id: str, ttl=None) -> Optional[IntegrationActionConfiguration]:
@@ -108,11 +120,20 @@ class IntegrationConfigurationManager:
             with attempt:
                 await self.db_client.set(key, integration.json(), ttl)
 
+    async def delete_webhook_configuration(self, integration_id: str):
+        key = self._get_webhook_config_key(integration_id)
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+            with attempt:
+                await self.db_client.delete(key)
+
     async def delete_integration(self, integration_id: str):
         key = self._get_integration_key(integration_id)
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
                 await self.db_client.delete(key)
+        # The webhook key (config or absence sentinel) is addressed separately,
+        # so deleting the integration must drop it too or it outlives its owner.
+        await self.delete_webhook_configuration(integration_id)
 
     async def get_integration_details(self, integration_id: str, ttl=None) -> Integration:
         integration_summary = await self.get_integration(integration_id, ttl)

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -303,6 +303,17 @@ class IntegrationConfigurationManager:
                 written = await self.db_client.set(key, config.json(), None, nx=True)
         return bool(written)
 
+    async def invalidate_action_configuration(self, integration_id: str, action_id: str) -> None:
+        """Drop the cached entry for this action, whatever it holds, so the next
+        lookup misses and rebuilds it from the portal. The consumer's last
+        resort after losing its compare-and-set race repeatedly: writing
+        anything could overwrite a newer value or tombstone, and leaving a
+        stale permanent config behind an acked event would never self-heal."""
+        key = self._get_action_config_key(integration_id, action_id)
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
+            with attempt:
+                await self.db_client.delete(key)
+
     async def delete_action_configuration(self, integration_id: str, action_id: str):
         # Record the absence rather than dropping the key: a deleted key misses on
         # the next lookup and reloads the whole integration from the Gundi API,

--- a/app/services/core.py
+++ b/app/services/core.py
@@ -6,3 +6,4 @@ class ActionTypeEnum(str, Enum):
     PULL_DATA = "pull"
     PUSH_DATA = "push"
     GENERIC = "generic"
+    REFERENCE = "reference"

--- a/app/services/errors.py
+++ b/app/services/errors.py
@@ -97,8 +97,11 @@ def classify_error(exc: Exception) -> Optional[ClassifiedError]:
             status_code=getattr(exc, "status_code", None),
         )
 
-    # getattr chain: non-HTTP exceptions have no .response attribute.
+    # getattr chain: non-HTTP exceptions have no .response attribute. aiohttp
+    # carries the status on the exception itself (.status), not on a response.
     status_code = getattr(getattr(exc, "response", None), "status_code", None)
+    if status_code is None and isinstance(exc, aiohttp.ClientResponseError):
+        status_code = exc.status
     # httpx.HTTPStatusError from raise_for_status() stringifies to multi-line
     # text (URL plus a "For more information check: ..." line) — only the
     # first line is useful as a short, human-first message.

--- a/app/services/errors.py
+++ b/app/services/errors.py
@@ -64,6 +64,20 @@ class IntegrationBadResponseError(IntegrationError):
     default_title = "Unexpected response from the provider"
 
 
+class IntegrationConfigurationError(IntegrationError):
+    """A problem the connector found with the integration's own configuration
+    or a query parameter (an empty site URL, an unknown event type), rather
+    than a verdict from the provider.
+
+    Connector-authored, but by contract the message describes the shape of
+    the problem without echoing the submitted values, so the ephemeral path
+    forwards it (as a 422) where it redacts every other connector message
+    (see action_runner._ephemeral_error_text).
+    """
+    error_type = "configuration"
+    default_title = "Invalid configuration"
+
+
 class ClassifiedError(NamedTuple):
     error_type: str
     title: str
@@ -140,15 +154,17 @@ def classify_error(exc: Exception) -> Optional[ClassifiedError]:
     return None
 
 
-def format_classified_error(classified: ClassifiedError) -> str:
+def format_classified_error(classified: ClassifiedError, *, include_message: bool = True) -> str:
     """Build the clean text: "<title> — <message> (HTTP <status>)".
 
     The portal prepends "Error running action '<id>': " to this string, so it
     must be short and lead with what an operator needs to see. The message
-    segment is skipped when redundant; the HTTP suffix when unknown.
+    segment is skipped when redundant, or when the caller passes
+    include_message=False (the ephemeral path, where the message may carry
+    str(exc) from the source); the HTTP suffix when unknown.
     """
     text = classified.title
-    if classified.message and classified.message != classified.title:
+    if include_message and classified.message and classified.message != classified.title:
         text = f"{text} — {classified.message}"
     if classified.status_code:
         text = f"{text} (HTTP {classified.status_code})"

--- a/app/services/errors.py
+++ b/app/services/errors.py
@@ -81,6 +81,33 @@ CONNECTIVITY_EXCEPTIONS = (
 )
 
 
+def source_status_code(exc: Exception) -> Optional[int]:
+    """The HTTP status the third party answered with, if the exception carries one.
+
+    Three shapes carry it: `IntegrationError.status_code`, aiohttp's
+    `ClientResponseError.status`, and the duck-typed `.response.status_code`
+    (httpx.HTTPStatusError, requests.HTTPError, and anything else that keeps
+    the response on the exception). This is the single reader shared by the
+    classifier and the ephemeral status forwarding, so the text and the HTTP
+    status the runner returns can never disagree about which status they saw.
+
+    Connectors are free to pre-set `status_code` on their own exception
+    hierarchies, so it is not trusted to be an int: anything else (a "401"
+    string, a bool) reads as unknown rather than raising inside an except
+    block, which would replace the redacted error with the raw one.
+    """
+    if isinstance(exc, IntegrationError):
+        code = getattr(exc, "status_code", None)
+    elif isinstance(exc, aiohttp.ClientResponseError):
+        code = exc.status
+    else:
+        # getattr chain: non-HTTP exceptions have no .response attribute.
+        code = getattr(getattr(exc, "response", None), "status_code", None)
+    if isinstance(code, bool) or not isinstance(code, int):
+        return None
+    return code
+
+
 def classify_error(exc: Exception) -> Optional[ClassifiedError]:
     """Classify a third-party failure for consistent activity-log reporting.
 
@@ -89,19 +116,15 @@ def classify_error(exc: Exception) -> Optional[ClassifiedError]:
     (`exc.response.status_code`, exception type). Returns None when the error
     can't be classified — callers keep the generic format.
     """
+    status_code = source_status_code(exc)
     if isinstance(exc, IntegrationError):
         return ClassifiedError(
             error_type=exc.error_type,
             title=exc.default_title,
             message=getattr(exc, "message", None) or "",
-            status_code=getattr(exc, "status_code", None),
+            status_code=status_code,
         )
 
-    # getattr chain: non-HTTP exceptions have no .response attribute. aiohttp
-    # carries the status on the exception itself (.status), not on a response.
-    status_code = getattr(getattr(exc, "response", None), "status_code", None)
-    if status_code is None and isinstance(exc, aiohttp.ClientResponseError):
-        status_code = exc.status
     # httpx.HTTPStatusError from raise_for_status() stringifies to multi-line
     # text (URL plus a "For more information check: ..." line) — only the
     # first line is useful as a short, human-first message.

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -27,11 +27,14 @@ def _block_if_ephemeral(op: str) -> None:
         )
 
 
-# One retry policy for every Gundi API call (the send helpers below and the
-# config manager's reloads), defined once so the wait curve and the stop
-# condition can't drift apart, and applied exactly once per call path:
-# nesting it (a decorated helper calling another decorated helper) multiplies
-# the attempts.
+# One retry policy for every request-time Gundi API call (the send helpers
+# below and the config manager's reloads), defined once so the wait curve and
+# the stop condition can't drift apart, and applied exactly once per call
+# path: nesting it (a decorated helper calling another decorated helper)
+# multiplies the attempts. Self-registration is the deliberate exception: a
+# one-shot startup/CLI path that keeps its own three-attempt policy in
+# self_registration.py, so a slow portal fails the boot fast instead of
+# holding the process for two minutes.
 #
 # stamina combines `attempts` and `timeout` with stop_any(), so the tighter
 # one wins, and its defaults (attempts=10 / timeout=45 s) silently truncate a

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -27,7 +27,25 @@ def _block_if_ephemeral(op: str) -> None:
         )
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
+# One retry policy for every Gundi API call, defined once so the wait curve and
+# the stop condition can't drift apart.
+#
+# `attempts` and `timeout` are both spelled out on purpose: stamina combines
+# them with stop_any(), so the tighter one wins, and its defaults are
+# attempts=10 / timeout=45s. With the waits below (10-20s, then 20-30s, ...)
+# the default 45s budget expires after ~3 attempts and wait_max=300 is never
+# reachable -- the declared backoff would silently not be the real one.
+GUNDI_API_RETRY = dict(
+    on=httpx.HTTPError,
+    attempts=10,
+    timeout=180.0,
+    wait_initial=10.0,
+    wait_jitter=10.0,
+    wait_max=300.0,
+)
+
+
+@stamina.retry(**GUNDI_API_RETRY)
 async def _get_gundi_api_key(integration_id):
     # An ephemeral run's synthetic integration has no persisted api key —
     # letting this reach the portal would 404 and then stamina would retry
@@ -48,7 +66,7 @@ async def _get_sensors_api_client(integration_id):
     return sensors_api_client
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
+@stamina.retry(**GUNDI_API_RETRY)
 async def send_events_to_gundi(events: List[dict], **kwargs) -> dict:
     """
     Send Events to Gundi using the REST API v2
@@ -78,7 +96,7 @@ async def send_events_to_gundi(events: List[dict], **kwargs) -> dict:
     return await sensors_api_client.post_events(data=events)
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
+@stamina.retry(**GUNDI_API_RETRY)
 async def send_event_attachments_to_gundi(event_id: str, attachments: List[tuple], **kwargs) -> dict:
     """
     Send Event Attachments to Gundi using the REST API v2
@@ -97,7 +115,7 @@ async def send_event_attachments_to_gundi(event_id: str, attachments: List[tuple
     return await sensors_api_client.post_event_attachments(event_id=event_id, attachments=attachments)
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
+@stamina.retry(**GUNDI_API_RETRY)
 async def send_observations_to_gundi(observations: List[dict], **kwargs) -> dict:
     """
     Send Observations to Gundi using the REST API v2
@@ -128,7 +146,7 @@ async def send_observations_to_gundi(observations: List[dict], **kwargs) -> dict
     return await sensors_api_client.post_observations(data=observations)
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
+@stamina.retry(**GUNDI_API_RETRY)
 async def send_messages_to_gundi(messages: List[dict], **kwargs) -> dict:
     """
     Send Messages to Gundi using the REST API v2

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -39,12 +39,14 @@ def _block_if_ephemeral(op: str) -> None:
 # n = 0..4, i.e. 2-7, 4-9, 8-13, 16-21 and 30 s: 60-80 s of waiting in total
 # for six attempts, inside the 120 s budget whenever the calls themselves are
 # quick. tenacity checks the stop after a failed attempt and then sleeps the
-# full wait, so the hard ceiling for one failing call is timeout + wait_max
-# plus one request, about 2.5 minutes. Gundi sends run inline in the PubSub
-# push request by default (PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND=False), so
-# that ceiling must stay well under the push ack deadline and the platform's
-# request timeout (Cloud Run defaults to 300 s); see the tests in
-# test_gundi_api.py that pin both properties.
+# full wait, so the loop's own overhead for one failing call is bounded by
+# timeout + wait_max = 150 s. The requests themselves come on top of that:
+# GundiDataSenderClient posts with an httpx timeout of 120 s, so a Sensors
+# API that hangs rather than fails can hold one send for roughly four and a
+# half minutes. Gundi sends run inline in the PubSub push request by default
+# (PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND=False), so deployments that expect
+# hangs should turn background processing on or shorten this policy; the
+# tests in test_gundi_api.py pin the loop-overhead bound.
 GUNDI_API_RETRY = dict(
     on=httpx.HTTPError,
     attempts=6,

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -4,9 +4,28 @@ import httpx
 import stamina
 from gundi_client_v2.client import GundiClient, GundiDataSenderClient
 
+from .activity_logger import ephemeral_run
+
+
+class EphemeralWriteBlocked(RuntimeError):
+    """Raised when a reference handler running against a draft integration
+    tries to move data through Gundi. Reference actions are read-only by
+    contract — a draft-credential run must never publish or send events."""
+
+
+def _block_if_ephemeral(op: str) -> None:
+    if ephemeral_run.get():
+        raise EphemeralWriteBlocked(
+            f"{op} is not allowed on the ephemeral (draft-integration) path"
+        )
+
 
 @stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
 async def _get_gundi_api_key(integration_id):
+    # An ephemeral run's synthetic integration has no persisted api key —
+    # letting this reach the portal would 404 and then stamina would retry
+    # for up to 5 minutes with the portal-facing request thread held.
+    _block_if_ephemeral("_get_gundi_api_key")
     async with GundiClient() as gundi_client:
         return await gundi_client.get_integration_api_key(
             integration_id=integration_id
@@ -24,6 +43,7 @@ async def _get_sensors_api_client(integration_id):
 
 @stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
 async def send_events_to_gundi(events: List[dict], **kwargs) -> dict:
+    _block_if_ephemeral("send_events_to_gundi")
     """
     Send Events to Gundi using the REST API v2
     :param events: A list of events in the following format:
@@ -63,6 +83,7 @@ async def send_event_attachments_to_gundi(event_id: str, attachments: List[tuple
     :param kwargs: integration_id: The UUID of the related integration
     :return: A dict with the response from the API
     """
+    _block_if_ephemeral("send_event_attachments_to_gundi")
     integration_id = kwargs.get("integration_id")
     assert integration_id, "integration_id is required"
     sensors_api_client = await _get_sensors_api_client(integration_id=str(integration_id))
@@ -93,6 +114,7 @@ async def send_observations_to_gundi(observations: List[dict], **kwargs) -> dict
     :param kwargs: integration_id: The UUID of the related integration
     :return: A dict with the response from the API
     """
+    _block_if_ephemeral("send_observations_to_gundi")
     integration_id = kwargs.get("integration_id")
     assert integration_id, "integration_id is required"
     sensors_api_client = await _get_sensors_api_client(integration_id=str(integration_id))
@@ -131,6 +153,7 @@ async def send_messages_to_gundi(messages: List[dict], **kwargs) -> dict:
     :param kwargs: integration_id: The UUID of the related integration
     :return: A dict with the response from the API
     """
+    _block_if_ephemeral("send_messages_to_gundi")
     integration_id = kwargs.get("integration_id")
     assert integration_id, "integration_id is required"
     sensors_api_client = await _get_sensors_api_client(integration_id=str(integration_id))

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -1,10 +1,11 @@
 """Public helpers for talking to Gundi from an action handler.
 
-Every write helper here short-circuits with `_block_if_ephemeral` on the
-ephemeral path (defense in depth on top of the config-model whitelist in
-`action_runner.execute_action`). Guards only cover code that routes through
-this module — handlers that construct `GundiDataSenderClient`, an
-`httpx.AsyncClient`, or a PubSub publisher directly are out of scope.
+Every write helper here, and `action_scheduler.trigger_action`, short-circuits
+with `_block_if_ephemeral` on the ephemeral path (defense in depth on top of
+the config-model whitelist in `action_runner.execute_action`). Guards only
+cover code that routes through these helpers — handlers that construct
+`GundiDataSenderClient`, an `httpx.AsyncClient`, or a PubSub publisher
+directly are out of scope.
 """
 import datetime
 from typing import List

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -1,20 +1,10 @@
 """Public helpers for talking to Gundi from an action handler.
 
-Ephemeral (draft-integration) execution runs handlers with a synthetic
-integration id and no audit trail, so every Gundi-write helper in this
-module short-circuits with `_block_if_ephemeral` when the `ephemeral_run`
-contextvar is truthy. The write-side guards here are defense-in-depth:
-`action_runner.execute_action` already whitelists reference and auth
-handlers by config-model class before the handler ever runs.
-
-**Scope of the guards**: they cover handlers that go through this module.
-A handler that constructs `GundiDataSenderClient` directly, opens its
-own `httpx.AsyncClient` to a Gundi URL, or publishes to Google Cloud
-PubSub via `gcloud.aio` is out of scope — none of those import paths
-route through `_block_if_ephemeral`. The practical risk stays low because
-those bypasses require the handler to know Gundi internals (URLs, API
-keys, GCP creds), but the module docstring is the honest place to name
-what "guard" means and what it doesn't.
+Every write helper here short-circuits with `_block_if_ephemeral` on the
+ephemeral path (defense in depth on top of the config-model whitelist in
+`action_runner.execute_action`). Guards only cover code that routes through
+this module — handlers that construct `GundiDataSenderClient`, an
+`httpx.AsyncClient`, or a PubSub publisher directly are out of scope.
 """
 import datetime
 from typing import List
@@ -26,10 +16,7 @@ from .activity_logger import ephemeral_run
 
 
 class EphemeralWriteBlocked(RuntimeError):
-    """Raised when a reference / auth handler running against a draft
-    integration tries to move data through Gundi via a helper in this
-    module. Reference and auth actions are read-only by contract — a
-    draft-credential run must never publish or send events."""
+    """Blocked write from a reference/auth handler on the ephemeral path."""
 
 
 def _block_if_ephemeral(op: str) -> None:

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -27,21 +27,31 @@ def _block_if_ephemeral(op: str) -> None:
         )
 
 
-# One retry policy for every Gundi API call, defined once so the wait curve and
-# the stop condition can't drift apart.
+# One retry policy for every Gundi API call (the helpers below and the
+# config manager's reload), defined once so the wait curve and the stop
+# condition can't drift apart.
 #
-# `attempts` and `timeout` are both spelled out on purpose: stamina combines
-# them with stop_any(), so the tighter one wins, and its defaults are
-# attempts=10 / timeout=45s. With the waits below (10-20s, then 20-30s, ...)
-# the default 45s budget expires after ~3 attempts and wait_max=300 is never
-# reachable -- the declared backoff would silently not be the real one.
+# stamina combines `attempts` and `timeout` with stop_any(), so the tighter
+# one wins, and its defaults (attempts=10 / timeout=45 s) silently truncate a
+# long curve: the hand-copied 10-20-40 s decorators this replaced ran three
+# attempts, not ten. Both stops are spelled out here and sized so every
+# declared attempt is reachable. The waits are min(2 * 2**n + jitter, 30) for
+# n = 0..4, i.e. 2-7, 4-9, 8-13, 16-21 and 30 s: 60-80 s of waiting in total
+# for six attempts, inside the 120 s budget whenever the calls themselves are
+# quick. tenacity checks the stop after a failed attempt and then sleeps the
+# full wait, so the hard ceiling for one failing call is timeout + wait_max
+# plus one request, about 2.5 minutes. Gundi sends run inline in the PubSub
+# push request by default (PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND=False), so
+# that ceiling must stay well under the push ack deadline and the platform's
+# request timeout (Cloud Run defaults to 300 s); see the tests in
+# test_gundi_api.py that pin both properties.
 GUNDI_API_RETRY = dict(
     on=httpx.HTTPError,
-    attempts=10,
-    timeout=180.0,
-    wait_initial=10.0,
-    wait_jitter=10.0,
-    wait_max=300.0,
+    attempts=6,
+    timeout=120.0,
+    wait_initial=2.0,
+    wait_jitter=5.0,
+    wait_max=30.0,
 )
 
 

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -27,9 +27,11 @@ def _block_if_ephemeral(op: str) -> None:
         )
 
 
-# One retry policy for every Gundi API call (the helpers below and the
-# config manager's reload), defined once so the wait curve and the stop
-# condition can't drift apart.
+# One retry policy for every Gundi API call (the send helpers below and the
+# config manager's reloads), defined once so the wait curve and the stop
+# condition can't drift apart, and applied exactly once per call path:
+# nesting it (a decorated helper calling another decorated helper) multiplies
+# the attempts.
 #
 # stamina combines `attempts` and `timeout` with stop_any(), so the tighter
 # one wins, and its defaults (attempts=10 / timeout=45 s) silently truncate a
@@ -57,8 +59,11 @@ GUNDI_API_RETRY = dict(
 )
 
 
-@stamina.retry(**GUNDI_API_RETRY)
 async def _get_gundi_api_key(integration_id):
+    # No retry decorator of its own: every caller is one of the retry-decorated
+    # send helpers below, and a second policy nested inside the first restarts
+    # the inner six attempts on each outer attempt (36 portal calls, many
+    # minutes of sleep) for a portal that keeps failing.
     # An ephemeral run's synthetic integration has no persisted api key —
     # letting this reach the portal would 404 and then stamina would retry
     # for up to 5 minutes with the portal-facing request thread held.

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -43,7 +43,6 @@ async def _get_sensors_api_client(integration_id):
 
 @stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
 async def send_events_to_gundi(events: List[dict], **kwargs) -> dict:
-    _block_if_ephemeral("send_events_to_gundi")
     """
     Send Events to Gundi using the REST API v2
     :param events: A list of events in the following format:
@@ -65,6 +64,7 @@ async def send_events_to_gundi(events: List[dict], **kwargs) -> dict:
     :param kwargs: integration_id: The UUID of the related integration
     :return: A dict with the response from the API
     """
+    _block_if_ephemeral("send_events_to_gundi")
     integration_id = kwargs.get("integration_id")
     assert integration_id, "integration_id is required"
     sensors_api_client = await _get_sensors_api_client(integration_id=str(integration_id))

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -1,3 +1,21 @@
+"""Public helpers for talking to Gundi from an action handler.
+
+Ephemeral (draft-integration) execution runs handlers with a synthetic
+integration id and no audit trail, so every Gundi-write helper in this
+module short-circuits with `_block_if_ephemeral` when the `ephemeral_run`
+contextvar is truthy. The write-side guards here are defense-in-depth:
+`action_runner.execute_action` already whitelists reference and auth
+handlers by config-model class before the handler ever runs.
+
+**Scope of the guards**: they cover handlers that go through this module.
+A handler that constructs `GundiDataSenderClient` directly, opens its
+own `httpx.AsyncClient` to a Gundi URL, or publishes to Google Cloud
+PubSub via `gcloud.aio` is out of scope — none of those import paths
+route through `_block_if_ephemeral`. The practical risk stays low because
+those bypasses require the handler to know Gundi internals (URLs, API
+keys, GCP creds), but the module docstring is the honest place to name
+what "guard" means and what it doesn't.
+"""
 import datetime
 from typing import List
 import httpx
@@ -8,9 +26,10 @@ from .activity_logger import ephemeral_run
 
 
 class EphemeralWriteBlocked(RuntimeError):
-    """Raised when a reference handler running against a draft integration
-    tries to move data through Gundi. Reference actions are read-only by
-    contract — a draft-credential run must never publish or send events."""
+    """Raised when a reference / auth handler running against a draft
+    integration tries to move data through Gundi via a helper in this
+    module. Reference and auth actions are read-only by contract — a
+    draft-credential run must never publish or send events."""
 
 
 def _block_if_ephemeral(op: str) -> None:

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -134,6 +134,7 @@ async def update_event_in_gundi(gundi_object_id: str, changes: dict, **kwargs) -
     :param kwargs: integration_id: The UUID of the related integration.
     :return: The API response dict.
     """
+    _block_if_ephemeral("update_event_in_gundi")
     integration_id = kwargs.get("integration_id")
     assert integration_id, "integration_id is required"
     sensors_api_client = await _get_sensors_api_client(integration_id=str(integration_id))

--- a/app/services/retry_policies.py
+++ b/app/services/retry_policies.py
@@ -1,0 +1,13 @@
+"""Retry policies shared across the service layer.
+
+Kept in a leaf module (no app imports) so config_manager and state can both
+use REDIS_RETRY without importing each other. GUNDI_API_RETRY lives in
+gundi.py next to the helpers it decorates.
+
+Iterate stamina with `async for`: its synchronous iterator sleeps with
+time.sleep, which inside a coroutine stalls the whole event loop for the
+length of the back-off.
+"""
+from redis.exceptions import RedisError
+
+REDIS_RETRY = dict(on=RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0)

--- a/app/services/self_registration.py
+++ b/app/services/self_registration.py
@@ -12,8 +12,14 @@ from app.actions import (
     PushActionConfiguration,
     ExecutableActionMixin,
     InternalActionConfiguration,
+    ReferenceActionConfiguration,
 )
-from app.settings import INTEGRATION_TYPE_SLUG, INTEGRATION_TYPE_NAME, INTEGRATION_SERVICE_URL
+from app.settings import (
+    INTEGRATION_TYPE_SLUG,
+    INTEGRATION_TYPE_NAME,
+    INTEGRATION_SERVICE_URL,
+    REGISTER_REFERENCE_ACTIONS,
+)
 from .core import ActionTypeEnum
 from app.webhooks.core import get_webhook_handler, GenericJsonTransformConfig
 
@@ -48,10 +54,18 @@ async def register_integration_in_gundi(gundi_client, type_slug=None, type_name=
         if issubclass(config_model, InternalActionConfiguration):
             logger.info(f"Skipping internal action '{action_id}'.")
             continue  # Internal actions are not registered in Gundi
+        if issubclass(config_model, ReferenceActionConfiguration) and not REGISTER_REFERENCE_ACTIONS:
+            logger.info(
+                f"Skipping reference action '{action_id}' "
+                "(REGISTER_REFERENCE_ACTIONS is off until the platform supports the 'reference' type)."
+            )
+            continue
         action_name = getattr(func, "action_title", None) or action_id.replace("_", " ").title()
         action_schema = json.loads(config_model.schema_json())
         action_ui_schema = config_model.ui_schema()
-        if issubclass(config_model, AuthActionConfiguration):
+        if issubclass(config_model, ReferenceActionConfiguration):
+            action_type = ActionTypeEnum.REFERENCE.value
+        elif issubclass(config_model, AuthActionConfiguration):
             action_type = ActionTypeEnum.AUTHENTICATION.value
         elif issubclass(config_model, PullActionConfiguration):
             action_type = ActionTypeEnum.PULL_DATA.value

--- a/app/services/self_registration.py
+++ b/app/services/self_registration.py
@@ -18,7 +18,6 @@ from app.settings import (
     INTEGRATION_TYPE_SLUG,
     INTEGRATION_TYPE_NAME,
     INTEGRATION_SERVICE_URL,
-    REGISTER_REFERENCE_ACTIONS,
 )
 from .core import ActionTypeEnum
 from app.webhooks.core import get_webhook_handler, GenericJsonTransformConfig
@@ -54,16 +53,13 @@ async def register_integration_in_gundi(gundi_client, type_slug=None, type_name=
         if issubclass(config_model, InternalActionConfiguration):
             logger.info(f"Skipping internal action '{action_id}'.")
             continue  # Internal actions are not registered in Gundi
-        if issubclass(config_model, ReferenceActionConfiguration) and not REGISTER_REFERENCE_ACTIONS:
-            logger.info(
-                f"Skipping reference action '{action_id}' "
-                "(REGISTER_REFERENCE_ACTIONS is off until the platform supports the 'reference' type)."
-            )
-            continue
         action_name = getattr(func, "action_title", None) or action_id.replace("_", " ").title()
         action_schema = json.loads(config_model.schema_json())
         action_ui_schema = config_model.ui_schema()
         if issubclass(config_model, ReferenceActionConfiguration):
+            # Registered with their own type so the platform can tell the
+            # read-only lookups apart from generic actions (and enforce the
+            # ephemeral whitelist on its side too).
             action_type = ActionTypeEnum.REFERENCE.value
         elif issubclass(config_model, AuthActionConfiguration):
             action_type = ActionTypeEnum.AUTHENTICATION.value

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -1,9 +1,26 @@
 import json
+import logging
 import stamina
 import httpx
 import redis.asyncio as redis
 from app import settings
 from .activity_logger import ephemeral_run
+
+logger = logging.getLogger(__name__)
+
+
+def _skip_on_ephemeral_run(op: str, integration_id: str, action_id: str) -> bool:
+    """Ephemeral runs get a fresh synthetic integration id and no TTL on state
+    keys, so any write would be a permanent orphan. Every mutating method
+    no-ops behind this, with a log line: a handler that writes then reads in
+    the same run sees {} and fails in a way that looks unrelated otherwise."""
+    if not ephemeral_run.get():
+        return False
+    logger.debug(
+        f"Skipping {op} for action '{action_id}' on ephemeral integration '{integration_id}': "
+        "state is not persisted on the ephemeral path."
+    )
+    return True
 
 
 class IntegrationStateManager:
@@ -22,8 +39,7 @@ class IntegrationStateManager:
         return value
 
     async def set_state(self, integration_id: str, action_id: str, state: dict, source_id: str = "no-source"):
-        # No TTL on this key + synthetic UUID per ephemeral run = permanent orphans.
-        if ephemeral_run.get():
+        if _skip_on_ephemeral_run("set_state", integration_id, action_id):
             return
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
@@ -40,8 +56,12 @@ class IntegrationStateManager:
         Returns True if the key was set by this call (i.e. the caller is the
         first within the TTL window), or False if it already existed. Useful
         for rate-limiting/throttling repeated events: the first caller in each
-        window gets True, the rest get False until the key expires.
+        window gets True, the rest get False until the key expires. On the
+        ephemeral path nothing is written and the answer is False, so a
+        throttling caller treats the window as already taken.
         """
+        if _skip_on_ephemeral_run("set_if_absent", integration_id, action_id):
+            return False
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
                 was_set = await self.db_client.set(
@@ -53,6 +73,8 @@ class IntegrationStateManager:
         return bool(was_set)
 
     async def delete_state(self, integration_id: str, action_id: str, source_id: str = "no-source"):
+        if _skip_on_ephemeral_run("delete_state", integration_id, action_id):
+            return
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
                 await self.db_client.delete(

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -1,10 +1,10 @@
 import json
 import logging
 import stamina
-import httpx
 import redis.asyncio as redis
 from app import settings
 from .activity_logger import ephemeral_run
+from .retry_policies import REDIS_RETRY
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class IntegrationStateManager:
         self.db_client = redis.Redis(host=host, port=port, db=db)
 
     async def get_state(self, integration_id: str, action_id: str, source_id: str = "no-source") -> dict:
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 json_value = await self.db_client.get(f"integration_state.{integration_id}.{action_id}.{source_id}")
         value = json.loads(json_value) if json_value else {}
@@ -41,7 +41,7 @@ class IntegrationStateManager:
     async def set_state(self, integration_id: str, action_id: str, state: dict, source_id: str = "no-source"):
         if _skip_on_ephemeral_run("set_state", integration_id, action_id):
             return
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 await self.db_client.set(
                     f"integration_state.{integration_id}.{action_id}.{source_id}",
@@ -62,7 +62,7 @@ class IntegrationStateManager:
         """
         if _skip_on_ephemeral_run("set_if_absent", integration_id, action_id):
             return False
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 was_set = await self.db_client.set(
                     f"integration_state.{integration_id}.{action_id}.{source_id}",
@@ -75,7 +75,7 @@ class IntegrationStateManager:
     async def delete_state(self, integration_id: str, action_id: str, source_id: str = "no-source"):
         if _skip_on_ephemeral_run("delete_state", integration_id, action_id):
             return
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+        async for attempt in stamina.retry_context(**REDIS_RETRY):
             with attempt:
                 await self.db_client.delete(
                     f"integration_state.{integration_id}.{action_id}.{source_id}"

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -22,11 +22,7 @@ class IntegrationStateManager:
         return value
 
     async def set_state(self, integration_id: str, action_id: str, state: dict, source_id: str = "no-source"):
-        # Ephemeral runs synthesize a fresh integration id per call, so any
-        # state persisted here would be a permanent orphan (this key has no
-        # TTL). Silently no-op on the ephemeral path — reference and auth
-        # handlers have no legitimate reason to persist state, and if one
-        # does try, we don't want it leaking watermarks into Redis.
+        # No TTL on this key + synthetic UUID per ephemeral run = permanent orphans.
         if ephemeral_run.get():
             return
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -3,6 +3,7 @@ import stamina
 import httpx
 import redis.asyncio as redis
 from app import settings
+from .activity_logger import ephemeral_run
 
 
 class IntegrationStateManager:
@@ -21,6 +22,13 @@ class IntegrationStateManager:
         return value
 
     async def set_state(self, integration_id: str, action_id: str, state: dict, source_id: str = "no-source"):
+        # Ephemeral runs synthesize a fresh integration id per call, so any
+        # state persisted here would be a permanent orphan (this key has no
+        # TTL). Silently no-op on the ephemeral path — reference and auth
+        # handlers have no legitimate reason to persist state, and if one
+        # does try, we don't want it leaking watermarks into Redis.
+        if ephemeral_run.get():
+            return
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
                 await self.db_client.set(

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -10,8 +10,8 @@ from gundi_core.events import IntegrationActionFailed, IntegrationActionCustomLo
 from gundi_core.events.transformers import ObservationTransformedER
 
 from app import settings
-from app.actions.core import ReferenceActionConfiguration
-from app.conftest import AsyncMock, MockSubActionConfiguration, MockPushActionConfiguration, async_return
+from app.actions.core import AuthActionConfiguration, ReferenceActionConfiguration
+from app.conftest import AsyncMock, MockSubActionConfiguration, MockPushActionConfiguration, MockPullActionConfiguration, async_return
 from app.main import app
 from app.services.action_scheduler import trigger_action
 from app.services.action_runner import execute_action
@@ -603,6 +603,10 @@ class _MockReferenceActionConfiguration(ReferenceActionConfiguration):
     tag_name: str = ""
 
 
+class _MockAuthActionConfiguration(AuthActionConfiguration):
+    token: str = ""
+
+
 @pytest.fixture
 def mock_reference_action_handler():
     handler = AsyncMock()
@@ -611,12 +615,21 @@ def mock_reference_action_handler():
 
 
 @pytest.fixture
+def mock_auth_action_handler():
+    handler = AsyncMock()
+    handler.return_value = {"valid_credentials": True}
+    return handler
+
+
+@pytest.fixture
 def mock_ephemeral_action_handlers(
         mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_auth_action_handler,
 ):
     return {
         "list_species": (mock_reference_action_handler, _MockReferenceActionConfiguration, None),
         "pull_observations": (mock_pull_observations_action_handler, MockPullActionConfiguration, None),
+        "auth": (mock_auth_action_handler, _MockAuthActionConfiguration, None),
     }
 
 
@@ -660,7 +673,7 @@ async def test_ephemeral_run_builds_synthetic_integration(
 
 
 @pytest.mark.asyncio
-async def test_ephemeral_run_rejects_non_reference_action(
+async def test_ephemeral_run_rejects_non_reference_non_auth_action(
         mocker, mock_gundi_client_v2, mock_config_manager,
         mock_publish_event, mock_ephemeral_action_handlers, mock_pull_observations_action_handler,
 ):
@@ -675,6 +688,50 @@ async def test_ephemeral_run_rejects_non_reference_action(
 
     assert response.status_code == 422
     assert not mock_pull_observations_action_handler.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_run_allows_auth_action(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers, mock_auth_action_handler,
+):
+    # Auth actions verify credentials without side effects, so the ephemeral
+    # path allows them — used by the portal's "Test Connection" button in the
+    # creation wizard before an integration exists.
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
+
+    assert response.status_code == 200
+    assert mock_auth_action_handler.called
+    # Handler receives the synthetic integration with auth already applied.
+    integration = mock_auth_action_handler.call_args.kwargs["integration"]
+    auth_config = find_config_for_action(integration.configurations, "auth")
+    assert auth_config.data == {"token": _EPHEMERAL_SECRET}
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_auth_publishes_no_activity_events(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers,
+):
+    # The reference-action version of this invariant already exists; auth is
+    # covered separately because it's the newly-allowed shape and the guard
+    # relaxation must not regress the "no audit trail on ephemeral" contract.
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
+
+    assert response.status_code == 200
+    assert not mock_publish_event.called
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1546,6 +1546,54 @@ async def test_ephemeral_configuration_error_forwards_its_message_as_422(
     assert not mock_publish_event.called
 
 
+def _mock_draft_url_resolution(mocker, ip):
+    mock_loop = mocker.MagicMock()
+    mock_loop.getaddrinfo = AsyncMock(return_value=[(None, None, None, None, (ip, 443))])
+    mocker.patch("app.services.url_policy.asyncio.get_running_loop", return_value=mock_loop)
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_draft_base_url_resolving_to_a_private_address_is_rejected_when_the_policy_is_on(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event, mock_ephemeral_action_handlers,
+):
+    # integration_state.base_url is request-controlled and reaches the
+    # connector's HTTP client unchanged. With the (opt-in) policy on, a draft
+    # URL that resolves to loopback, RFC 1918 or the cloud metadata range is
+    # refused before any handler runs, with the runner's own text.
+    from app import settings
+
+    _patch_ephemeral_runner(mocker, mock_ephemeral_action_handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+    mocker.patch.object(settings, "EPHEMERAL_BASE_URL_BLOCK_PRIVATE_ADDRESSES", True)
+    _mock_draft_url_resolution(mocker, "169.254.169.254")
+
+    response = api_client.post(
+        "/v1/actions/execute/", json=_ephemeral_body(base_url="https://metadata.internal.example"),
+    )
+
+    assert response.status_code == 422
+    assert "private or reserved" in response.json()["detail"]["error"]
+    handler, _, _ = mock_ephemeral_action_handlers["list_species"]
+    assert not handler.called
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_draft_base_url_resolving_publicly_runs_when_the_policy_is_on(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event, mock_ephemeral_action_handlers,
+):
+    from app import settings
+
+    _patch_ephemeral_runner(mocker, mock_ephemeral_action_handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+    mocker.patch.object(settings, "EPHEMERAL_BASE_URL_BLOCK_PRIVATE_ADDRESSES", True)
+    _mock_draft_url_resolution(mocker, "93.184.216.34")
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(base_url="https://sandbox.pamdas.org"))
+
+    assert response.status_code == 200
+    handler, _, _ = mock_ephemeral_action_handlers["list_species"]
+    assert handler.called
+
+
 @pytest.mark.asyncio
 async def test_ephemeral_auth_error_without_status_code_is_401(
         mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -744,22 +744,95 @@ async def test_ephemeral_run_allows_auth_action(
     assert auth_config.data == {"token": _EPHEMERAL_SECRET}
 
 
+@pytest.mark.parametrize("source_status", [401, 403, 500])
 @pytest.mark.asyncio
 async def test_ephemeral_handler_httpstatuserror_propagates_upstream_status(
-        mocker, mock_gundi_client_v2, mock_config_manager,
+        source_status, mocker, mock_gundi_client_v2, mock_config_manager,
         mock_publish_event, mock_reference_action_handler, mock_pull_observations_action_handler,
         mock_push_action_handler, mock_generic_action_handler,
 ):
-    # When the auth handler raises httpx.HTTPStatusError (source system said
-    # 401/403 to the credentials), the response status must reflect the source's
-    # code — cdip then surfaces it as upstream_status so the portal can classify
-    # as "invalid credentials" instead of a generic runner error.
+    # httpx.HTTPStatusError from a handler forwards the source's status.
+    # Parametrized so 401/403 (bad creds — portal classifies as invalid) and
+    # 500 (source-side bug — portal classifies as error) both propagate
+    # correctly. Ensures the check isn't 401-specific.
     import httpx
 
     async def rejecting_auth_handler(**kwargs):
         request = httpx.Request("GET", "https://source.example/status")
-        response = httpx.Response(status_code=401, request=request, json={"detail": "bad token"})
-        raise httpx.HTTPStatusError("401 Unauthorized", request=request, response=response)
+        response = httpx.Response(status_code=source_status, request=request, json={"detail": "source said no"})
+        raise httpx.HTTPStatusError(f"{source_status}", request=request, response=response)
+
+    handlers = {
+        "list_species": (mock_reference_action_handler, _MockReferenceActionConfiguration, None),
+        "pull_observations": (mock_pull_observations_action_handler, MockPullActionConfiguration, None),
+        "auth": (rejecting_auth_handler, _MockAuthActionConfiguration, None),
+        "push_observations": (mock_push_action_handler, MockPushActionConfiguration, None),
+        "generic_lookup": (mock_generic_action_handler, _MockGenericActionConfiguration, None),
+    }
+    mocker.patch("app.services.action_runner.action_handlers", handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
+
+    assert response.status_code == source_status
+    assert response.json() == {
+        "detail": {"action_id": "auth", "error": "HTTPStatusError"},
+    }
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_handler_connect_error_falls_back_to_500(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_push_action_handler, mock_generic_action_handler,
+):
+    # Network-level failures don't carry a source status. Response must fall
+    # back to 500 (via the else branch of the propagation logic), not accidentally
+    # bubble up as some other status via .response access on None.
+    import httpx
+
+    async def unreachable_source_handler(**kwargs):
+        raise httpx.ConnectError("source unreachable")
+
+    handlers = {
+        "list_species": (mock_reference_action_handler, _MockReferenceActionConfiguration, None),
+        "pull_observations": (mock_pull_observations_action_handler, MockPullActionConfiguration, None),
+        "auth": (unreachable_source_handler, _MockAuthActionConfiguration, None),
+        "push_observations": (mock_push_action_handler, MockPushActionConfiguration, None),
+        "generic_lookup": (mock_generic_action_handler, _MockGenericActionConfiguration, None),
+    }
+    mocker.patch("app.services.action_runner.action_handlers", handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "detail": {"action_id": "auth", "error": "ConnectError"},
+    }
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_handler_integration_error_propagates_status_code(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_push_action_handler, mock_generic_action_handler,
+):
+    # A handler that wraps the source failure as IntegrationAuthError (401)
+    # instead of raising httpx directly must still propagate its status_code
+    # so cdip's upstream_status matches the semantic verdict.
+    from app.services.errors import IntegrationAuthError
+
+    async def rejecting_auth_handler(**kwargs):
+        raise IntegrationAuthError("bad creds", status_code=401)
 
     handlers = {
         "list_species": (mock_reference_action_handler, _MockReferenceActionConfiguration, None),
@@ -778,7 +851,7 @@ async def test_ephemeral_handler_httpstatuserror_propagates_upstream_status(
 
     assert response.status_code == 401
     assert response.json() == {
-        "detail": {"action_id": "auth", "error": "HTTPStatusError"},
+        "detail": {"action_id": "auth", "error": "IntegrationAuthError"},
     }
     assert not mock_publish_event.called
 

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1019,30 +1019,43 @@ async def test_ephemeral_run_uses_unique_integration_id_per_run(
 
 
 @pytest.mark.asyncio
-async def test_ephemeral_contextvar_or_folds_with_outer_state(mocker):
+async def test_ephemeral_contextvar_or_folds_with_outer_state(mocker, mock_publish_event):
     # If ephemeral_run is already True when execute_action starts (a nested
     # execute inside a reference handler), a saved-integration inner call
     # (is_ephemeral=False for the inner) must NOT re-enable publishing.
+    #
+    # Old form of this test only asserted "ephemeral_run.get() is True after
+    # the call returns", which passes trivially because the finally-reset
+    # restores the outer value regardless of the OR-fold. The real invariant
+    # is that publish_event stays suppressed inside — assert THAT so a
+    # regression from `is_ephemeral or ephemeral_run.get()` to just
+    # `is_ephemeral` fails the test loudly.
     from app.services.activity_logger import ephemeral_run
     mock_config_manager = mocker.MagicMock()
-    async def _crash(*a, **kw):
-        raise RuntimeError("should not reach the portal from an ephemeral outer")
-    mock_config_manager.get_integration_details = _crash
+    async def _fail(*a, **kw):
+        raise RuntimeError("config manager exploded — inner should still be ephemeral")
+    mock_config_manager.get_integration_details = _fail
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
 
     outer_token = ephemeral_run.set(True)
     try:
-        # Call execute_action directly with a saved integration_id (inner
-        # scenario). The or-fold should keep the contextvar True so
-        # publish_event stays suppressed inside; and the outer context is
-        # restored on return so nothing bleeds out of this test.
+        # Inner call: saved integration_id (is_ephemeral=False for the inner).
+        # The OR-fold with the outer True must keep the contextvar True so
+        # _handle_error's ephemeral branch fires and no IntegrationActionFailed
+        # event is published.
         try:
             await execute_action(integration_id="00000000-0000-0000-0000-000000000000", action_id="anything")
         except Exception:
             pass
-        # If the or-fold worked, we didn't reach _crash — but even if the
-        # code path changed, the invariant we care about is that the
-        # contextvar is still True after the nested call returns.
+        # Contract: no PubSub publish under an ephemeral outer context —
+        # regardless of the inner call's own is_ephemeral flag.
+        assert not mock_publish_event.called, (
+            "publish_event fired despite the outer ephemeral_run being True — "
+            "the OR-fold was regressed"
+        )
+        # Outer context restored on return (unchanged from earlier version).
         assert ephemeral_run.get() is True
     finally:
         ephemeral_run.reset(outer_token)

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1570,9 +1570,10 @@ async def test_ephemeral_configuration_error_with_a_status_code_still_answers_42
 
 
 def _mock_draft_url_resolution(mocker, ip):
-    mock_loop = mocker.MagicMock()
-    mock_loop.getaddrinfo = AsyncMock(return_value=[(None, None, None, None, (ip, 443))])
-    mocker.patch("app.services.url_policy.asyncio.get_running_loop", return_value=mock_loop)
+    # Patch the policy's resolver seam, never asyncio.get_running_loop: that
+    # module attribute is shared with the test client's portal, which then
+    # hands its task to a MagicMock loop and waits forever.
+    mocker.patch("app.services.url_policy._resolve_addresses", AsyncMock(return_value=[ip]))
 
 
 @pytest.mark.asyncio
@@ -1611,6 +1612,45 @@ async def test_ephemeral_draft_base_url_resolving_publicly_runs_when_the_policy_
     _mock_draft_url_resolution(mocker, "93.184.216.34")
 
     response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(base_url="https://sandbox.pamdas.org"))
+
+    assert response.status_code == 200
+    handler, _, _ = mock_ephemeral_action_handlers["list_species"]
+    assert handler.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_draft_base_url_outside_the_allowlist_is_rejected(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event, mock_ephemeral_action_handlers,
+):
+    from app import settings
+
+    _patch_ephemeral_runner(mocker, mock_ephemeral_action_handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+    mocker.patch.object(settings, "EPHEMERAL_BASE_URL_BLOCK_PRIVATE_ADDRESSES", True)
+    mocker.patch.object(settings, "EPHEMERAL_BASE_URL_ALLOWLIST", ["sandbox.pamdas.org"])
+    _mock_draft_url_resolution(mocker, "93.184.216.34")  # not reached: the allowlist check runs before DNS
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(base_url="https://other.example.org"))
+
+    assert response.status_code == 422
+    assert "not in the configured allowlist" in response.json()["detail"]["error"]
+    handler, _, _ = mock_ephemeral_action_handlers["list_species"]
+    assert not handler.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_draft_base_url_in_the_allowlist_runs_after_hostname_normalization(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event, mock_ephemeral_action_handlers,
+):
+    # Allowlist entries and URL hostnames are compared case-insensitively and
+    # without a trailing dot, so an operator's "Sandbox.PamDAS.org." matches.
+    from app import settings
+
+    _patch_ephemeral_runner(mocker, mock_ephemeral_action_handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+    mocker.patch.object(settings, "EPHEMERAL_BASE_URL_BLOCK_PRIVATE_ADDRESSES", True)
+    mocker.patch.object(settings, "EPHEMERAL_BASE_URL_ALLOWLIST", ["Sandbox.PamDAS.org."])
+    _mock_draft_url_resolution(mocker, "93.184.216.34")
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(base_url="https://SANDBOX.pamdas.org"))
 
     assert response.status_code == 200
     handler, _, _ = mock_ephemeral_action_handlers["list_species"]

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -940,10 +940,14 @@ async def test_ephemeral_auth_handler_write_is_blocked_end_to_end(
     response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
 
     assert response.status_code == 500
-    # Sanitized error shape — no configurations, no request/response bodies,
-    # only the exception type name.
+    # Sanitized error shape — no configurations, no request/response bodies.
+    # The exception is runner-authored (it names only the blocked operation),
+    # so its message survives: the wizard can say which write was refused.
     assert response.json() == {
-        "detail": {"action_id": "auth", "error": EphemeralWriteBlocked.__name__},
+        "detail": {
+            "action_id": "auth",
+            "error": "EphemeralWriteBlocked: send_events_to_gundi is not allowed on the ephemeral (draft-integration) path",
+        },
     }
     assert call_marker["called"], "buggy auth handler must have been reached"
     assert not mock_publish_event.called
@@ -1643,6 +1647,161 @@ async def test_ephemeral_validation_error_from_custom_pydantic_error_does_not_ec
     error = response.json()["detail"]["error"]
     assert _EPHEMERAL_SECRET not in response.text
     assert "token" in error and "invalid value" in error
+
+
+@pytest.mark.asyncio
+async def test_nested_portal_failure_under_ephemeral_context_is_not_classified_as_provider_auth(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_ephemeral_action_handlers, integration_v2,
+):
+    # A reference handler that calls execute_action(integration_id=...) under
+    # the ephemeral context gets the ephemeral error branch for a failure in
+    # get_integration_details too. A 401 from the Gundi portal there is a
+    # portal auth problem, and must not render as the provider wording the
+    # handler-failure path uses ("Authentication failed"), which would point
+    # the operator at the wrong system. Same scoping the saved path enforces.
+    from app.services.activity_logger import ephemeral_run
+    request = httpx.Request("GET", "https://gundi.example/integrations/x")
+    mock_config_manager.get_integration_details.side_effect = httpx.HTTPStatusError(
+        "401 from the portal", request=request, response=httpx.Response(401, request=request),
+    )
+    _patch_ephemeral_runner(mocker, mock_ephemeral_action_handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+
+    token = ephemeral_run.set(True)
+    try:
+        response = await execute_action(integration_id=str(integration_v2.id), action_id="list_species")
+    finally:
+        ephemeral_run.reset(token)
+
+    assert response.status_code == 500
+    assert json.loads(response.body)["detail"]["error"] == "HTTPStatusError"
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_duck_typed_response_status_gives_matching_text_and_status(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_push_action_handler, mock_generic_action_handler,
+):
+    # requests.HTTPError and friends carry `.response.status_code` without
+    # being httpx types. The classifier already duck-types that; the response
+    # status must come from the same reading, or the body says
+    # "Authentication failed (HTTP 401)" while the status says 500.
+    class FakeResponse:
+        status_code = 401
+
+    class OtherClientHTTPError(Exception):
+        response = FakeResponse()
+
+    handlers = _auth_handlers_raising(
+        OtherClientHTTPError("401 Client Error"), mock_reference_action_handler,
+        mock_pull_observations_action_handler, mock_push_action_handler, mock_generic_action_handler,
+    )
+    _patch_ephemeral_runner(mocker, handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["error"] == "Authentication failed (HTTP 401)"
+
+
+@pytest.mark.parametrize(
+    "preset_status_code,expected_status,expected_error",
+    [
+        # A connector hierarchy that stores the status as text: not a status
+        # the runner can forward, but still an auth failure, so 401 — and no
+        # TypeError inside the except block, which would have logged the raw
+        # exception text and answered with the unredacted 500.
+        ("401", 401, "Authentication failed"),
+        # Out of the HTTP range: a connector bug, never handed to the response.
+        (999, 500, "Unexpected response from the provider (HTTP 999)"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_ephemeral_untrusted_status_code_on_connector_exception(
+        preset_status_code, expected_status, expected_error,
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_push_action_handler, mock_generic_action_handler, caplog,
+):
+    from app.services.errors import IntegrationAuthError, IntegrationBadResponseError
+    import logging
+
+    class ClientBase(Exception):
+        def __init__(self, message, status_code=None):
+            self.status_code = status_code
+            self.message = message
+            super().__init__(message)
+
+    base = IntegrationAuthError if preset_status_code == "401" else IntegrationBadResponseError
+
+    class ClientError(ClientBase, base):
+        pass
+
+    exc = ClientError(f"provider said no to {_EPHEMERAL_SECRET}", status_code=preset_status_code)
+    handlers = _auth_handlers_raising(
+        exc, mock_reference_action_handler,
+        mock_pull_observations_action_handler, mock_push_action_handler, mock_generic_action_handler,
+    )
+    _patch_ephemeral_runner(mocker, handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+    caplog.set_level(logging.DEBUG, logger="app.services.action_runner")
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
+
+    assert response.status_code == expected_status
+    assert response.json()["detail"]["error"] == expected_error
+    assert _EPHEMERAL_SECRET not in response.text
+    assert _EPHEMERAL_SECRET not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "field_path,bad_value",
+    [
+        (("type_value",), "Earth Ranger"),
+        (("configurations", 0, "action_value"), "Auth-Token"),
+    ],
+)
+def test_ephemeral_natural_keys_are_validated_on_the_request_model(field_path, bad_value):
+    # gundi_core constrains IntegrationType.value / IntegrationAction.value to
+    # ^[a-z0-9_]+$. Mirrored on the request model, a bad key is a request
+    # 422 that names the field the caller sent, not one synthesized inside
+    # Integration.parse_obj such as `type.actions.0.value`.
+    body = _ephemeral_body(action_id="auth")
+    target = body["integration_state"]
+    for part in field_path[:-1]:
+        target = target[part]
+    target[field_path[-1]] = bad_value
+
+    response = api_client.post("/v1/actions/execute/", json=body)
+
+    assert response.status_code == 422
+    locs = [tuple(err["loc"]) for err in response.json()["detail"]]
+    assert ("body", "integration_state", *field_path) in locs
+    assert "type.actions" not in response.text
+    assert _EPHEMERAL_SECRET not in response.text
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_error_log_names_the_exception_type_once(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event, mock_ephemeral_action_handlers, caplog,
+):
+    import logging
+    _patch_ephemeral_runner(mocker, mock_ephemeral_action_handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+    caplog.set_level(logging.ERROR, logger="app.services.action_runner")
+    body = {
+        "action_id": "list_event_fields",
+        "integration_state": {
+            "type_value": "earth_ranger",
+            "configurations": [{"action_value": "auth", "data": {"token": _EPHEMERAL_SECRET}}],
+        },
+    }
+
+    response = api_client.post("/v1/actions/execute/", json=body)
+
+    assert response.status_code == 422
+    assert "ValidationError: event_type: field required" in caplog.text
+    assert "ValidationError: ValidationError" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1012,7 +1012,8 @@ async def test_ephemeral_run_rejects_background_execution(
     response = api_client.post("/v1/actions/execute/", json=body)
 
     assert response.status_code == 422
-    assert "background" in response.json()["detail"].lower()
+    # Router 422s now match the runner-side shape: {"detail": {"action_id", "error"}}.
+    assert "background" in response.json()["detail"]["error"].lower()
     assert not mock_reference_action_handler.called
 
 

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1430,6 +1430,9 @@ async def test_ephemeral_aiohttp_response_error_propagates_status(
     response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
 
     assert response.status_code == 403
+    # Same curated text an httpx 403 gets; a bare "ClientResponseError" is
+    # what the shared classifier produced before it learned aiohttp's .status.
+    assert response.json()["detail"]["error"] == "Authentication failed (HTTP 403)"
     assert not mock_publish_event.called
 
 
@@ -1500,6 +1503,33 @@ def test_validation_error_log_does_not_carry_the_request_body(caplog):
     assert response.status_code == 422
     assert _EPHEMERAL_SECRET not in response.text
     assert _EPHEMERAL_SECRET not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_nested_saved_integration_call_under_ephemeral_context_keeps_the_whitelist(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_ephemeral_action_handlers, mock_push_action_handler, integration_v2,
+):
+    # A reference/auth handler that calls execute_action(integration_id=...)
+    # for a push action gets a nested run whose own is_ephemeral is False.
+    # The read-only whitelist must key on the effective (OR-folded) context,
+    # or the nested push runs against a saved integration with no activity
+    # log and only the Gundi helpers standing in the way.
+    from app.services.activity_logger import ephemeral_run
+    _patch_ephemeral_runner(mocker, mock_ephemeral_action_handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+
+    token = ephemeral_run.set(True)
+    try:
+        response = await execute_action(
+            integration_id=str(integration_v2.id), action_id="push_observations",
+        )
+    finally:
+        ephemeral_run.reset(token)
+
+    assert response.status_code == 422
+    assert "only reference and auth actions are supported" in response.body.decode()
+    assert not mock_push_action_handler.called
+    assert not mock_publish_event.called
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -745,6 +745,45 @@ async def test_ephemeral_run_allows_auth_action(
 
 
 @pytest.mark.asyncio
+async def test_ephemeral_handler_httpstatuserror_propagates_upstream_status(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_push_action_handler, mock_generic_action_handler,
+):
+    # When the auth handler raises httpx.HTTPStatusError (source system said
+    # 401/403 to the credentials), the response status must reflect the source's
+    # code — cdip then surfaces it as upstream_status so the portal can classify
+    # as "invalid credentials" instead of a generic runner error.
+    import httpx
+
+    async def rejecting_auth_handler(**kwargs):
+        request = httpx.Request("GET", "https://source.example/status")
+        response = httpx.Response(status_code=401, request=request, json={"detail": "bad token"})
+        raise httpx.HTTPStatusError("401 Unauthorized", request=request, response=response)
+
+    handlers = {
+        "list_species": (mock_reference_action_handler, _MockReferenceActionConfiguration, None),
+        "pull_observations": (mock_pull_observations_action_handler, MockPullActionConfiguration, None),
+        "auth": (rejecting_auth_handler, _MockAuthActionConfiguration, None),
+        "push_observations": (mock_push_action_handler, MockPushActionConfiguration, None),
+        "generic_lookup": (mock_generic_action_handler, _MockGenericActionConfiguration, None),
+    }
+    mocker.patch("app.services.action_runner.action_handlers", handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "detail": {"action_id": "auth", "error": "HTTPStatusError"},
+    }
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
 async def test_ephemeral_auth_handler_write_is_blocked_end_to_end(
         mocker, mock_gundi_client_v2, mock_config_manager,
         mock_publish_event, mock_reference_action_handler, mock_pull_observations_action_handler,
@@ -873,7 +912,9 @@ async def test_ephemeral_run_error_does_not_leak_request_or_response_bodies(
 
     resp = api_client.post("/v1/actions/execute/", json=_ephemeral_body())
 
-    assert resp.status_code == 500
+    # Runner propagates HTTPStatusError.response.status_code so cdip's
+    # upstream_status matches what the source returned (401 here).
+    assert resp.status_code == 401
     body = resp.text
     assert _EPHEMERAL_SECRET not in body
     assert "authorization" not in body.lower()

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -15,6 +15,7 @@ from app.actions.core import GenericActionConfiguration
 from app.conftest import AsyncMock, MockSubActionConfiguration, MockPushActionConfiguration, MockPullActionConfiguration, async_return
 from app.main import app
 from app.services.action_scheduler import trigger_action
+from app.api_schemas import IntegrationState
 from app.services.action_runner import execute_action
 from app.services.errors import IntegrationAuthError
 from app.services.utils import find_config_for_action
@@ -1032,6 +1033,56 @@ async def test_request_with_both_integration_id_and_state_is_422(
 
     assert response.status_code == 422
     assert not mock_reference_action_handler.called
+    # Request-shape errors must not publish a bogus IntegrationActionFailed event
+    # (would leak a phantom activity-log entry against a real integration_id).
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+
+
+@pytest.mark.asyncio
+async def test_execute_action_both_ids_direct_call_does_not_publish(
+        mocker, mock_publish_event,
+):
+    # The router rejects both/neither before execute_action runs, so the
+    # API-level test above doesn't actually exercise the runner-side guard.
+    # main.py's PubSub route calls execute_action() directly with the payload
+    # it decodes, so a malformed message reaches the runner branches. This
+    # test pins the fix at that entry point: request-shape errors must return
+    # 422 without publishing IntegrationActionFailed against a real integration id.
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    state = IntegrationState(
+        type_value="earth_ranger",
+        base_url="https://sandbox.pamdas.org",
+        configurations=[],
+    )
+
+    response = await execute_action(
+        integration_id="779ff3ab-5589-4f4c-9e0a-ae8d6c9edff0",
+        integration_state=state,
+        action_id="list_species",
+    )
+
+    assert response.status_code == 422
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
+async def test_execute_action_neither_id_nor_state_direct_call_does_not_publish(
+        mocker, mock_publish_event,
+):
+    # Same reasoning as the "both" companion above — bypass the router so
+    # the runner-level branch (line ~308) actually runs.
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = await execute_action(
+        integration_id=None,
+        integration_state=None,
+        action_id="list_species",
+    )
+
+    assert response.status_code == 422
+    assert not mock_publish_event.called
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -609,6 +609,19 @@ class _MockAuthActionConfiguration(AuthActionConfiguration):
     token: str = ""
 
 
+class _MockRequiredParamReferenceConfiguration(ReferenceActionConfiguration):
+    event_type: str  # required query param
+
+
+# Curated classification titles the ephemeral path returns for third-party
+# failures, in place of str(exc) which can embed our request or the source body.
+_EXPECTED_SOURCE_STATUS_TEXT = {
+    401: "Authentication failed (HTTP 401)",
+    403: "Authentication failed (HTTP 403)",
+    500: "Unexpected response from the provider (HTTP 500)",
+}
+
+
 class _MockGenericActionConfiguration(GenericActionConfiguration):
     pass
 
@@ -648,6 +661,7 @@ def mock_ephemeral_action_handlers(
 ):
     return {
         "list_species": (mock_reference_action_handler, _MockReferenceActionConfiguration, None),
+        "list_event_fields": (mock_reference_action_handler, _MockRequiredParamReferenceConfiguration, None),
         "pull_observations": (mock_pull_observations_action_handler, MockPullActionConfiguration, None),
         "auth": (mock_auth_action_handler, _MockAuthActionConfiguration, None),
         # Present so the parametrized rejection test can prove every
@@ -780,7 +794,7 @@ async def test_ephemeral_handler_httpstatuserror_propagates_upstream_status(
 
     assert response.status_code == source_status
     assert response.json() == {
-        "detail": {"action_id": "auth", "error": "HTTPStatusError"},
+        "detail": {"action_id": "auth", "error": _EXPECTED_SOURCE_STATUS_TEXT[source_status]},
     }
     assert not mock_publish_event.called
 
@@ -816,7 +830,7 @@ async def test_ephemeral_handler_connect_error_falls_back_to_500(
 
     assert response.status_code == 500
     assert response.json() == {
-        "detail": {"action_id": "auth", "error": "ConnectError"},
+        "detail": {"action_id": "auth", "error": "Could not reach the provider"},
     }
     assert not mock_publish_event.called
 
@@ -852,7 +866,7 @@ async def test_ephemeral_handler_integration_error_propagates_status_code(
 
     assert response.status_code == 401
     assert response.json() == {
-        "detail": {"action_id": "auth", "error": "IntegrationAuthError"},
+        "detail": {"action_id": "auth", "error": "Authentication failed (HTTP 401)"},
     }
     assert not mock_publish_event.called
 
@@ -1315,6 +1329,154 @@ async def test_saved_integration_reference_action_error_never_carries_stored_con
     for event in _published_events_of_type(mock_publish_event, IntegrationActionFailed):
         assert not event.payload.config_data
         assert stored_token not in event.json()
+
+
+def _patch_ephemeral_runner(mocker, handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event):
+    mocker.patch("app.services.action_runner.action_handlers", handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_whitelist_rejection_explains_itself(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event, mock_ephemeral_action_handlers,
+):
+    # Runner-authored errors carry their own text: the runner built the
+    # message, so it cannot contain draft credentials. A bare "ValueError"
+    # is what the portal used to render in the toast.
+    _patch_ephemeral_runner(mocker, mock_ephemeral_action_handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="pull_observations"))
+
+    assert response.status_code == 422
+    assert "only reference and auth actions are supported" in response.json()["detail"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_unknown_action_explains_itself(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event, mock_ephemeral_action_handlers,
+):
+    _patch_ephemeral_runner(mocker, mock_ephemeral_action_handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="list_nothing"))
+
+    assert response.status_code == 422
+    assert "Action 'list_nothing' is not supported" in response.json()["detail"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_missing_required_param_names_the_field(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event, mock_ephemeral_action_handlers,
+):
+    # pydantic 1.x ValidationError.errors() carries loc/msg/type and never the
+    # offending input, so naming the field is safe and is what the wizard
+    # needs to tell the user what to supply.
+    _patch_ephemeral_runner(mocker, mock_ephemeral_action_handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+    body = {
+        "action_id": "list_event_fields",
+        "config_overrides": {},
+        "integration_state": {
+            "type_value": "earth_ranger",
+            "base_url": "https://sandbox.pamdas.org",
+            "configurations": [{"action_value": "auth", "data": {"token": _EPHEMERAL_SECRET}}],
+        },
+    }
+
+    response = api_client.post("/v1/actions/execute/", json=body)
+
+    assert response.status_code == 422
+    error = response.json()["detail"]["error"]
+    assert "event_type" in error and "field required" in error
+    assert _EPHEMERAL_SECRET not in response.text
+
+
+def _auth_handlers_raising(exc, mock_reference_action_handler, mock_pull_observations_action_handler,
+                           mock_push_action_handler, mock_generic_action_handler):
+    async def failing_auth_handler(**kwargs):
+        raise exc
+    return {
+        "list_species": (mock_reference_action_handler, _MockReferenceActionConfiguration, None),
+        "pull_observations": (mock_pull_observations_action_handler, MockPullActionConfiguration, None),
+        "auth": (failing_auth_handler, _MockAuthActionConfiguration, None),
+        "push_observations": (mock_push_action_handler, MockPushActionConfiguration, None),
+        "generic_lookup": (mock_generic_action_handler, _MockGenericActionConfiguration, None),
+    }
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_auth_error_without_status_code_is_401(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_push_action_handler, mock_generic_action_handler,
+):
+    # The idiomatic `raise IntegrationAuthError("Invalid API key")` sets no
+    # status_code. On the Test Connection path that must still read as bad
+    # credentials (401), not as an internal error (500).
+    from app.services.errors import IntegrationAuthError
+    handlers = _auth_handlers_raising(
+        IntegrationAuthError("Invalid API key"), mock_reference_action_handler,
+        mock_pull_observations_action_handler, mock_push_action_handler, mock_generic_action_handler,
+    )
+    _patch_ephemeral_runner(mocker, handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["error"] == "Authentication failed"
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_aiohttp_response_error_propagates_status(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_push_action_handler, mock_generic_action_handler,
+):
+    # aiohttp carries the source status on `.status`, not `.response.status_code`.
+    import aiohttp
+    from multidict import CIMultiDict, CIMultiDictProxy
+    from yarl import URL
+    request_info = aiohttp.RequestInfo(
+        url=URL("https://source.example/me"), method="GET",
+        headers=CIMultiDictProxy(CIMultiDict()), real_url=URL("https://source.example/me"),
+    )
+    exc = aiohttp.ClientResponseError(request_info, (), status=403, message="Forbidden")
+    handlers = _auth_handlers_raising(
+        exc, mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_push_action_handler, mock_generic_action_handler,
+    )
+    _patch_ephemeral_runner(mocker, handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
+
+    assert response.status_code == 403
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_source_redirect_is_not_forwarded_as_runner_status(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_push_action_handler, mock_generic_action_handler,
+):
+    # raise_for_status raises on 3xx when redirects are off. Answering 301
+    # with a JSON body and no Location header is not a response the portal
+    # can act on; only source statuses >= 400 are forwarded.
+    import httpx
+    request = httpx.Request("GET", "http://source.example/me")
+    response = httpx.Response(301, request=request, headers={"location": "https://source.example/me"})
+    exc = httpx.HTTPStatusError("301 Moved Permanently", request=request, response=response)
+    handlers = _auth_handlers_raising(
+        exc, mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_push_action_handler, mock_generic_action_handler,
+    )
+    _patch_ephemeral_runner(mocker, handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+
+    resp = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
+
+    assert resp.status_code == 500
+    assert "location" not in {k.lower() for k in resp.headers}
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -10,6 +10,8 @@ from gundi_core.events import IntegrationActionFailed, IntegrationActionCustomLo
 from gundi_core.events.transformers import ObservationTransformedER
 
 from app import settings
+import pydantic
+
 from app.actions.core import AuthActionConfiguration, ReferenceActionConfiguration
 from app.actions.core import GenericActionConfiguration
 from app.conftest import AsyncMock, MockSubActionConfiguration, MockPushActionConfiguration, MockPullActionConfiguration, async_return
@@ -613,6 +615,18 @@ class _MockRequiredParamReferenceConfiguration(ReferenceActionConfiguration):
     event_type: str  # required query param
 
 
+class _MockEchoingValidatorAuthConfiguration(AuthActionConfiguration):
+    # Connector-defined validators are free to put the offending value in the
+    # message; the ephemeral path must not forward it.
+    token: str = ""
+
+    @pydantic.validator("token")
+    def _token_must_be_hex(cls, value):
+        if value and not all(c in "0123456789abcdef" for c in value):
+            raise ValueError(f"invalid token {value}")
+        return value
+
+
 # Curated classification titles the ephemeral path returns for third-party
 # failures, in place of str(exc) which can embed our request or the source body.
 _EXPECTED_SOURCE_STATUS_TEXT = {
@@ -662,6 +676,7 @@ def mock_ephemeral_action_handlers(
     return {
         "list_species": (mock_reference_action_handler, _MockReferenceActionConfiguration, None),
         "list_event_fields": (mock_reference_action_handler, _MockRequiredParamReferenceConfiguration, None),
+        "auth_echoing": (mock_auth_action_handler, _MockEchoingValidatorAuthConfiguration, None),
         "pull_observations": (mock_pull_observations_action_handler, MockPullActionConfiguration, None),
         "auth": (mock_auth_action_handler, _MockAuthActionConfiguration, None),
         # Present so the parametrized rejection test can prove every
@@ -1530,6 +1545,60 @@ async def test_nested_saved_integration_call_under_ephemeral_context_keeps_the_w
     assert "only reference and auth actions are supported" in response.body.decode()
     assert not mock_push_action_handler.called
     assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_validation_error_from_custom_validator_does_not_echo_the_value(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event, mock_ephemeral_action_handlers,
+):
+    # pydantic's own messages ("field required", "value is not a valid
+    # integer") never contain the input, but a connector validator's
+    # ValueError text is arbitrary. Keep the field location; replace the
+    # message unless it is one of pydantic's built-in (dotted-type) errors.
+    _patch_ephemeral_runner(mocker, mock_ephemeral_action_handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+    body = {
+        "action_id": "auth_echoing",
+        "integration_state": {
+            "type_value": "earth_ranger",
+            "base_url": "https://sandbox.pamdas.org",
+            "configurations": [{"action_value": "auth_echoing", "data": {"token": _EPHEMERAL_SECRET}}],
+        },
+    }
+
+    response = api_client.post("/v1/actions/execute/", json=body)
+
+    assert response.status_code == 422
+    error = response.json()["detail"]["error"]
+    assert _EPHEMERAL_SECRET not in response.text
+    assert "token" in error and "invalid value" in error
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_handler_error_is_not_logged_verbatim(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_ephemeral_action_handlers, mock_reference_action_handler, caplog,
+):
+    # The same untrusted exception text the response scrubs (our outgoing
+    # request with its auth header, the source's response body) must not
+    # reach the application log either; logs outlive and outreach the request.
+    import httpx
+    import logging
+    outgoing_body = f'{{"authorization": "Bearer {_EPHEMERAL_SECRET}"}}'
+    source_body = f'{{"error": "invalid credential {_EPHEMERAL_SECRET}"}}'
+    request = httpx.Request("POST", f"https://sandbox.pamdas.org/events/?token={_EPHEMERAL_SECRET}", content=outgoing_body)
+    response = httpx.Response(401, text=source_body, request=request)
+    mock_reference_action_handler.side_effect = httpx.HTTPStatusError(
+        f"401 Unauthorized for url with {_EPHEMERAL_SECRET}", request=request, response=response,
+    )
+    _patch_ephemeral_runner(mocker, mock_ephemeral_action_handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+    caplog.set_level(logging.DEBUG, logger="app.services.action_runner")
+
+    resp = api_client.post("/v1/actions/execute/", json=_ephemeral_body())
+
+    assert resp.status_code == 401
+    assert _EPHEMERAL_SECRET not in caplog.text
+    # Still enough to debug: the action, the exception type, and the frames.
+    assert "list_species" in caplog.text and "HTTPStatusError" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1228,6 +1228,56 @@ async def test_ephemeral_contextvar_or_folds_with_outer_state(mocker, mock_publi
 
 
 @pytest.mark.asyncio
+async def test_saved_integration_reference_action_with_no_config_and_no_overrides_is_not_404(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_ephemeral_action_handlers, mock_reference_action_handler, integration_v2,
+):
+    # Same rule the earthranger and inaturalist forks already ship: a
+    # reference action is stateless, so "no stored config row and no
+    # overrides" is a complete zero-param query on a *saved* integration too,
+    # not a missing-configuration 404. config_model.parse_obj({}) below still
+    # 422s when params are actually required.
+    mock_config_manager.get_action_configuration = AsyncMock(return_value=None)
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post(
+        "/v1/actions/execute/",
+        json={"integration_id": str(integration_v2.id), "action_id": "list_species"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert mock_reference_action_handler.called
+    assert mock_reference_action_handler.call_args.kwargs["action_config"].tag_name == ""
+
+
+@pytest.mark.asyncio
+async def test_saved_integration_generic_action_with_no_config_and_no_overrides_still_404s(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_ephemeral_action_handlers, mock_generic_action_handler, integration_v2,
+):
+    # Pin: relaxing the missing-config 404 for reference actions must not
+    # loosen it for any other non-pull action type.
+    mock_config_manager.get_action_configuration = AsyncMock(return_value=None)
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post(
+        "/v1/actions/execute/",
+        json={"integration_id": str(integration_v2.id), "action_id": "generic_lookup"},
+    )
+
+    assert response.status_code == 404
+    assert not mock_generic_action_handler.called
+
+
+@pytest.mark.asyncio
 async def test_push_data_acks_message_without_destination_id(
         mocker, pubsub_message_request_headers, run_push_action_pubsub_payload
 ):

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -65,7 +65,7 @@ async def test_execute_pull_action_from_pubsub(
     integration_id = payload_dict.get("integration_id")
     action_id = payload_dict.get("action_id")
     assert mock_config_manager.get_integration_details.called
-    mock_config_manager.get_integration_details.assert_called_with(integration_id)
+    mock_config_manager.get_integration_details.assert_called_with(integration_id, include_webhook_config=False)
     mock_action_handler, mock_config, mock_datamodel = mock_action_handlers[action_id]
     assert mock_action_handler.called
 
@@ -95,7 +95,7 @@ async def test_execute_push_action_from_pubsub(
     # Check that the action config is retrieved for the integration
     integration_id = attributes.get("destination_id")
     assert mock_config_manager.get_integration_details.called
-    mock_config_manager.get_integration_details.assert_called_with(integration_id)
+    mock_config_manager.get_integration_details.assert_called_with(integration_id, include_webhook_config=False)
     # Check that the right handler is called, with config and data
     assert mock_push_observations_handler.call_count == 1
     mock_call = mock_push_observations_handler.mock_calls[0]
@@ -135,7 +135,7 @@ async def test_execute_action_from_api(
     assert response.status_code == 200
     assert not mock_gundi_client_v2.get_integration_details.called
     assert mock_config_manager.get_integration_details.called
-    mock_config_manager.get_integration_details.assert_called_with(integration_id)
+    mock_config_manager.get_integration_details.assert_called_with(integration_id, include_webhook_config=False)
     mock_action_handler, mock_config, mock_datamodel = mock_action_handlers[action_id]
     assert mock_action_handler.called
 
@@ -1899,6 +1899,26 @@ async def test_ephemeral_error_log_names_the_exception_type_once(
     assert response.status_code == 422
     assert "ValidationError: event_type: field required" in caplog.text
     assert "ValidationError: ValidationError" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_action_run_loads_the_integration_without_the_webhook_config(
+        mocker, mock_gundi_client_v2, integration_v2, mock_config_manager, mock_publish_event, mock_action_handlers,
+):
+    # The webhook key is the one cache entry with a TTL nothing invalidates, so
+    # loading it would send every warm action run back to the portal once per
+    # TTL and let a portal outage fail actions whose configs are cached.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    await execute_action(integration_id=str(integration_v2.id), action_id="pull_observations")
+
+    mock_config_manager.get_integration_details.assert_called_once_with(
+        str(integration_v2.id), include_webhook_config=False,
+    )
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1519,6 +1519,34 @@ def _auth_handlers_raising(exc, mock_reference_action_handler, mock_pull_observa
 
 
 @pytest.mark.asyncio
+async def test_ephemeral_configuration_error_forwards_its_message_as_422(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_push_action_handler, mock_generic_action_handler,
+):
+    # A connector's own guard ("site URL is empty", "unknown event type") is
+    # neither a source verdict nor runner-authored, so today it redacts to the
+    # bare type name with a 500 and the portal wizard has nothing to act on.
+    # IntegrationConfigurationError is the connector's explicit opt-in: its
+    # message describes the shape of the problem without echoing submitted
+    # values, so the ephemeral path forwards it, as a 422 (the request was
+    # understood; its content cannot be acted on).
+    from app.services.errors import IntegrationConfigurationError
+
+    handlers = _auth_handlers_raising(
+        IntegrationConfigurationError("Site URL is empty or invalid"), mock_reference_action_handler,
+        mock_pull_observations_action_handler, mock_push_action_handler, mock_generic_action_handler,
+    )
+    _patch_ephemeral_runner(mocker, handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["error"] == "Invalid configuration — Site URL is empty or invalid"
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
 async def test_ephemeral_auth_error_without_status_code_is_401(
         mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
         mock_reference_action_handler, mock_pull_observations_action_handler,

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1546,6 +1546,29 @@ async def test_ephemeral_configuration_error_forwards_its_message_as_422(
     assert not mock_publish_event.called
 
 
+@pytest.mark.asyncio
+async def test_ephemeral_configuration_error_with_a_status_code_still_answers_422_and_says_so(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_push_action_handler, mock_generic_action_handler,
+):
+    # A connector may attach the source status it saw (a 404 for an unknown
+    # event type). The response is still the runner's 422, so the body must
+    # not carry a contradicting "(HTTP 404)" suffix.
+    from app.services.errors import IntegrationConfigurationError
+
+    handlers = _auth_handlers_raising(
+        IntegrationConfigurationError("Unknown event type", status_code=404), mock_reference_action_handler,
+        mock_pull_observations_action_handler, mock_push_action_handler, mock_generic_action_handler,
+    )
+    _patch_ephemeral_runner(mocker, handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["error"] == "Invalid configuration — Unknown event type"
+
+
 def _mock_draft_url_resolution(mocker, ip):
     mock_loop = mocker.MagicMock()
     mock_loop.getaddrinfo = AsyncMock(return_value=[(None, None, None, None, (ip, 443))])

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1459,6 +1459,50 @@ async def test_ephemeral_source_redirect_is_not_forwarded_as_runner_status(
 
 
 @pytest.mark.asyncio
+async def test_trigger_action_is_blocked_on_ephemeral_run(mocker, mock_publish_event):
+    # The last unguarded outbound path from the #87 thread. Publishing a
+    # RunIntegrationAction against a synthetic id would either vanish
+    # silently (async) or run a saved-integration lookup that fails (sync);
+    # raising is the only honest answer to a reference/auth handler.
+    from app.services.activity_logger import ephemeral_run
+    from app.services.gundi import EphemeralWriteBlocked
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+
+    token = ephemeral_run.set(True)
+    try:
+        with pytest.raises(EphemeralWriteBlocked):
+            await trigger_action(integration_id="synthetic-uuid", action_id="pull_observations")
+    finally:
+        ephemeral_run.reset(token)
+
+    assert not mock_publish_event.called
+
+
+def test_validation_error_log_does_not_carry_the_request_body(caplog):
+    # Copilot on #98: the DEBUG log of a failed body validation wrote the
+    # whole body, draft credentials included. Log access is usually broader
+    # than access to the originating request, so only the sanitized errors
+    # may be logged.
+    import logging
+    caplog.set_level(logging.DEBUG, logger="app.main")
+    body = {
+        "action_id": "auth",
+        "integration_state": {
+            "type_value": "earth_ranger",
+            # `data` missing -> RequestValidationError; the token rides along
+            # in the body that used to be logged verbatim.
+            "configurations": [{"action_value": "auth", "token": _EPHEMERAL_SECRET}],
+        },
+    }
+
+    response = api_client.post("/v1/actions/execute/", json=body)
+
+    assert response.status_code == 422
+    assert _EPHEMERAL_SECRET not in response.text
+    assert _EPHEMERAL_SECRET not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_push_data_acks_message_without_destination_id(
         mocker, pubsub_message_request_headers, run_push_action_pubsub_payload
 ):

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1306,10 +1306,11 @@ async def test_saved_integration_reference_action_error_never_carries_stored_con
     # _handle_error normalizes a None config_data to {}; the invariant is that
     # no configuration (and no secret) reaches the response or the event.
     assert not response.json()["detail"]["config_data"]
-    events = _published_events_of_type(mock_publish_event, IntegrationActionFailed)
-    assert len(events) == 1
-    assert not events[0].payload.config_data
-    assert stored_token not in events[0].json()
+    # Whether a failing reference action publishes an activity event at all is
+    # not this test's concern; whatever is published must be redacted.
+    for event in _published_events_of_type(mock_publish_event, IntegrationActionFailed):
+        assert not event.payload.config_data
+        assert stored_token not in event.json()
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1054,41 +1054,17 @@ async def test_request_with_both_integration_id_and_state_is_422(
 
 
 @pytest.mark.asyncio
-async def test_execute_action_both_ids_direct_call_does_not_publish(
-        mocker, mock_publish_event,
+async def test_execute_action_neither_id_nor_state_direct_call_logs_but_does_not_publish(
+        mocker, mock_publish_event, caplog,
 ):
-    # The router rejects both/neither before execute_action runs, so the
-    # API-level test above doesn't actually exercise the runner-side guard.
-    # main.py's PubSub route calls execute_action() directly with the payload
-    # it decodes, so a malformed message reaches the runner branches. This
-    # test pins the fix at that entry point: request-shape errors must return
-    # 422 without publishing IntegrationActionFailed against a real integration id.
+    # Bypass the router: main.py's PubSub route calls execute_action directly
+    # with whatever the message carried, so a command with no integration_id
+    # reaches this branch. It must not publish a phantom activity event, but
+    # it must leave a server-log trace (before #98 it did both).
+    import logging
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
     mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
-    state = IntegrationState(
-        type_value="earth_ranger",
-        base_url="https://sandbox.pamdas.org",
-        configurations=[],
-    )
-
-    response = await execute_action(
-        integration_id="779ff3ab-5589-4f4c-9e0a-ae8d6c9edff0",
-        integration_state=state,
-        action_id="list_species",
-    )
-
-    assert response.status_code == 422
-    assert not mock_publish_event.called
-
-
-@pytest.mark.asyncio
-async def test_execute_action_neither_id_nor_state_direct_call_does_not_publish(
-        mocker, mock_publish_event,
-):
-    # Same reasoning as the "both" companion above — bypass the router so
-    # the runner-level branch (line ~308) actually runs.
-    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    caplog.set_level(logging.ERROR, logger="app.services.action_runner")
 
     response = await execute_action(
         integration_id=None,
@@ -1098,6 +1074,9 @@ async def test_execute_action_neither_id_nor_state_direct_call_does_not_publish(
 
     assert response.status_code == 422
     assert not mock_publish_event.called
+    body = response.body.decode()
+    assert "Provide either integration_id or integration_state." in body
+    assert any("integration_id" in r.getMessage() and r.levelno == logging.ERROR for r in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -10,11 +10,13 @@ from gundi_core.events import IntegrationActionFailed, IntegrationActionCustomLo
 from gundi_core.events.transformers import ObservationTransformedER
 
 from app import settings
-from app.conftest import MockSubActionConfiguration, MockPushActionConfiguration, async_return
+from app.actions.core import ReferenceActionConfiguration
+from app.conftest import AsyncMock, MockSubActionConfiguration, MockPushActionConfiguration, async_return
 from app.main import app
 from app.services.action_scheduler import trigger_action
 from app.services.action_runner import execute_action
 from app.services.errors import IntegrationAuthError
+from app.services.utils import find_config_for_action
 
 api_client = TestClient(app)
 
@@ -593,6 +595,325 @@ async def test_execute_action_with_handler_error(
     assert event.payload.server_response_status == expected_error.response.status_code
     assert event.payload.server_response_body == str(expected_error.response.text)
 
+
+_EPHEMERAL_SECRET = "ephemeral-token-abc123"
+
+
+class _MockReferenceActionConfiguration(ReferenceActionConfiguration):
+    tag_name: str = ""
+
+
+@pytest.fixture
+def mock_reference_action_handler():
+    handler = AsyncMock()
+    handler.return_value = {"options": [{"value": "elephant", "label": "Elephant"}]}
+    return handler
+
+
+@pytest.fixture
+def mock_ephemeral_action_handlers(
+        mock_reference_action_handler, mock_pull_observations_action_handler,
+):
+    return {
+        "list_species": (mock_reference_action_handler, _MockReferenceActionConfiguration, None),
+        "pull_observations": (mock_pull_observations_action_handler, MockPullActionConfiguration, None),
+    }
+
+
+def _ephemeral_body(action_id="list_species", token=_EPHEMERAL_SECRET, base_url="https://sandbox.pamdas.org"):
+    return {
+        "action_id": action_id,
+        "integration_state": {
+            "type_value": "earth_ranger",
+            "base_url": base_url,
+            "configurations": [
+                {"action_value": "auth", "data": {"token": token}},
+                {"action_value": action_id, "data": {"tag_name": "elephant"}},
+            ],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_run_builds_synthetic_integration(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers, mock_reference_action_handler,
+):
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body())
+
+    assert response.status_code == 200
+    assert not mock_config_manager.get_integration_details.called
+    assert not mock_config_manager.get_action_configuration.called
+    assert mock_reference_action_handler.called
+    call_kwargs = mock_reference_action_handler.call_args.kwargs
+    integration = call_kwargs["integration"]
+    assert integration.base_url == "https://sandbox.pamdas.org"
+    auth_config = find_config_for_action(integration.configurations, "auth")
+    assert auth_config is not None
+    assert auth_config.data == {"token": _EPHEMERAL_SECRET}
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_run_rejects_non_reference_action(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers, mock_pull_observations_action_handler,
+):
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    body = _ephemeral_body(action_id="pull_observations")
+    response = api_client.post("/v1/actions/execute/", json=body)
+
+    assert response.status_code == 422
+    assert not mock_pull_observations_action_handler.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_run_publishes_no_activity_events(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers,
+):
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body())
+
+    assert response.status_code == 200
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_run_error_payload_scrubs_credentials(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers, mock_reference_action_handler,
+):
+    mock_reference_action_handler.side_effect = RuntimeError("upstream unreachable")
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body())
+
+    assert response.status_code == 500
+    body = response.text
+    assert _EPHEMERAL_SECRET not in body
+    # Sanitized: only exception type + action_id, no traceback / request / response.
+    detail = response.json()["detail"]
+    assert detail == {"action_id": "list_species", "error": "RuntimeError"}
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_run_error_does_not_leak_request_or_response_bodies(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers, mock_reference_action_handler,
+):
+    # A realistic upstream failure carries our outgoing request (which may
+    # embed auth headers/tokens) and the source's response body. Neither must
+    # appear in the response returned to the portal.
+    import httpx
+    outgoing_body = f'{{"authorization": "Bearer {_EPHEMERAL_SECRET}"}}'
+    source_body = f'{{"error": "invalid credential {_EPHEMERAL_SECRET}"}}'
+    request = httpx.Request("POST", "https://sandbox.pamdas.org/events/", content=outgoing_body)
+    response = httpx.Response(401, text=source_body, request=request)
+    mock_reference_action_handler.side_effect = httpx.HTTPStatusError(
+        "401 Unauthorized", request=request, response=response,
+    )
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    resp = api_client.post("/v1/actions/execute/", json=_ephemeral_body())
+
+    assert resp.status_code == 500
+    body = resp.text
+    assert _EPHEMERAL_SECRET not in body
+    assert "authorization" not in body.lower()
+    assert "Traceback" not in body
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_run_rejects_background_execution(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers, mock_reference_action_handler,
+):
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    body = _ephemeral_body()
+    body["run_in_background"] = True
+    response = api_client.post("/v1/actions/execute/", json=body)
+
+    assert response.status_code == 422
+    assert "background" in response.json()["detail"].lower()
+    assert not mock_reference_action_handler.called
+
+
+@pytest.mark.asyncio
+async def test_request_with_both_integration_id_and_state_is_422(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers, mock_reference_action_handler,
+):
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    body = _ephemeral_body()
+    body["integration_id"] = "779ff3ab-5589-4f4c-9e0a-ae8d6c9edff0"
+    response = api_client.post("/v1/actions/execute/", json=body)
+
+    assert response.status_code == 422
+    assert not mock_reference_action_handler.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_run_returns_handler_result(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers, mock_reference_action_handler,
+):
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body())
+
+    assert response.status_code == 200
+    assert response.json() == {"options": [{"value": "elephant", "label": "Elephant"}]}
+
+
+@pytest.mark.asyncio
+async def test_request_without_integration_id_or_state_is_422(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers,
+):
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post(
+        "/v1/actions/execute/",
+        json={"action_id": "list_species"},
+    )
+
+    assert response.status_code == 422
+    # Validation errors must not publish a bogus IntegrationActionFailed event.
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_run_succeeds_for_parameter_less_reference_action(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers, mock_reference_action_handler,
+):
+    # The real portal wizard forwards `configurations` only for the sections
+    # the user edited (auth). A parameter-less reference action like ER's
+    # list_event_types has no config entry — the 404 branch used to fire
+    # here and cdip wrapped it as a 502.
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    # Body mirrors the actual portal: only the edited section (auth), no
+    # config row for the reference action itself, empty config_overrides.
+    body = {
+        "action_id": "list_species",
+        "integration_state": {
+            "type_value": "earth_ranger",
+            "base_url": "https://sandbox.pamdas.org",
+            "configurations": [
+                {"action_value": "auth", "data": {"token": _EPHEMERAL_SECRET}},
+            ],
+        },
+    }
+
+    response = api_client.post("/v1/actions/execute/", json=body)
+
+    assert response.status_code == 200, response.text
+    assert mock_reference_action_handler.called
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_run_uses_unique_integration_id_per_run(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers, mock_reference_action_handler,
+):
+    # Every ephemeral run must get a fresh synthetic integration id so
+    # concurrent runs by different users can't collide on any
+    # IntegrationStateManager keys downstream handlers might set under
+    # `integration.id`.
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    api_client.post("/v1/actions/execute/", json=_ephemeral_body())
+    api_client.post("/v1/actions/execute/", json=_ephemeral_body())
+
+    assert mock_reference_action_handler.call_count == 2
+    seen_ids = {
+        str(call.kwargs["integration"].id)
+        for call in mock_reference_action_handler.mock_calls
+    }
+    assert len(seen_ids) == 2, f"expected two distinct ids, got {seen_ids}"
+    assert "00000000-0000-0000-0000-000000000000" not in seen_ids
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_contextvar_or_folds_with_outer_state(mocker):
+    # If ephemeral_run is already True when execute_action starts (a nested
+    # execute inside a reference handler), a saved-integration inner call
+    # (is_ephemeral=False for the inner) must NOT re-enable publishing.
+    from app.services.activity_logger import ephemeral_run
+    mock_config_manager = mocker.MagicMock()
+    async def _crash(*a, **kw):
+        raise RuntimeError("should not reach the portal from an ephemeral outer")
+    mock_config_manager.get_integration_details = _crash
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+
+    outer_token = ephemeral_run.set(True)
+    try:
+        # Call execute_action directly with a saved integration_id (inner
+        # scenario). The or-fold should keep the contextvar True so
+        # publish_event stays suppressed inside; and the outer context is
+        # restored on return so nothing bleeds out of this test.
+        try:
+            await execute_action(integration_id="00000000-0000-0000-0000-000000000000", action_id="anything")
+        except Exception:
+            pass
+        # If the or-fold worked, we didn't reach _crash — but even if the
+        # code path changed, the invariant we care about is that the
+        # contextvar is still True after the nested call returns.
+        assert ephemeral_run.get() is True
+    finally:
+        ephemeral_run.reset(outer_token)
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -627,6 +627,23 @@ class _MockEchoingValidatorAuthConfiguration(AuthActionConfiguration):
         return value
 
 
+class _TokenFormatError(pydantic.PydanticValueError):
+    # Produces the dotted type "value_error.invalid_token", indistinguishable
+    # by shape from pydantic's own errors, with a template that echoes input.
+    code = "invalid_token"
+    msg_template = "invalid token {value}"
+
+
+class _MockPydanticErrorAuthConfiguration(AuthActionConfiguration):
+    token: str = ""
+
+    @pydantic.validator("token")
+    def _token_must_be_hex(cls, value):
+        if value and not all(c in "0123456789abcdef" for c in value):
+            raise _TokenFormatError(value=value)
+        return value
+
+
 # Curated classification titles the ephemeral path returns for third-party
 # failures, in place of str(exc) which can embed our request or the source body.
 _EXPECTED_SOURCE_STATUS_TEXT = {
@@ -677,6 +694,7 @@ def mock_ephemeral_action_handlers(
         "list_species": (mock_reference_action_handler, _MockReferenceActionConfiguration, None),
         "list_event_fields": (mock_reference_action_handler, _MockRequiredParamReferenceConfiguration, None),
         "auth_echoing": (mock_auth_action_handler, _MockEchoingValidatorAuthConfiguration, None),
+        "auth_pydantic_error": (mock_auth_action_handler, _MockPydanticErrorAuthConfiguration, None),
         "pull_observations": (mock_pull_observations_action_handler, MockPullActionConfiguration, None),
         "auth": (mock_auth_action_handler, _MockAuthActionConfiguration, None),
         # Present so the parametrized rejection test can prove every
@@ -1599,6 +1617,32 @@ async def test_ephemeral_handler_error_is_not_logged_verbatim(
     assert _EPHEMERAL_SECRET not in caplog.text
     # Still enough to debug: the action, the exception type, and the frames.
     assert "list_species" in caplog.text and "HTTPStatusError" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_validation_error_from_custom_pydantic_error_does_not_echo_the_value(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event, mock_ephemeral_action_handlers,
+):
+    # A dotted error type does not prove pydantic authored the message: a
+    # connector's PydanticValueError subclass gets one too, and its template
+    # can interpolate the submitted value. Only an explicit allowlist of
+    # server-owned text may pass through.
+    _patch_ephemeral_runner(mocker, mock_ephemeral_action_handlers, mock_gundi_client_v2, mock_config_manager, mock_publish_event)
+    body = {
+        "action_id": "auth_pydantic_error",
+        "integration_state": {
+            "type_value": "earth_ranger",
+            "base_url": "https://sandbox.pamdas.org",
+            "configurations": [{"action_value": "auth_pydantic_error", "data": {"token": _EPHEMERAL_SECRET}}],
+        },
+    }
+
+    response = api_client.post("/v1/actions/execute/", json=body)
+
+    assert response.status_code == 422
+    error = response.json()["detail"]["error"]
+    assert _EPHEMERAL_SECRET not in response.text
+    assert "token" in error and "invalid value" in error
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -263,6 +263,73 @@ async def test_triggered_by_marker_is_case_insensitive(
 
 
 @pytest.mark.asyncio
+async def test_triggered_by_marker_is_read_from_pubsub_attributes(
+        mocker, mock_gundi_client_v2, integration_v2, mock_config_manager,
+        mock_publish_event, mock_action_handlers, pubsub_message_request_headers,
+):
+    # gundi_core's RunIntegrationAction command has no `triggered_by` field, so a
+    # portal that publishes that model cannot put the marker in the message body.
+    # The attributes are the only channel available to it -- if they aren't read,
+    # every PubSub-delivered run is classified automated and the MANUAL branch is
+    # dead code.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    bad_config = mocker.MagicMock()
+    bad_config.data = {"lookback_days": "two"}  # should be an integer
+    mock_config_manager.get_action_configuration.return_value = async_return(bad_config)
+    encoded = base64.b64encode(json.dumps({
+        "integration_id": str(integration_v2.id),
+        "action_id": "pull_observations",
+    }).encode("utf-8")).decode("utf-8")
+
+    response = api_client.post(
+        "/",
+        headers=pubsub_message_request_headers,
+        json={"message": {"data": encoded, "attributes": {"triggered_by": "manual"}}},
+    )
+
+    assert response.status_code == 200
+    mock_action_handler, _, _ = mock_action_handlers["pull_observations"]
+    assert not mock_action_handler.called
+    # Treated as manual -> strict -> the operator sees the validation error.
+    assert _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionCustomLog)
+
+
+@pytest.mark.asyncio
+async def test_body_triggered_by_wins_over_attributes(
+        mocker, mock_gundi_client_v2, integration_v2, mock_config_manager,
+        mock_publish_event, mock_action_handlers, pubsub_message_request_headers,
+):
+    # The body stays authoritative when both carry the marker.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    bad_config = mocker.MagicMock()
+    bad_config.data = {"lookback_days": "two"}
+    mock_config_manager.get_action_configuration.return_value = async_return(bad_config)
+    encoded = base64.b64encode(json.dumps({
+        "integration_id": str(integration_v2.id),
+        "action_id": "pull_observations",
+        "triggered_by": "manual",
+    }).encode("utf-8")).decode("utf-8")
+
+    response = api_client.post(
+        "/",
+        headers=pubsub_message_request_headers,
+        json={"message": {"data": encoded, "attributes": {"triggered_by": "auto"}}},
+    )
+
+    assert response.status_code == 200
+    assert _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+
+
+@pytest.mark.asyncio
 async def test_scheduled_pull_action_with_invalid_config_is_skipped(
         mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
         mock_action_handlers, mock_state_manager, pubsub_message_request_headers,

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -429,6 +429,36 @@ async def test_scheduled_pull_action_invalid_config_skip_survives_throttle_failu
 
 
 @pytest.mark.asyncio
+async def test_scheduled_pull_action_invalid_config_skip_survives_publish_failure(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_action_handlers, mock_state_manager, pubsub_message_request_headers,
+        run_pull_action_pubsub_payload,
+):
+    # Same contract as the throttle above, for the event publisher: if the skip
+    # WARNING can't be published, the skip must still succeed rather than escape
+    # as a 500 / PubSub redelivery. The warning is already in the logs.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.action_runner.state_manager", mock_state_manager)
+    mocker.patch(
+        "app.services.action_runner.log_action_activity",
+        mocker.AsyncMock(side_effect=Exception("pubsub unavailable")),
+    )
+    bad_config = mocker.MagicMock()
+    bad_config.data = {"lookback_days": "two"}
+    mock_config_manager.get_action_configuration.return_value = async_return(bad_config)
+
+    response = api_client.post(
+        "/", headers=pubsub_message_request_headers, json=run_pull_action_pubsub_payload,
+    )
+
+    assert response.status_code == 200
+    mock_action_handler, _, _ = mock_action_handlers["pull_observations"]
+    assert not mock_action_handler.called
+
+
+@pytest.mark.asyncio
 async def test_scheduled_pull_action_with_missing_config_is_skipped(
         mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
         mock_action_handlers, pubsub_message_request_headers, run_pull_action_pubsub_payload,

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -11,6 +11,7 @@ from gundi_core.events.transformers import ObservationTransformedER
 
 from app import settings
 from app.actions.core import AuthActionConfiguration, ReferenceActionConfiguration
+from app.actions.core import GenericActionConfiguration
 from app.conftest import AsyncMock, MockSubActionConfiguration, MockPushActionConfiguration, MockPullActionConfiguration, async_return
 from app.main import app
 from app.services.action_scheduler import trigger_action
@@ -607,6 +608,10 @@ class _MockAuthActionConfiguration(AuthActionConfiguration):
     token: str = ""
 
 
+class _MockGenericActionConfiguration(GenericActionConfiguration):
+    pass
+
+
 @pytest.fixture
 def mock_reference_action_handler():
     handler = AsyncMock()
@@ -622,14 +627,34 @@ def mock_auth_action_handler():
 
 
 @pytest.fixture
+def mock_push_action_handler():
+    handler = AsyncMock()
+    handler.return_value = {"pushed": 1}
+    return handler
+
+
+@pytest.fixture
+def mock_generic_action_handler():
+    handler = AsyncMock()
+    handler.return_value = {}
+    return handler
+
+
+@pytest.fixture
 def mock_ephemeral_action_handlers(
         mock_reference_action_handler, mock_pull_observations_action_handler,
-        mock_auth_action_handler,
+        mock_auth_action_handler, mock_push_action_handler, mock_generic_action_handler,
 ):
     return {
         "list_species": (mock_reference_action_handler, _MockReferenceActionConfiguration, None),
         "pull_observations": (mock_pull_observations_action_handler, MockPullActionConfiguration, None),
         "auth": (mock_auth_action_handler, _MockAuthActionConfiguration, None),
+        # Present so the parametrized rejection test can prove every
+        # non-safe action type is rejected — the guard uses config-model
+        # isinstance, and Generic is the fallback for handlers without an
+        # explicit annotation, so leaving it untested is the highest-risk gap.
+        "push_observations": (mock_push_action_handler, MockPushActionConfiguration, None),
+        "generic_lookup": (mock_generic_action_handler, _MockGenericActionConfiguration, None),
     }
 
 
@@ -672,22 +697,27 @@ async def test_ephemeral_run_builds_synthetic_integration(
     assert auth_config.data == {"token": _EPHEMERAL_SECRET}
 
 
+@pytest.mark.parametrize("action_id", ["pull_observations", "push_observations", "generic_lookup"])
 @pytest.mark.asyncio
 async def test_ephemeral_run_rejects_non_reference_non_auth_action(
-        mocker, mock_gundi_client_v2, mock_config_manager,
-        mock_publish_event, mock_ephemeral_action_handlers, mock_pull_observations_action_handler,
+        action_id, mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers,
 ):
+    # Every non-safe action type must be rejected — parametrized so nobody
+    # relaxes the guard for one type (e.g. Generic, the default fallback for
+    # handlers without an explicit config annotation) without regressing tests.
     mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
     mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
 
-    body = _ephemeral_body(action_id="pull_observations")
+    handler = mock_ephemeral_action_handlers[action_id][0]
+    body = _ephemeral_body(action_id=action_id)
     response = api_client.post("/v1/actions/execute/", json=body)
 
     assert response.status_code == 422
-    assert not mock_pull_observations_action_handler.called
+    assert not handler.called
 
 
 @pytest.mark.asyncio
@@ -712,6 +742,51 @@ async def test_ephemeral_run_allows_auth_action(
     integration = mock_auth_action_handler.call_args.kwargs["integration"]
     auth_config = find_config_for_action(integration.configurations, "auth")
     assert auth_config.data == {"token": _EPHEMERAL_SECRET}
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_auth_handler_write_is_blocked_end_to_end(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_reference_action_handler, mock_pull_observations_action_handler,
+        mock_push_action_handler, mock_generic_action_handler,
+):
+    # Composition test: even if a buggy auth handler tries to write to Gundi
+    # from inside its own body, the write path's guard fires and the response
+    # is sanitized to the standard {action_id, error} shape. This is the
+    # defense-in-depth layer that keeps the "allow auth ephemeral" relaxation
+    # safe — the config-model guard whitelists auth; the write-path guard makes
+    # sure "auth" doesn't accidentally mean "arbitrary I/O against Gundi".
+    from app.services.gundi import send_events_to_gundi, EphemeralWriteBlocked
+
+    call_marker = {"called": False}
+    async def buggy_auth_handler(**kwargs):
+        call_marker["called"] = True
+        await send_events_to_gundi(events=[], integration_id="x")
+        return {"valid_credentials": True}
+
+    handlers = {
+        "list_species": (mock_reference_action_handler, _MockReferenceActionConfiguration, None),
+        "pull_observations": (mock_pull_observations_action_handler, MockPullActionConfiguration, None),
+        "auth": (buggy_auth_handler, _MockAuthActionConfiguration, None),
+        "push_observations": (mock_push_action_handler, MockPushActionConfiguration, None),
+        "generic_lookup": (mock_generic_action_handler, _MockGenericActionConfiguration, None),
+    }
+    mocker.patch("app.services.action_runner.action_handlers", handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post("/v1/actions/execute/", json=_ephemeral_body(action_id="auth"))
+
+    assert response.status_code == 500
+    # Sanitized error shape — no configurations, no request/response bodies,
+    # only the exception type name.
+    assert response.json() == {
+        "detail": {"action_id": "auth", "error": EphemeralWriteBlocked.__name__},
+    }
+    assert call_marker["called"], "buggy auth handler must have been reached"
+    assert not mock_publish_event.called
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1278,6 +1278,41 @@ async def test_saved_integration_generic_action_with_no_config_and_no_overrides_
 
 
 @pytest.mark.asyncio
+async def test_saved_integration_reference_action_error_never_carries_stored_configurations(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_ephemeral_action_handlers, mock_reference_action_handler, integration_v2,
+):
+    # Reference actions run at dropdown-open frequency, so a handler failure is
+    # routine, not exceptional. Like every ephemeral error, it must not carry
+    # the saved integration's configurations (raw auth secrets) into the JSON
+    # error response or the published IntegrationActionFailed event. Same rule
+    # the earthranger and inaturalist forks already ship.
+    mock_reference_action_handler.side_effect = RuntimeError("upstream unreachable")
+    mock_config_manager.get_action_configuration = AsyncMock(return_value=None)
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post(
+        "/v1/actions/execute/",
+        json={"integration_id": str(integration_v2.id), "action_id": "list_species"},
+    )
+
+    assert response.status_code == 500
+    stored_token = find_config_for_action(integration_v2.configurations, "auth").data["token"]
+    assert stored_token not in response.text
+    # _handle_error normalizes a None config_data to {}; the invariant is that
+    # no configuration (and no secret) reaches the response or the event.
+    assert not response.json()["detail"]["config_data"]
+    events = _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+    assert len(events) == 1
+    assert not events[0].payload.config_data
+    assert stored_token not in events[0].json()
+
+
+@pytest.mark.asyncio
 async def test_push_data_acks_message_without_destination_id(
         mocker, pubsub_message_request_headers, run_push_action_pubsub_payload
 ):

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1252,6 +1252,10 @@ async def test_saved_integration_reference_action_with_no_config_and_no_override
     assert response.status_code == 200, response.text
     assert mock_reference_action_handler.called
     assert mock_reference_action_handler.call_args.kwargs["action_config"].tag_name == ""
+    # A stateless action has no row to look up, and a redis miss in
+    # get_action_configuration reloads the integration from the portal, so
+    # looking it up on every dropdown open would be a portal call each time.
+    assert not mock_config_manager.get_action_configuration.called
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -79,7 +79,10 @@ async def test_process_event_action_config_created_from_pubsub(
     )
 
     assert response.status_code == 200
-    assert mock_config_manager.set_action_configuration.called
+    # Created installs the portal row conditionally over what the cache held.
+    assert mock_config_manager._fetch_integration_from_gundi.called
+    assert mock_config_manager.replace_cached_entry.called
+    assert not mock_config_manager.set_action_configuration.called
 
 
 @pytest.mark.asyncio
@@ -495,3 +498,80 @@ async def test_action_config_updated_give_up_stops_when_the_re_read_shows_an_abs
     assert not mock_config_manager.install_action_configuration_if_missing.called
     assert mock_config_manager.replace_cached_entry.await_count == config_events_consumer.UPDATE_ATTEMPTS
     assert any("Gave up" in r.getMessage() for r in caplog.records)
+
+
+def _created_event(integration_id, config):
+    from gundi_core.events import ActionConfigCreated
+
+    return ActionConfigCreated.parse_obj({"payload": {**config.dict(), "integration": integration_id}})
+
+
+@pytest.mark.asyncio
+async def test_action_config_created_installs_the_portal_row_over_the_observed_sentinel(
+        mocker, mock_config_manager, integration_v2,
+):
+    """A delayed Created delivery can arrive after ActionConfigDeleted installed a
+    fresh tombstone; an unconditional SET would resurrect the deleted row
+    permanently. Created now reads the cache, fetches the portal (authoritative,
+    read after everything), and installs the portal row only over exactly what
+    the cache held."""
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    mock_config_manager.read_cached_action_configuration = AsyncMock(return_value=(None, "null:e:3:x"))
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=True)
+    mock_config_manager.install_action_configuration_if_missing = AsyncMock(return_value=True)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_created_event(_created_event(str(integration_v2.id), existing))
+
+    assert not mock_config_manager.set_action_configuration.called, "never an unconditional write"
+    kwargs = mock_config_manager.replace_cached_entry.await_args.kwargs
+    assert kwargs["observed"] == "null:e:3:x"
+    assert kwargs["config"].json() == existing.json(), "the portal row, not the event payload"
+
+
+@pytest.mark.asyncio
+async def test_action_config_created_does_nothing_when_the_portal_no_longer_has_the_row(
+        mocker, mock_config_manager, integration_v2,
+):
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    gone = integration_v2.copy(update={"configurations": []})
+    mock_config_manager.read_cached_action_configuration = AsyncMock(return_value=(None, "null:e:3:x"))
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=gone)
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=True)
+    mock_config_manager.install_action_configuration_if_missing = AsyncMock(return_value=True)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_created_event(_created_event(str(integration_v2.id), existing))
+
+    assert not mock_config_manager.set_action_configuration.called
+    assert not mock_config_manager.replace_cached_entry.called
+    assert not mock_config_manager.install_action_configuration_if_missing.called
+
+
+@pytest.mark.asyncio
+async def test_action_config_created_on_a_cold_cache_installs_only_if_still_missing(
+        mocker, mock_config_manager, integration_v2,
+):
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    mock_config_manager.read_cached_action_configuration = AsyncMock(return_value=(None, None))
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=True)
+    mock_config_manager.install_action_configuration_if_missing = AsyncMock(return_value=True)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_created_event(_created_event(str(integration_v2.id), existing))
+
+    assert not mock_config_manager.set_action_configuration.called
+    assert not mock_config_manager.replace_cached_entry.called
+    installed = mock_config_manager.install_action_configuration_if_missing.await_args.kwargs["config"]
+    assert installed.json() == existing.json()

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -152,6 +152,7 @@ async def test_action_config_updated_reloads_from_the_portal_when_the_cache_reco
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
+    mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=True)
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
     await config_events_consumer.handle_action_config_updated_event(
@@ -162,10 +163,41 @@ async def test_action_config_updated_reloads_from_the_portal_when_the_cache_reco
     (fetched_id,), _ = mock_config_manager._fetch_integration_from_gundi.await_args
     assert str(fetched_id) == str(integration_v2.id)
     assert not mock_config_manager._reload_integration_from_gundi.called, "must not rewrite the whole cache"
-    assert mock_config_manager.set_action_configuration.await_count == 1
-    saved = mock_config_manager.set_action_configuration.await_args.kwargs["config"]
+    # The recovered value replaces the sentinel only while the sentinel is still
+    # there (one server-side step): a plain SET would let the slower of two
+    # concurrent recoveries restore its stale snapshot over the newer one.
+    assert not mock_config_manager.set_action_configuration.called
+    saved = mock_config_manager.replace_absence_sentinel.await_args.kwargs["config"]
     assert saved.id == existing.id
     assert saved.data == {"lookback_days": 2}
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_recovery_that_loses_the_race_applies_its_changes_to_the_newer_value(
+        mocker, mock_config_manager, integration_v2,
+):
+    """Two Updated events for the same action both see the sentinel and fetch.
+    The one whose conditional write finds the sentinel gone must not overwrite
+    the newer value; it re-reads the cache and applies its own changes on top,
+    the way every ordinary Updated does."""
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    newer = existing.copy(update={"data": {**existing.data, "lookback_days": 9, "fresh": True}})
+    mock_config_manager.get_action_configuration = AsyncMock(side_effect=[None, newer])
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=False)
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    assert mock_config_manager.get_action_configuration.await_count == 2
+    saved = mock_config_manager.set_action_configuration.await_args.kwargs["config"]
+    assert saved.data == {"lookback_days": 2}, "this event's changes, applied to the value that won"
+    assert saved.id == newer.id
 
 
 @pytest.mark.asyncio
@@ -180,6 +212,7 @@ async def test_action_config_updated_for_an_action_the_portal_has_no_config_for_
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
+    mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=True)
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
     await config_events_consumer.handle_action_config_updated_event(
@@ -187,3 +220,4 @@ async def test_action_config_updated_for_an_action_the_portal_has_no_config_for_
     )
 
     assert not mock_config_manager.set_action_configuration.called
+    assert not mock_config_manager.replace_absence_sentinel.called

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -270,12 +270,11 @@ async def test_action_config_updated_on_a_cold_cache_installs_the_fetched_row_on
         mocker, mock_config_manager, integration_v2,
 ):
     """Nothing cached for this action (cold cache or an expired sentinel). The
-    ordinary lookup would run the full portal reload, whose unconditional SETs
-    of configured actions can overwrite a tombstone written by a concurrent
-    ActionConfigDeleted after the reload's fetch; the update would then
-    persist that stale config. The recovery instead fetches the row without
-    touching the cache and installs it with SET NX, so anything written
-    meanwhile wins."""
+    ordinary lookup would run the full portal reload, which rewrites the cache
+    from a snapshot and would leave this handler without the "still missing"
+    state its conditional write depends on. The recovery instead fetches the
+    row without touching the cache and installs it with SET NX, so anything
+    written meanwhile (a config or a tombstone) wins."""
     from app.services import config_events_consumer
 
     existing = integration_v2.configurations[0]

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -152,6 +152,7 @@ async def test_action_config_updated_reloads_from_the_portal_when_the_cache_reco
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
+    mock_config_manager.read_absence_sentinel = AsyncMock(return_value="null:gen1")
     mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=True)
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
@@ -163,13 +164,16 @@ async def test_action_config_updated_reloads_from_the_portal_when_the_cache_reco
     (fetched_id,), _ = mock_config_manager._fetch_integration_from_gundi.await_args
     assert str(fetched_id) == str(integration_v2.id)
     assert not mock_config_manager._reload_integration_from_gundi.called, "must not rewrite the whole cache"
-    # The recovered value replaces the sentinel only while the sentinel is still
-    # there (one server-side step): a plain SET would let the slower of two
-    # concurrent recoveries restore its stale snapshot over the newer one.
+    # The recovered value replaces the exact sentinel generation this handler
+    # observed, in one server-side step: a plain SET would let the slower of
+    # two concurrent recoveries restore its stale snapshot over the newer one,
+    # and comparing against a bare "null" would let it overwrite a newer
+    # tombstone from a concurrent ActionConfigDeleted.
     assert not mock_config_manager.set_action_configuration.called
-    saved = mock_config_manager.replace_absence_sentinel.await_args.kwargs["config"]
-    assert saved.id == existing.id
-    assert saved.data == {"lookback_days": 2}
+    kwargs = mock_config_manager.replace_absence_sentinel.await_args.kwargs
+    assert kwargs["observed"] == "null:gen1"
+    assert kwargs["config"].id == existing.id
+    assert kwargs["config"].data == {"lookback_days": 2}
 
 
 @pytest.mark.asyncio
@@ -187,6 +191,7 @@ async def test_action_config_updated_recovery_that_loses_the_race_applies_its_ch
     mock_config_manager.get_action_configuration = AsyncMock(side_effect=[None, newer])
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
+    mock_config_manager.read_absence_sentinel = AsyncMock(return_value="null:gen1")
     mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=False)
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
@@ -212,6 +217,7 @@ async def test_action_config_updated_for_an_action_the_portal_has_no_config_for_
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
+    mock_config_manager.read_absence_sentinel = AsyncMock(return_value="null:gen1")
     mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=True)
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
@@ -221,3 +227,30 @@ async def test_action_config_updated_for_an_action_the_portal_has_no_config_for_
 
     assert not mock_config_manager.set_action_configuration.called
     assert not mock_config_manager.replace_absence_sentinel.called
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_recovery_does_not_undo_a_concurrent_delete(
+        mocker, mock_config_manager, integration_v2,
+):
+    """Recovery observes sentinel generation 1 and fetches the portal. Before
+    it writes, an ActionConfigDeleted lands and writes generation 2. The
+    compare-and-set against generation 1 fails, the re-read still says
+    absent, and the recovery stops: the newer delete wins, and the deleted
+    config is not resurrected as a permanent key."""
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    mock_config_manager.get_action_configuration = AsyncMock(side_effect=[None, None])
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mock_config_manager.read_absence_sentinel = AsyncMock(return_value="null:gen1")
+    mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=False)
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    assert mock_config_manager.replace_absence_sentinel.await_args.kwargs["observed"] == "null:gen1"
+    assert not mock_config_manager.set_action_configuration.called

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -98,7 +98,7 @@ async def test_process_event_action_config_updated_from_pubsub(
 
     assert response.status_code == 200
     assert mock_config_manager.read_cached_action_configuration.called
-    assert mock_config_manager.set_action_configuration.called
+    assert mock_config_manager.replace_cached_entry.called
 
 
 @pytest.mark.asyncio
@@ -152,7 +152,7 @@ async def test_action_config_updated_reloads_from_the_portal_when_the_cache_reco
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
-    mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=True)
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=True)
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
     await config_events_consumer.handle_action_config_updated_event(
@@ -172,7 +172,7 @@ async def test_action_config_updated_reloads_from_the_portal_when_the_cache_reco
     # observe that newer tombstone and compare against it instead.
     assert mock_config_manager.read_cached_action_configuration.await_count == 1
     assert not mock_config_manager.set_action_configuration.called
-    kwargs = mock_config_manager.replace_absence_sentinel.await_args.kwargs
+    kwargs = mock_config_manager.replace_cached_entry.await_args.kwargs
     assert kwargs["observed"] == "null:gen1"
     assert kwargs["config"].id == existing.id
     assert kwargs["config"].data == {"lookback_days": 2}
@@ -190,10 +190,15 @@ async def test_action_config_updated_recovery_that_loses_the_race_applies_its_ch
 
     existing = integration_v2.configurations[0]
     newer = existing.copy(update={"data": {**existing.data, "lookback_days": 9, "fresh": True}})
-    mock_config_manager.read_cached_action_configuration = AsyncMock(side_effect=[(None, "null:gen1"), (newer, None)])
+    newer_raw = newer.json()  # before the handler applies its changes to this object
+    mock_config_manager.read_cached_action_configuration = AsyncMock(
+        side_effect=[(None, "null:gen1"), (newer, newer_raw)],
+    )
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
-    mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=False)
+    # First compare-and-set loses (against the sentinel); the second, against
+    # the newer value's raw JSON, wins.
+    mock_config_manager.replace_cached_entry = AsyncMock(side_effect=[False, True])
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
     await config_events_consumer.handle_action_config_updated_event(
@@ -201,9 +206,11 @@ async def test_action_config_updated_recovery_that_loses_the_race_applies_its_ch
     )
 
     assert mock_config_manager.read_cached_action_configuration.await_count == 2
-    saved = mock_config_manager.set_action_configuration.await_args.kwargs["config"]
-    assert saved.data == {"lookback_days": 2}, "this event's changes, applied to the value that won"
-    assert saved.id == newer.id
+    assert not mock_config_manager.set_action_configuration.called, "never a plain SET: a delete can land in between"
+    kwargs = mock_config_manager.replace_cached_entry.await_args.kwargs
+    assert kwargs["observed"] == newer_raw, "compare-and-set against exactly the value re-read"
+    assert kwargs["config"].data == {"lookback_days": 2}, "this event's changes, applied to the value that won"
+    assert kwargs["config"].id == newer.id
 
 
 @pytest.mark.asyncio
@@ -218,7 +225,7 @@ async def test_action_config_updated_for_an_action_the_portal_has_no_config_for_
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
-    mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=True)
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=True)
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
     await config_events_consumer.handle_action_config_updated_event(
@@ -226,7 +233,7 @@ async def test_action_config_updated_for_an_action_the_portal_has_no_config_for_
     )
 
     assert not mock_config_manager.set_action_configuration.called
-    assert not mock_config_manager.replace_absence_sentinel.called
+    assert not mock_config_manager.replace_cached_entry.called
 
 
 @pytest.mark.asyncio
@@ -246,14 +253,15 @@ async def test_action_config_updated_recovery_does_not_undo_a_concurrent_delete(
     )
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
-    mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=False)
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=False)
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
     await config_events_consumer.handle_action_config_updated_event(
         _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
     )
 
-    assert mock_config_manager.replace_absence_sentinel.await_args.kwargs["observed"] == "null:gen1"
+    assert mock_config_manager.replace_cached_entry.await_args.kwargs["observed"] == "null:gen1"
+    assert mock_config_manager._fetch_integration_from_gundi.await_count == 1, "a tombstone on the re-read ends the recovery"
     assert not mock_config_manager.set_action_configuration.called
 
 
@@ -275,7 +283,7 @@ async def test_action_config_updated_on_a_cold_cache_installs_the_fetched_row_on
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.install_action_configuration_if_missing = AsyncMock(return_value=True)
-    mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=True)
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=True)
     mock_config_manager.set_action_configuration = AsyncMock()
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
@@ -284,7 +292,7 @@ async def test_action_config_updated_on_a_cold_cache_installs_the_fetched_row_on
     )
 
     assert not mock_config_manager._reload_integration_from_gundi.called
-    assert not mock_config_manager.replace_absence_sentinel.called
+    assert not mock_config_manager.replace_cached_entry.called
     assert not mock_config_manager.set_action_configuration.called
     installed = mock_config_manager.install_action_configuration_if_missing.await_args.kwargs["config"]
     assert installed.id == existing.id and installed.data == {"lookback_days": 2}
@@ -309,3 +317,74 @@ async def test_action_config_updated_on_a_cold_cache_yields_to_a_delete_that_lan
 
     assert mock_config_manager.read_cached_action_configuration.await_count == 2
     assert not mock_config_manager.set_action_configuration.called
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_on_a_cached_config_is_a_compare_and_set(
+        mocker, mock_config_manager, integration_v2,
+):
+    """The ordinary path is read-modify-write too. A plain SET after the read
+    would overwrite a tombstone (or a newer value) another concurrent delivery
+    wrote in between; the write compares against the raw value read."""
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    mock_config_manager.read_cached_action_configuration = AsyncMock(return_value=(existing.copy(), existing.json()))
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=True)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    assert not mock_config_manager.set_action_configuration.called
+    kwargs = mock_config_manager.replace_cached_entry.await_args.kwargs
+    assert kwargs["observed"] == existing.json()
+    assert kwargs["config"].data == {"lookback_days": 2}
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_retries_a_bounded_number_of_times_then_gives_up(
+        mocker, mock_config_manager, integration_v2, caplog,
+):
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    mock_config_manager.read_cached_action_configuration = AsyncMock(return_value=(existing.copy(), existing.json()))
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=False)  # always beaten
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    assert mock_config_manager.replace_cached_entry.await_count == config_events_consumer.UPDATE_ATTEMPTS
+    assert not mock_config_manager.set_action_configuration.called
+    assert any("Gave up" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_warning_on_a_lost_race_does_not_claim_a_delete(
+        mocker, mock_config_manager, integration_v2, caplog,
+):
+    """(None, None) on the re-read can be an expired sentinel or a cold-cache
+    winner that vanished, not only a delete; the operator must not be sent
+    looking for a delete event that never happened."""
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    mock_config_manager.read_cached_action_configuration = AsyncMock(side_effect=[(None, None), (None, None)])
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.install_action_configuration_if_missing = AsyncMock(return_value=False)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    assert not mock_config_manager.set_action_configuration.called
+    messages = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert messages and all("deleted" not in m for m in messages)

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -97,7 +97,7 @@ async def test_process_event_action_config_updated_from_pubsub(
     )
 
     assert response.status_code == 200
-    assert mock_config_manager.get_action_configuration.called
+    assert mock_config_manager.get_action_configuration_and_sentinel.called
     assert mock_config_manager.set_action_configuration.called
 
 
@@ -148,11 +148,10 @@ async def test_action_config_updated_reloads_from_the_portal_when_the_cache_reco
     from app.services import config_events_consumer
 
     existing = integration_v2.configurations[0]
-    mock_config_manager.get_action_configuration = AsyncMock(return_value=None)
+    mock_config_manager.get_action_configuration_and_sentinel = AsyncMock(return_value=(None, "null:gen1"))
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
-    mock_config_manager.read_absence_sentinel = AsyncMock(return_value="null:gen1")
     mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=True)
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
@@ -165,10 +164,13 @@ async def test_action_config_updated_reloads_from_the_portal_when_the_cache_reco
     assert str(fetched_id) == str(integration_v2.id)
     assert not mock_config_manager._reload_integration_from_gundi.called, "must not rewrite the whole cache"
     # The recovered value replaces the exact sentinel generation this handler
-    # observed, in one server-side step: a plain SET would let the slower of
-    # two concurrent recoveries restore its stale snapshot over the newer one,
-    # and comparing against a bare "null" would let it overwrite a newer
-    # tombstone from a concurrent ActionConfigDeleted.
+    # observed on the read that established the absence, in one server-side
+    # step: a plain SET would let the slower of two concurrent recoveries
+    # restore its stale snapshot over the newer one, comparing against a bare
+    # "null" would let it overwrite a newer tombstone from a concurrent
+    # ActionConfigDeleted, and a second read to pick up the generation could
+    # observe that newer tombstone and compare against it instead.
+    assert mock_config_manager.get_action_configuration_and_sentinel.await_count == 1
     assert not mock_config_manager.set_action_configuration.called
     kwargs = mock_config_manager.replace_absence_sentinel.await_args.kwargs
     assert kwargs["observed"] == "null:gen1"
@@ -188,10 +190,9 @@ async def test_action_config_updated_recovery_that_loses_the_race_applies_its_ch
 
     existing = integration_v2.configurations[0]
     newer = existing.copy(update={"data": {**existing.data, "lookback_days": 9, "fresh": True}})
-    mock_config_manager.get_action_configuration = AsyncMock(side_effect=[None, newer])
+    mock_config_manager.get_action_configuration_and_sentinel = AsyncMock(side_effect=[(None, "null:gen1"), (newer, None)])
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
-    mock_config_manager.read_absence_sentinel = AsyncMock(return_value="null:gen1")
     mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=False)
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
@@ -199,7 +200,7 @@ async def test_action_config_updated_recovery_that_loses_the_race_applies_its_ch
         _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
     )
 
-    assert mock_config_manager.get_action_configuration.await_count == 2
+    assert mock_config_manager.get_action_configuration_and_sentinel.await_count == 2
     saved = mock_config_manager.set_action_configuration.await_args.kwargs["config"]
     assert saved.data == {"lookback_days": 2}, "this event's changes, applied to the value that won"
     assert saved.id == newer.id
@@ -213,11 +214,10 @@ async def test_action_config_updated_for_an_action_the_portal_has_no_config_for_
 
     configured = {c.action.value for c in integration_v2.configurations}
     unconfigured = next(a.value for a in integration_v2.type.actions if a.value not in configured)
-    mock_config_manager.get_action_configuration = AsyncMock(return_value=None)
+    mock_config_manager.get_action_configuration_and_sentinel = AsyncMock(return_value=(None, "null:gen1"))
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
-    mock_config_manager.read_absence_sentinel = AsyncMock(return_value="null:gen1")
     mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=True)
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
@@ -241,10 +241,11 @@ async def test_action_config_updated_recovery_does_not_undo_a_concurrent_delete(
     from app.services import config_events_consumer
 
     existing = integration_v2.configurations[0]
-    mock_config_manager.get_action_configuration = AsyncMock(side_effect=[None, None])
+    mock_config_manager.get_action_configuration_and_sentinel = AsyncMock(
+        side_effect=[(None, "null:gen1"), (None, "null:gen2")],
+    )
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
-    mock_config_manager.read_absence_sentinel = AsyncMock(return_value="null:gen1")
     mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=False)
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -351,8 +351,21 @@ async def test_action_config_updated_retries_a_bounded_number_of_times_then_give
     from app.services import config_events_consumer
 
     existing = integration_v2.configurations[0]
-    mock_config_manager.read_cached_action_configuration = AsyncMock(return_value=(existing.copy(), existing.json()))
-    mock_config_manager.replace_cached_entry = AsyncMock(return_value=False)  # always beaten
+    """After the attempts, reconcile from the portal rather than write blind or
+    delete: a DEL could erase a tombstone a concurrent delete just wrote, and
+    a later reload whose fetch predates that delete would then resurrect the
+    config. The portal row (authoritative, read after everything) is installed
+    with one more compare-and-set against exactly what the cache holds now."""
+    portal_row = integration_v2.configurations[0]
+    latest_raw = '{"id": "latest"}'
+    mock_config_manager.read_cached_action_configuration = AsyncMock(
+        side_effect=[(existing.copy(), existing.json())] * config_events_consumer.UPDATE_ATTEMPTS
+        + [(existing.copy(), latest_raw)],
+    )
+    mock_config_manager.replace_cached_entry = AsyncMock(
+        side_effect=[False] * config_events_consumer.UPDATE_ATTEMPTS + [True],
+    )
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
     mock_config_manager.invalidate_action_configuration = AsyncMock()
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
@@ -361,15 +374,38 @@ async def test_action_config_updated_retries_a_bounded_number_of_times_then_give
         _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
     )
 
-    assert mock_config_manager.replace_cached_entry.await_count == config_events_consumer.UPDATE_ATTEMPTS
+    assert mock_config_manager.replace_cached_entry.await_count == config_events_consumer.UPDATE_ATTEMPTS + 1
     assert not mock_config_manager.set_action_configuration.called
-    # Giving up must not leave a stale permanent config behind an acked event:
-    # drop the key so the next lookup rebuilds it from the portal, the source
-    # of truth for whatever won the race.
-    mock_config_manager.invalidate_action_configuration.assert_awaited_once()
-    (inv_integration, inv_action), _ = mock_config_manager.invalidate_action_configuration.await_args
-    assert (str(inv_integration), inv_action) == (str(integration_v2.id), existing.action.value)
-    assert any("Gave up" in r.getMessage() and "rebuil" in r.getMessage() for r in caplog.records)
+    assert not mock_config_manager.invalidate_action_configuration.called, "never delete an unobserved value"
+    final = mock_config_manager.replace_cached_entry.await_args.kwargs
+    assert final["observed"] == latest_raw
+    assert final["config"].json() == portal_row.json(), "the portal row as fetched, not this event's changes"
+    assert any("Gave up" in r.getMessage() and "portal" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_give_up_records_an_absence_when_the_portal_has_no_row(
+        mocker, mock_config_manager, integration_v2,
+):
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    gone = integration_v2.copy(update={"configurations": []})
+    mock_config_manager.read_cached_action_configuration = AsyncMock(return_value=(existing.copy(), existing.json()))
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=False)
+    mock_config_manager.replace_cached_entry_with_absence = AsyncMock(return_value=True)
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=gone)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mock_config_manager.invalidate_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    mock_config_manager.replace_cached_entry_with_absence.assert_awaited_once()
+    assert mock_config_manager.replace_cached_entry_with_absence.await_args.kwargs["observed"] == existing.json()
+    assert not mock_config_manager.invalidate_action_configuration.called
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -463,3 +463,36 @@ async def test_action_config_updated_on_a_cached_config_stops_when_a_delete_wins
     assert mock_config_manager.replace_cached_entry.await_count == 1
     assert not mock_config_manager.install_action_configuration_if_missing.called
     assert not mock_config_manager.set_action_configuration.called
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_give_up_stops_when_the_re_read_shows_an_absence(
+        mocker, mock_config_manager, integration_v2, caplog,
+):
+    """The same rule as inside the loop applies after it: if the last attempt
+    lost to a delete, the reconciliation's re-read shows that fresh tombstone,
+    and fetching a (possibly stale) portal row to install over it would
+    resurrect the deleted configuration. No cached configuration on the
+    re-read means stop, without fetching or writing."""
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    mock_config_manager.read_cached_action_configuration = AsyncMock(
+        side_effect=[(existing.copy(), existing.json())] * config_events_consumer.UPDATE_ATTEMPTS + [(None, "null:e:9:x")],
+    )
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=False)
+    mock_config_manager.replace_cached_entry_with_absence = AsyncMock(return_value=True)
+    mock_config_manager.install_action_configuration_if_missing = AsyncMock(return_value=True)
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    assert not mock_config_manager._fetch_integration_from_gundi.called, "never fetch over a fresh tombstone"
+    assert not mock_config_manager.replace_cached_entry_with_absence.called
+    assert not mock_config_manager.install_action_configuration_if_missing.called
+    assert mock_config_manager.replace_cached_entry.await_count == config_events_consumer.UPDATE_ATTEMPTS
+    assert any("Gave up" in r.getMessage() for r in caplog.records)

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -354,6 +354,7 @@ async def test_action_config_updated_retries_a_bounded_number_of_times_then_give
     mock_config_manager.read_cached_action_configuration = AsyncMock(return_value=(existing.copy(), existing.json()))
     mock_config_manager.replace_cached_entry = AsyncMock(return_value=False)  # always beaten
     mock_config_manager.set_action_configuration = AsyncMock()
+    mock_config_manager.invalidate_action_configuration = AsyncMock()
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
 
     await config_events_consumer.handle_action_config_updated_event(
@@ -362,7 +363,13 @@ async def test_action_config_updated_retries_a_bounded_number_of_times_then_give
 
     assert mock_config_manager.replace_cached_entry.await_count == config_events_consumer.UPDATE_ATTEMPTS
     assert not mock_config_manager.set_action_configuration.called
-    assert any("Gave up" in r.getMessage() for r in caplog.records)
+    # Giving up must not leave a stale permanent config behind an acked event:
+    # drop the key so the next lookup rebuilds it from the portal, the source
+    # of truth for whatever won the race.
+    mock_config_manager.invalidate_action_configuration.assert_awaited_once()
+    (inv_integration, inv_action), _ = mock_config_manager.invalidate_action_configuration.await_args
+    assert (str(inv_integration), inv_action) == (str(integration_v2.id), existing.action.value)
+    assert any("Gave up" in r.getMessage() and "rebuil" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -388,3 +395,35 @@ async def test_action_config_updated_warning_on_a_lost_race_does_not_claim_a_del
     assert not mock_config_manager.set_action_configuration.called
     messages = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
     assert messages and all("deleted" not in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_on_a_cached_config_stops_when_a_delete_wins_the_race(
+        mocker, mock_config_manager, integration_v2, caplog,
+):
+    """An ordinary update reads a config, loses its compare-and-set to a
+    concurrent ActionConfigDeleted, and re-reads a tombstone. That absence
+    must end the update: treating it as an initial absence would fetch the
+    portal and replace that exact tombstone with the fetched config, the
+    delete race this recovery exists to prevent. Only an absence seen on the
+    first read may trigger a recovery."""
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    mock_config_manager.read_cached_action_configuration = AsyncMock(
+        side_effect=[(existing.copy(), existing.json()), (None, "null:gen2")],
+    )
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=False)
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.install_action_configuration_if_missing = AsyncMock(return_value=True)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    assert not mock_config_manager._fetch_integration_from_gundi.called, "no recovery after a failed write"
+    assert mock_config_manager.replace_cached_entry.await_count == 1
+    assert not mock_config_manager.install_action_configuration_if_missing.called
+    assert not mock_config_manager.set_action_configuration.called

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -116,3 +118,63 @@ async def test_process_event_action_config_deleted_from_pubsub(
     assert response.status_code == 200
     assert mock_config_manager.delete_action_configuration.called
 
+
+
+def _updated_event(integration_id, action_id, changes):
+    from gundi_core.events import ActionConfigUpdated
+
+    return ActionConfigUpdated.parse_obj({"payload": {
+        "id": "81344345-f691-4230-8fab-6d2464729085",
+        "alt_id": action_id,
+        "changes": changes,
+        "integration_id": integration_id,
+    }})
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_reloads_from_the_portal_when_the_cache_records_absence(
+        mocker, mock_config_manager, integration_v2,
+):
+    """get_action_configuration answers None from the absence sentinel without
+    touching the portal. An Updated event can still arrive for that action
+    (its Created was lost or delivered out of order): applying the changes
+    to None raised AttributeError, which process_config_event logged and
+    acked, so the change was silently dropped and the sentinel stayed."""
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    mock_config_manager.get_action_configuration = AsyncMock(return_value=None)
+    mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    # The payload parses integration_id as a UUID; the key builders stringify it.
+    (reloaded_id,), _ = mock_config_manager._reload_integration_from_gundi.await_args
+    assert str(reloaded_id) == str(integration_v2.id)
+    saved = mock_config_manager.set_action_configuration.await_args.kwargs["config"]
+    assert saved.id == existing.id
+    assert saved.data == {"lookback_days": 2}
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_for_an_action_the_portal_has_no_config_for_is_a_no_op(
+        mocker, mock_config_manager, integration_v2,
+):
+    from app.services import config_events_consumer
+
+    configured = {c.action.value for c in integration_v2.configurations}
+    unconfigured = next(a.value for a in integration_v2.type.actions if a.value not in configured)
+    mock_config_manager.get_action_configuration = AsyncMock(return_value=None)
+    mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), unconfigured, {"data": {"lookback_days": 2}})
+    )
+
+    assert not mock_config_manager.set_action_configuration.called

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -139,11 +139,17 @@ async def test_action_config_updated_reloads_from_the_portal_when_the_cache_reco
     touching the portal. An Updated event can still arrive for that action
     (its Created was lost or delivered out of order): applying the changes
     to None raised AttributeError, which process_config_event logged and
-    acked, so the change was silently dropped and the sentinel stayed."""
+    acked, so the change was silently dropped and the sentinel stayed.
+
+    The recovery fetches the portal row without rewriting the cache: a full
+    reload SETs every action's config from one snapshot and would overwrite a
+    newer value another event cached while the fetch was in flight. Only this
+    action's key is written, by the handler's own final set."""
     from app.services import config_events_consumer
 
     existing = integration_v2.configurations[0]
     mock_config_manager.get_action_configuration = AsyncMock(return_value=None)
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
@@ -153,8 +159,10 @@ async def test_action_config_updated_reloads_from_the_portal_when_the_cache_reco
     )
 
     # The payload parses integration_id as a UUID; the key builders stringify it.
-    (reloaded_id,), _ = mock_config_manager._reload_integration_from_gundi.await_args
-    assert str(reloaded_id) == str(integration_v2.id)
+    (fetched_id,), _ = mock_config_manager._fetch_integration_from_gundi.await_args
+    assert str(fetched_id) == str(integration_v2.id)
+    assert not mock_config_manager._reload_integration_from_gundi.called, "must not rewrite the whole cache"
+    assert mock_config_manager.set_action_configuration.await_count == 1
     saved = mock_config_manager.set_action_configuration.await_args.kwargs["config"]
     assert saved.id == existing.id
     assert saved.data == {"lookback_days": 2}
@@ -169,6 +177,7 @@ async def test_action_config_updated_for_an_action_the_portal_has_no_config_for_
     configured = {c.action.value for c in integration_v2.configurations}
     unconfigured = next(a.value for a in integration_v2.type.actions if a.value not in configured)
     mock_config_manager.get_action_configuration = AsyncMock(return_value=None)
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
     mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -575,3 +575,58 @@ async def test_action_config_created_on_a_cold_cache_installs_only_if_still_miss
     assert not mock_config_manager.replace_cached_entry.called
     installed = mock_config_manager.install_action_configuration_if_missing.await_args.kwargs["config"]
     assert installed.json() == existing.json()
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_reconciliation_keeps_trying_against_the_newest_token(
+        mocker, mock_config_manager, integration_v2, caplog,
+):
+    """A competing write that beats the reconciling compare-and-set is only
+    later in cache time, not necessarily newer portal state: a delayed older
+    Updated can land after the reconciliation fetched the final portal row.
+    Acknowledging the event there would leave that stale value permanent with
+    nothing to repair it. The reconciliation re-reads and retries against the
+    newest token, bounded, and reports at error level if it still loses."""
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    n = config_events_consumer.UPDATE_ATTEMPTS
+    mock_config_manager.read_cached_action_configuration = AsyncMock(
+        side_effect=[(existing.copy(), existing.json())] * n + [(existing.copy(), '{"id": "t1"}'), (existing.copy(), '{"id": "t2"}')],
+    )
+    mock_config_manager.replace_cached_entry = AsyncMock(side_effect=[False] * n + [False, True])
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    assert mock_config_manager.replace_cached_entry.await_count == n + 2
+    assert [c.kwargs["observed"] for c in mock_config_manager.replace_cached_entry.await_args_list[n:]] == ['{"id": "t1"}', '{"id": "t2"}']
+    assert mock_config_manager._fetch_integration_from_gundi.await_count == 1, "the portal row is final; fetch it once"
+    assert not any(r.levelname == "ERROR" for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_reconciliation_that_keeps_losing_is_reported_as_an_error(
+        mocker, mock_config_manager, integration_v2, caplog,
+):
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    mock_config_manager.read_cached_action_configuration = AsyncMock(return_value=(existing.copy(), existing.json()))
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=False)
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    n = config_events_consumer.UPDATE_ATTEMPTS
+    assert mock_config_manager.replace_cached_entry.await_count == 2 * n, "the update's attempts, then the reconciliation's"
+    errors = [r.getMessage() for r in caplog.records if r.levelname == "ERROR"]
+    assert errors and "may be stale" in errors[-1]

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -97,7 +97,7 @@ async def test_process_event_action_config_updated_from_pubsub(
     )
 
     assert response.status_code == 200
-    assert mock_config_manager.get_action_configuration_and_sentinel.called
+    assert mock_config_manager.read_cached_action_configuration.called
     assert mock_config_manager.set_action_configuration.called
 
 
@@ -148,7 +148,7 @@ async def test_action_config_updated_reloads_from_the_portal_when_the_cache_reco
     from app.services import config_events_consumer
 
     existing = integration_v2.configurations[0]
-    mock_config_manager.get_action_configuration_and_sentinel = AsyncMock(return_value=(None, "null:gen1"))
+    mock_config_manager.read_cached_action_configuration = AsyncMock(return_value=(None, "null:gen1"))
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
@@ -170,7 +170,7 @@ async def test_action_config_updated_reloads_from_the_portal_when_the_cache_reco
     # "null" would let it overwrite a newer tombstone from a concurrent
     # ActionConfigDeleted, and a second read to pick up the generation could
     # observe that newer tombstone and compare against it instead.
-    assert mock_config_manager.get_action_configuration_and_sentinel.await_count == 1
+    assert mock_config_manager.read_cached_action_configuration.await_count == 1
     assert not mock_config_manager.set_action_configuration.called
     kwargs = mock_config_manager.replace_absence_sentinel.await_args.kwargs
     assert kwargs["observed"] == "null:gen1"
@@ -190,7 +190,7 @@ async def test_action_config_updated_recovery_that_loses_the_race_applies_its_ch
 
     existing = integration_v2.configurations[0]
     newer = existing.copy(update={"data": {**existing.data, "lookback_days": 9, "fresh": True}})
-    mock_config_manager.get_action_configuration_and_sentinel = AsyncMock(side_effect=[(None, "null:gen1"), (newer, None)])
+    mock_config_manager.read_cached_action_configuration = AsyncMock(side_effect=[(None, "null:gen1"), (newer, None)])
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
     mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=False)
@@ -200,7 +200,7 @@ async def test_action_config_updated_recovery_that_loses_the_race_applies_its_ch
         _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
     )
 
-    assert mock_config_manager.get_action_configuration_and_sentinel.await_count == 2
+    assert mock_config_manager.read_cached_action_configuration.await_count == 2
     saved = mock_config_manager.set_action_configuration.await_args.kwargs["config"]
     assert saved.data == {"lookback_days": 2}, "this event's changes, applied to the value that won"
     assert saved.id == newer.id
@@ -214,7 +214,7 @@ async def test_action_config_updated_for_an_action_the_portal_has_no_config_for_
 
     configured = {c.action.value for c in integration_v2.configurations}
     unconfigured = next(a.value for a in integration_v2.type.actions if a.value not in configured)
-    mock_config_manager.get_action_configuration_and_sentinel = AsyncMock(return_value=(None, "null:gen1"))
+    mock_config_manager.read_cached_action_configuration = AsyncMock(return_value=(None, "null:gen1"))
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
     mock_config_manager.set_action_configuration = AsyncMock()
@@ -241,7 +241,7 @@ async def test_action_config_updated_recovery_does_not_undo_a_concurrent_delete(
     from app.services import config_events_consumer
 
     existing = integration_v2.configurations[0]
-    mock_config_manager.get_action_configuration_and_sentinel = AsyncMock(
+    mock_config_manager.read_cached_action_configuration = AsyncMock(
         side_effect=[(None, "null:gen1"), (None, "null:gen2")],
     )
     mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
@@ -254,4 +254,58 @@ async def test_action_config_updated_recovery_does_not_undo_a_concurrent_delete(
     )
 
     assert mock_config_manager.replace_absence_sentinel.await_args.kwargs["observed"] == "null:gen1"
+    assert not mock_config_manager.set_action_configuration.called
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_on_a_cold_cache_installs_the_fetched_row_only_if_still_missing(
+        mocker, mock_config_manager, integration_v2,
+):
+    """Nothing cached for this action (cold cache or an expired sentinel). The
+    ordinary lookup would run the full portal reload, whose unconditional SETs
+    of configured actions can overwrite a tombstone written by a concurrent
+    ActionConfigDeleted after the reload's fetch; the update would then
+    persist that stale config. The recovery instead fetches the row without
+    touching the cache and installs it with SET NX, so anything written
+    meanwhile wins."""
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    mock_config_manager.read_cached_action_configuration = AsyncMock(return_value=(None, None))
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager._reload_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.install_action_configuration_if_missing = AsyncMock(return_value=True)
+    mock_config_manager.replace_absence_sentinel = AsyncMock(return_value=True)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    assert not mock_config_manager._reload_integration_from_gundi.called
+    assert not mock_config_manager.replace_absence_sentinel.called
+    assert not mock_config_manager.set_action_configuration.called
+    installed = mock_config_manager.install_action_configuration_if_missing.await_args.kwargs["config"]
+    assert installed.id == existing.id and installed.data == {"lookback_days": 2}
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_on_a_cold_cache_yields_to_a_delete_that_landed_meanwhile(
+        mocker, mock_config_manager, integration_v2,
+):
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    mock_config_manager.read_cached_action_configuration = AsyncMock(side_effect=[(None, None), (None, "null:gen2")])
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.install_action_configuration_if_missing = AsyncMock(return_value=False)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    assert mock_config_manager.read_cached_action_configuration.await_count == 2
     assert not mock_config_manager.set_action_configuration.called

--- a/app/services/tests/test_config_events_consumer.py
+++ b/app/services/tests/test_config_events_consumer.py
@@ -605,7 +605,9 @@ async def test_action_config_updated_reconciliation_keeps_trying_against_the_new
 
     assert mock_config_manager.replace_cached_entry.await_count == n + 2
     assert [c.kwargs["observed"] for c in mock_config_manager.replace_cached_entry.await_args_list[n:]] == ['{"id": "t1"}', '{"id": "t2"}']
-    assert mock_config_manager._fetch_integration_from_gundi.await_count == 1, "the portal row is final; fetch it once"
+    # A lost compare-and-set means the portal may have moved too (the write
+    # that won came from a newer event): re-fetch on every retry.
+    assert mock_config_manager._fetch_integration_from_gundi.await_count == 2
     assert not any(r.levelname == "ERROR" for r in caplog.records)
 
 
@@ -630,3 +632,87 @@ async def test_action_config_updated_reconciliation_that_keeps_losing_is_reporte
     assert mock_config_manager.replace_cached_entry.await_count == 2 * n, "the update's attempts, then the reconciliation's"
     errors = [r.getMessage() for r in caplog.records if r.levelname == "ERROR"]
     assert errors and "may be stale" in errors[-1]
+
+
+@pytest.mark.asyncio
+async def test_action_config_updated_reconciliation_refetches_the_portal_on_every_retry(
+        mocker, mock_config_manager, integration_v2,
+):
+    """Reusing the first portal snapshot across retries would let the loop write
+    stale row A over row B after B's Created/Updated landed in both the portal
+    and the cache and made the first compare-and-set lose."""
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    row_a = existing
+    row_b = existing.copy(update={"data": {**existing.data, "lookback_days": 42}})
+    portal_a = integration_v2
+    portal_b = integration_v2.copy(update={"configurations": [row_b] + list(integration_v2.configurations[1:])})
+    n = config_events_consumer.UPDATE_ATTEMPTS
+    mock_config_manager.read_cached_action_configuration = AsyncMock(
+        side_effect=[(existing.copy(), existing.json())] * n + [(existing.copy(), "token-1"), (row_b.copy(), row_b.json())],
+    )
+    mock_config_manager.replace_cached_entry = AsyncMock(side_effect=[False] * n + [False, True])
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(side_effect=[portal_a, portal_b])
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_updated_event(
+        _updated_event(str(integration_v2.id), existing.action.value, {"data": {"lookback_days": 2}})
+    )
+
+    final = mock_config_manager.replace_cached_entry.await_args.kwargs
+    assert final["observed"] == row_b.json()
+    assert final["config"].json() == row_b.json(), "the portal as re-read on the retry, not the first snapshot"
+
+
+@pytest.mark.asyncio
+async def test_action_config_created_that_loses_its_write_reconciles_when_the_winner_is_a_config(
+        mocker, mock_config_manager, integration_v2,
+):
+    """A failed Created compare-and-set is not proof that the winner is newer
+    portal state: a delayed older Updated can land after this handler's read.
+    Re-read the winner; if it is a configuration, run the same bounded fresh-
+    portal reconciliation the Updated handler uses."""
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    stale = existing.copy(update={"data": {**existing.data, "lookback_days": 1}})
+    mock_config_manager.read_cached_action_configuration = AsyncMock(
+        side_effect=[(None, "null:e:1:x"), (stale.copy(), stale.json())],
+    )
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.replace_cached_entry = AsyncMock(side_effect=[False, True])
+    mock_config_manager.install_action_configuration_if_missing = AsyncMock(return_value=True)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_created_event(_created_event(str(integration_v2.id), existing))
+
+    assert mock_config_manager.replace_cached_entry.await_count == 2
+    second = mock_config_manager.replace_cached_entry.await_args_list[1].kwargs
+    assert second["observed"] == stale.json()
+    assert second["config"].json() == existing.json(), "the portal row over the stale winner"
+
+
+@pytest.mark.asyncio
+async def test_action_config_created_that_loses_its_write_stops_when_the_winner_is_a_tombstone(
+        mocker, mock_config_manager, integration_v2,
+):
+    from app.services import config_events_consumer
+
+    existing = integration_v2.configurations[0]
+    mock_config_manager.read_cached_action_configuration = AsyncMock(
+        side_effect=[(None, "null:e:1:x"), (None, "null:e:2:y")],
+    )
+    mock_config_manager._fetch_integration_from_gundi = AsyncMock(return_value=integration_v2)
+    mock_config_manager.replace_cached_entry = AsyncMock(return_value=False)
+    mock_config_manager.install_action_configuration_if_missing = AsyncMock(return_value=True)
+    mock_config_manager.set_action_configuration = AsyncMock()
+    mocker.patch.object(config_events_consumer, "config_manager", mock_config_manager)
+
+    await config_events_consumer.handle_action_config_created_event(_created_event(str(integration_v2.id), existing))
+
+    assert mock_config_manager.replace_cached_entry.await_count == 1
+    assert mock_config_manager._fetch_integration_from_gundi.await_count == 1, "no second fetch over a fresh tombstone"
+    assert not mock_config_manager.install_action_configuration_if_missing.called

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -555,12 +555,20 @@ async def test_reload_writes_absence_sentinels_for_unconfigured_actions(
     tombstones = {c.args[2]: c.args for c in evals if c.args[0] is cm._WRITE_TOMBSTONE_SCRIPT}
     snapshots = {c.args[2]: c.args for c in evals if c.args[0] is cm._WRITE_SNAPSHOT_CONFIG_SCRIPT}
     for action_id in unconfigured:
-        _, numkeys, _, counter, epoch_key, _hex, _ttl, mode, _, _ = tombstones[f"integrationconfig.{integration_id}.{action_id}"]
+        _, numkeys, _, counter, epoch_key, _hex, _ttl, mode, _, _, _ = tombstones[f"integrationconfig.{integration_id}.{action_id}"]
         assert (numkeys, counter, epoch_key, mode) == (3, cm._GENERATION_KEY, cm._GENERATION_EPOCH_KEY, "missing"), \
             "a Redis-issued generation, and never replacing an existing key"
     for action_id in configured:
         # Written through the snapshot script, which preserves a newer tombstone.
         assert not snapshots[f"integrationconfig.{integration_id}.{action_id}"][3].startswith("null")
+
+
+@pytest.fixture
+def generations_on(mocker):
+    """Generated tombstones are opt-in until every replica runs a tolerant
+    reader (see CONFIG_CACHE_SENTINEL_GENERATIONS); these tests exercise them."""
+    from app.services import config_manager as cm
+    mocker.patch.object(cm.settings, "CONFIG_CACHE_SENTINEL_GENERATIONS", True)
 
 
 class _FakeRedis:
@@ -604,12 +612,15 @@ class _FakeRedis:
             return next_generation(counter, epoch_key, args[0])
         if script is cm._WRITE_TOMBSTONE_SCRIPT:
             counter, epoch_key = keys[1], keys[2]
-            hex_part, ttl, mode, expected, candidate_epoch = args
+            hex_part, ttl, mode, expected, candidate_epoch, generated = args
             if mode == "missing" and current is not None:
                 return 0
             if mode == "equals" and current != expected:
                 return 0
-            self.data[key] = f"null:{next_generation(counter, epoch_key, candidate_epoch)}:{hex_part}"
+            if generated == "1":
+                self.data[key] = f"null:{next_generation(counter, epoch_key, candidate_epoch)}:{hex_part}"
+            else:
+                self.data[key] = "null"  # the format every deployed replica can read
             return 1
         if script is cm._WRITE_SNAPSHOT_CONFIG_SCRIPT:
             value, fetch_token, ttl = args
@@ -688,7 +699,7 @@ async def test_deleting_an_action_configuration_records_its_absence(
     await config_manager.delete_action_configuration(integration_id, "pull_events")
 
     from app.services import config_manager as cm
-    (script, numkeys, key, counter, epoch_key, _hex, ttl, mode, _, _), _ = mock_redis_empty.Redis.return_value.eval.call_args
+    (script, numkeys, key, counter, epoch_key, _hex, ttl, mode, _, _, _), _ = mock_redis_empty.Redis.return_value.eval.call_args
     assert script is cm._WRITE_TOMBSTONE_SCRIPT
     assert (numkeys, key, counter, epoch_key, ttl, mode) == (
         3, f"integrationconfig.{integration_id}.pull_events", cm._GENERATION_KEY, cm._GENERATION_EPOCH_KEY,
@@ -699,9 +710,7 @@ async def test_deleting_an_action_configuration_records_its_absence(
 
 
 @pytest.mark.asyncio
-async def test_every_absence_sentinel_write_has_its_own_generation(
-        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
-):
+async def test_every_absence_sentinel_write_has_its_own_generation(generations_on, mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,):
     """A recovery reads a sentinel, fetches the portal, then replaces the
     sentinel if it is still there. If a concurrent ActionConfigDeleted wrote a
     new sentinel in between and both read "null", the recovery could not tell
@@ -996,7 +1005,7 @@ async def test_a_legacy_permanent_webhook_entry_gets_the_default_ttl_on_its_next
 
 
 @pytest.mark.asyncio
-async def test_absence_sentinels_carry_a_redis_issued_generation(integration_v2):
+async def test_absence_sentinels_carry_a_redis_issued_generation(generations_on, integration_v2):
     """The reload compares a tombstone's generation with the one it took before
     its portal fetch, to tell a tombstone written while the fetch was in flight
     (preserve it) from one that predates the fetch (the portal is newer;
@@ -1024,7 +1033,7 @@ async def test_absence_sentinels_carry_a_redis_issued_generation(integration_v2)
 
 
 @pytest.mark.asyncio
-async def test_reload_preserves_a_tombstone_written_while_its_fetch_was_in_flight(mocker, integration_v2):
+async def test_reload_preserves_a_tombstone_written_while_its_fetch_was_in_flight(generations_on, mocker, integration_v2):
     """_reload_integration_from_gundi takes a generation, fetches the portal,
     then writes each configured action. A concurrent ActionConfigDeleted that
     lands between the fetch and the write leaves a tombstone with a higher
@@ -1064,7 +1073,7 @@ async def test_reload_preserves_a_tombstone_written_while_its_fetch_was_in_fligh
 
 
 @pytest.mark.asyncio
-async def test_reload_overwrites_a_sentinel_that_predates_its_fetch(mocker, integration_v2):
+async def test_reload_overwrites_a_sentinel_that_predates_its_fetch(generations_on, mocker, integration_v2):
     """A sentinel written before the reload took its generation is older than
     the snapshot (the lost-Created case the sentinel TTL exists for): the
     portal's row wins."""
@@ -1102,7 +1111,7 @@ async def test_replace_cached_entry_with_absence_writes_a_fresh_expiring_tombsto
     won = await config_manager.replace_cached_entry_with_absence(integration_id, "pull_events", observed='{"id": "x"}')
 
     assert won is True
-    (script, numkeys, key, counter, epoch_key, _hex, ttl, mode, expected, _), _ = client.eval.call_args
+    (script, numkeys, key, counter, epoch_key, _hex, ttl, mode, expected, _, _), _ = client.eval.call_args
     assert script is cm._WRITE_TOMBSTONE_SCRIPT
     assert (numkeys, key, counter, epoch_key, ttl, mode, expected) == (
         3, f"integrationconfig.{integration_id}.pull_events", cm._GENERATION_KEY, cm._GENERATION_EPOCH_KEY,
@@ -1111,7 +1120,7 @@ async def test_replace_cached_entry_with_absence_writes_a_fresh_expiring_tombsto
 
 
 @pytest.mark.asyncio
-async def test_reload_preserves_a_tombstone_from_a_later_epoch_even_with_a_lower_generation(mocker, integration_v2):
+async def test_reload_preserves_a_tombstone_from_a_later_epoch_even_with_a_lower_generation(generations_on, mocker, integration_v2):
     """The counter is an ordinary Redis key. If the cache is flushed (or the
     counter evicted) while a reload is in flight, a delete that follows
     numbers from 1 again; compared by number alone, that fresh tombstone would
@@ -1149,3 +1158,27 @@ async def test_reload_preserves_a_tombstone_from_a_later_epoch_even_with_a_lower
     await reload
 
     assert fake.data[key] == tombstone, "a tombstone from another epoch is never overwritten by a snapshot"
+
+
+@pytest.mark.asyncio
+async def test_by_default_tombstones_are_the_bare_value_every_replica_can_read(integration_v2):
+    """Rolling deployments run old and new replicas side by side. A replica on
+    the previous release recognises only the exact "null" sentinel and parses
+    anything else as a configuration, so a generated tombstone would raise on
+    every lookup there until the rollout completes. Generated tombstones are
+    therefore opt-in (CONFIG_CACHE_SENTINEL_GENERATIONS): this release ships
+    the tolerant reader everywhere; a later one turns the writer on."""
+    from app.services import config_manager as cm
+
+    assert cm.settings.CONFIG_CACHE_SENTINEL_GENERATIONS is False
+    config_manager = IntegrationConfigurationManager()
+    fake = _FakeRedis()
+    config_manager.db_client = fake
+    integration_id = str(integration_v2.id)
+    key = f"integrationconfig.{integration_id}.pull_events"
+
+    await config_manager.delete_action_configuration(integration_id, "pull_events")
+
+    assert fake.data[key] == "null"
+    assert cm._GENERATION_KEY not in fake.data, "no counter traffic while generations are off"
+    assert await config_manager.get_action_configuration(integration_id, "pull_events") is None

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -680,9 +680,14 @@ async def test_any_generation_of_the_sentinel_reads_as_absence(
 
 
 @pytest.mark.asyncio
-async def test_read_absence_sentinel_returns_the_exact_stored_value_or_none(
+async def test_get_action_configuration_and_sentinel_returns_the_sentinel_from_the_same_read(
         mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2, pull_observations_config_as_json,
 ):
+    """The consumer's recovery compares-and-sets against the sentinel it saw.
+    That value must come from the very read that established the absence: a
+    second read could observe a fresh tombstone written by a concurrent
+    ActionConfigDeleted in between, and the compare-and-set would then succeed
+    against the newer tombstone and resurrect the deleted configuration."""
     client = mock_redis_empty.Redis.return_value
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
@@ -690,14 +695,18 @@ async def test_read_absence_sentinel_returns_the_exact_stored_value_or_none(
     integration_id = str(integration_v2.id)
 
     client.get.return_value = async_return(b"null:0123abcd")
-    assert await config_manager.read_absence_sentinel(integration_id, "pull_events") == "null:0123abcd"
-    client.get.return_value = async_return(pull_observations_config_as_json.encode())
-    assert await config_manager.read_absence_sentinel(integration_id, "pull_events") is None
-    client.get.return_value = async_return(None)
-    assert await config_manager.read_absence_sentinel(integration_id, "pull_events") is None
+    assert await config_manager.get_action_configuration_and_sentinel(integration_id, "pull_events") == (None, "null:0123abcd")
+    assert client.get.call_count == 1, "one read establishes both the absence and the generation"
     assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
 
+    client.get.return_value = async_return(pull_observations_config_as_json.encode())
+    config, sentinel = await config_manager.get_action_configuration_and_sentinel(integration_id, "pull_observations")
+    assert (config.json(), sentinel) == (pull_observations_config_as_json, None)
 
+    client.get.return_value = async_return(None)
+    config, sentinel = await config_manager.get_action_configuration_and_sentinel(integration_id, "pull_observations")
+    assert mock_gundi_client_v2_class.return_value.get_integration_details.called, "a miss still reloads from the portal"
+    assert sentinel is None
 @pytest.mark.asyncio
 async def test_reload_absence_sentinels_expire_when_the_caller_asks_for_no_ttl(
         mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -85,6 +85,7 @@ async def test_get_action_configuration_from_gundi(
 ):
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    _miss_once_then_serve_snapshot(mock_redis_empty.Redis.return_value, integration_v2)
     config_manager = IntegrationConfigurationManager()
     integration_id = str(integration_v2.id)
     action_v2 = integration_v2.configurations[0].action
@@ -106,6 +107,7 @@ async def test_get_integration_details_with_empty_redis_db(
 ):
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    _miss_once_then_serve_snapshot(mock_redis_empty.Redis.return_value, integration_v2)
     config_manager = IntegrationConfigurationManager()
     integration_id = str(integration_v2.id)
 
@@ -152,6 +154,7 @@ async def test_get_action_configuration_with_ttl(
 ):
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    _miss_once_then_serve_snapshot(mock_redis_empty.Redis.return_value, integration_v2)
     config_manager = IntegrationConfigurationManager()
     integration_id = str(integration_v2.id)
     action_v2 = integration_v2.configurations[0].action
@@ -166,7 +169,7 @@ async def test_get_action_configuration_with_ttl(
     # with the caller's TTL (the script preserves a newer tombstone, so this
     # write is an EVAL rather than a plain SET).
     snapshot_writes = {c.args[2]: c.args for c in mock_redis_empty.Redis.return_value.eval.call_args_list}
-    _, _, _, written_json, _, written_ttl = snapshot_writes[f"integrationconfig.{integration_id}.{action_id}"]
+    _, _, _, written_json, _, written_ttl, _ = snapshot_writes[f"integrationconfig.{integration_id}.{action_id}"]
     assert (written_json, written_ttl) == (action_config.json(), ttl)
     # Verify that integration was also saved with TTL
     mock_redis_empty.Redis.return_value.set.assert_any_call(
@@ -565,6 +568,27 @@ async def test_reload_writes_absence_sentinels_for_unconfigured_actions(
         assert not snapshots[f"integrationconfig.{integration_id}.{action_id}"][3].startswith("null")
 
 
+def _miss_once_then_serve_snapshot(client, integration):
+    """Make the stateless redis mock behave like Redis across a reload: the
+    first GET of a key misses, later GETs return what the reload's snapshot
+    would have written (a config's JSON, a bare sentinel for an unconfigured
+    action, the webhook sentinel). Lookups answer from the cache after a
+    reload, so the mock has to remember that the reload wrote."""
+    by_action = {c.action.value: c.json().encode() for c in integration.configurations}
+    seen = set()
+
+    async def get(key):
+        if key not in seen:
+            seen.add(key)
+            return None
+        action_id = key.rsplit(".", 1)[-1]
+        if key.endswith(".webhook"):
+            return b"null"
+        return by_action.get(action_id, b"null")
+
+    client.get.side_effect = get
+
+
 async def _fetch_started_or_failed(task, fetch_started):
     """Wait for a reload (or lookup) task to reach its portal fetch; if the task
     fails before that, surface the failure instead of waiting forever."""
@@ -637,12 +661,15 @@ class _FakeRedis:
                 self.data[key] = "null"  # the format every deployed replica can read
             return 1
         if script is cm._WRITE_SNAPSHOT_CONFIG_SCRIPT:
-            value, fetch_token, ttl = args
-            m = re.match(r"^null:([^:]+):(\d+):", current) if isinstance(current, str) else None
-            if m:
-                fetch_epoch, fetch_generation = fetch_token.split(":")
-                if m.group(1) != fetch_epoch or int(m.group(2)) > int(fetch_generation):
-                    return 0
+            value, fetch_token, ttl, generations_enabled = args
+            if isinstance(current, str) and current.startswith("null"):
+                m = re.match(r"^null:([^:]+):(\d+):", current)
+                if m:
+                    fetch_epoch, fetch_generation = fetch_token.split(":")
+                    if m.group(1) != fetch_epoch or int(m.group(2)) > int(fetch_generation):
+                        return 0
+                elif generations_enabled == "1":
+                    return 0  # a bare tombstone from a not-yet-enabled replica: cannot be ordered, so preserve it
             self.data[key] = value
             return 1
         if script is cm._REPLACE_CACHED_ENTRY_SCRIPT:
@@ -1231,3 +1258,75 @@ async def test_lookup_that_reloads_returns_the_cache_winner_not_the_fetched_row(
     release_fetch.set()
 
     assert await lookup is None, "the cached tombstone, not the stale snapshot's row"
+
+
+@pytest.mark.asyncio
+async def test_lookup_that_reloads_answers_absent_when_the_key_vanished_after_the_reload(generations_on, mocker, integration_v2):
+    """A second miss right after the reload means the key changed under it: a
+    concurrent IntegrationDeleted dropped every action key, or a tombstone
+    expired. The cache is authoritative after the reload; the fetched row is a
+    stale snapshot and returning it would execute stale configuration."""
+    from app.services import config_manager as cm
+
+    manager = cm.IntegrationConfigurationManager()
+    fake = _FakeRedis()
+    manager.db_client = fake
+    integration_id = str(integration_v2.id)
+    configured_action = integration_v2.configurations[0].action.value
+    key = f"integrationconfig.{integration_id}.{configured_action}"
+
+    async def fetch_then_drop(_integration_id):
+        return integration_v2
+
+    mocker.patch.object(manager, "_fetch_integration_from_gundi", fetch_then_drop)
+    original_eval = fake.eval
+
+    async def eval_then_drop(script, numkeys, *rest):
+        result = await original_eval(script, numkeys, *rest)
+        if script is cm._WRITE_SNAPSHOT_CONFIG_SCRIPT and rest[0] == key:
+            fake.data.pop(key, None)  # IntegrationDeleted lands right after the snapshot write
+        return result
+
+    fake.eval = eval_then_drop
+
+    assert await manager.get_action_configuration(integration_id, configured_action) is None
+
+
+@pytest.mark.asyncio
+async def test_reload_preserves_a_bare_tombstone_written_mid_fetch_while_generations_are_enabled(
+        generations_on, mocker, integration_v2,
+):
+    """Turning CONFIG_CACHE_SENTINEL_GENERATIONS on is itself a rolling restart:
+    for a while, replicas with the old value still write bare "null" tombstones
+    while enabled replicas write generations. A bare tombstone cannot be
+    ordered against the reload's generation, so an enabled reload preserves it
+    rather than risk overwriting a concurrent delete. The cost is bounded: a
+    bare sentinel that merely predates the fetch expires on its TTL and the
+    next miss reloads."""
+    import asyncio
+    from app.services import config_manager as cm
+
+    manager = cm.IntegrationConfigurationManager()
+    fake = _FakeRedis()
+    manager.db_client = fake
+    integration_id = str(integration_v2.id)
+    configured_action = integration_v2.configurations[0].action.value
+    key = f"integrationconfig.{integration_id}.{configured_action}"
+
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
+
+    async def slow_fetch(_integration_id):
+        fetch_started.set()
+        await release_fetch.wait()
+        return integration_v2
+
+    mocker.patch.object(manager, "_fetch_integration_from_gundi", slow_fetch)
+
+    reload = asyncio.create_task(manager._reload_integration_from_gundi(integration_id))
+    await _fetch_started_or_failed(reload, fetch_started)
+    fake.data[key] = "null"  # a not-yet-enabled replica handled the delete
+    release_fetch.set()
+    await reload
+
+    assert fake.data[key] == "null"

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -1349,3 +1349,48 @@ async def test_reload_preserves_a_bare_tombstone_written_mid_fetch_while_generat
     await reload
 
     assert fake.data[key] == "null"
+
+
+@pytest.mark.asyncio
+async def test_compare_and_set_over_a_bare_sentinel_is_refused_while_generations_are_enabled(
+        generations_on, mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2, pull_observations_config_as_json,
+):
+    """During the rolling restart that enables generations, a not-yet-enabled
+    replica can still write a bare "null" for a delete. A recovery that read a
+    bare "null" earlier cannot tell that fresh delete from the one it saw, so
+    an equality compare-and-set would resurrect it. While the setting is on,
+    a bare sentinel is not a token anyone may write over; the caller's re-read
+    then treats it as an absence and stops, and the sentinel's TTL takes it
+    from there."""
+    client = mock_redis_empty.Redis.return_value
+    client.eval.return_value = async_return(1)
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+    config = IntegrationActionConfiguration.parse_raw(pull_observations_config_as_json)
+
+    assert await config_manager.replace_cached_entry(integration_id, "pull_observations", config=config, observed="null") is False
+    assert await config_manager.replace_cached_entry_with_absence(integration_id, "pull_observations", observed="null") is False
+    assert not client.eval.called, "refused client-side; nothing is written"
+
+    # A generated sentinel is a proper token and proceeds as usual.
+    assert await config_manager.replace_cached_entry(integration_id, "pull_observations", config=config, observed="null:e:3:x") is True
+    assert client.eval.called
+
+
+@pytest.mark.asyncio
+async def test_compare_and_set_over_a_bare_sentinel_proceeds_while_generations_are_off(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2, pull_observations_config_as_json,
+):
+    # With generations off every replica writes bare sentinels and the old
+    # behavior (and its known race) is what we have; nothing to refuse.
+    client = mock_redis_empty.Redis.return_value
+    client.eval.return_value = async_return(1)
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    config = IntegrationActionConfiguration.parse_raw(pull_observations_config_as_json)
+
+    assert await config_manager.replace_cached_entry(str(integration_v2.id), "pull_observations", config=config, observed="null") is True
+    assert client.eval.called

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -555,8 +555,8 @@ async def test_reload_writes_absence_sentinels_for_unconfigured_actions(
     tombstones = {c.args[2]: c.args for c in evals if c.args[0] is cm._WRITE_TOMBSTONE_SCRIPT}
     snapshots = {c.args[2]: c.args for c in evals if c.args[0] is cm._WRITE_SNAPSHOT_CONFIG_SCRIPT}
     for action_id in unconfigured:
-        _, numkeys, _, counter, _hex, _ttl, mode, _ = tombstones[f"integrationconfig.{integration_id}.{action_id}"]
-        assert (numkeys, counter, mode) == (2, cm._GENERATION_KEY, "missing"), \
+        _, numkeys, _, counter, epoch_key, _hex, _ttl, mode, _, _ = tombstones[f"integrationconfig.{integration_id}.{action_id}"]
+        assert (numkeys, counter, epoch_key, mode) == (3, cm._GENERATION_KEY, cm._GENERATION_EPOCH_KEY, "missing"), \
             "a Redis-issued generation, and never replacing an existing key"
     for action_id in configured:
         # Written through the snapshot script, which preserves a newer tombstone.
@@ -591,24 +591,33 @@ class _FakeRedis:
         keys, args = keys_and_args[:numkeys], keys_and_args[numkeys:]
         key = keys[0]
         current = self.data.get(key)
+        def next_generation(counter, epoch_key, candidate_epoch):
+            # An epoch is valid only alongside its counter: a missing counter
+            # (flush, eviction) mints a new epoch, so restarted numbering is
+            # never compared with numbers from before the reset.
+            if counter not in self.data or epoch_key not in self.data:
+                self.data[epoch_key] = candidate_epoch
+            self.data[counter] = int(self.data.get(counter, 0)) + 1
+            return f"{self.data[epoch_key]}:{self.data[counter]}"
         if script is cm._NEXT_GENERATION_SCRIPT:
-            self.data[key] = int(self.data.get(key, 0)) + 1
-            return self.data[key]
+            counter, epoch_key = keys
+            return next_generation(counter, epoch_key, args[0])
         if script is cm._WRITE_TOMBSTONE_SCRIPT:
-            counter = keys[1]
-            hex_part, ttl, mode, expected = args
+            counter, epoch_key = keys[1], keys[2]
+            hex_part, ttl, mode, expected, candidate_epoch = args
             if mode == "missing" and current is not None:
                 return 0
             if mode == "equals" and current != expected:
                 return 0
-            self.data[counter] = int(self.data.get(counter, 0)) + 1
-            self.data[key] = f"null:{self.data[counter]}:{hex_part}"
+            self.data[key] = f"null:{next_generation(counter, epoch_key, candidate_epoch)}:{hex_part}"
             return 1
         if script is cm._WRITE_SNAPSHOT_CONFIG_SCRIPT:
-            value, fetch_generation, ttl = args
-            m = re.match(r"^null:(\d+):", current) if isinstance(current, str) else None
-            if m and int(m.group(1)) > int(fetch_generation):
-                return 0
+            value, fetch_token, ttl = args
+            m = re.match(r"^null:([^:]+):(\d+):", current) if isinstance(current, str) else None
+            if m:
+                fetch_epoch, fetch_generation = fetch_token.split(":")
+                if m.group(1) != fetch_epoch or int(m.group(2)) > int(fetch_generation):
+                    return 0
             self.data[key] = value
             return 1
         if script is cm._REPLACE_CACHED_ENTRY_SCRIPT:
@@ -679,10 +688,11 @@ async def test_deleting_an_action_configuration_records_its_absence(
     await config_manager.delete_action_configuration(integration_id, "pull_events")
 
     from app.services import config_manager as cm
-    (script, numkeys, key, counter, _hex, ttl, mode, _), _ = mock_redis_empty.Redis.return_value.eval.call_args
+    (script, numkeys, key, counter, epoch_key, _hex, ttl, mode, _, _), _ = mock_redis_empty.Redis.return_value.eval.call_args
     assert script is cm._WRITE_TOMBSTONE_SCRIPT
-    assert (numkeys, key, counter, ttl, mode) == (
-        2, f"integrationconfig.{integration_id}.pull_events", cm._GENERATION_KEY, ACTION_ABSENCE_SENTINEL_TTL_SECONDS, "any",
+    assert (numkeys, key, counter, epoch_key, ttl, mode) == (
+        3, f"integrationconfig.{integration_id}.pull_events", cm._GENERATION_KEY, cm._GENERATION_EPOCH_KEY,
+        ACTION_ABSENCE_SENTINEL_TTL_SECONDS, "any",
     )
     assert not mock_redis_empty.Redis.return_value.set.called
     assert not mock_redis_empty.Redis.return_value.delete.called
@@ -713,9 +723,10 @@ async def test_every_absence_sentinel_write_has_its_own_generation(
 
     # The generation is issued by Redis (one INCR shared by every writer), so
     # ordering holds across runner instances regardless of their clocks.
-    g1, g2 = (int(re.fullmatch(r"null:(\d+):[0-9a-f]{32}", v).group(1)) for v in (first, second))
-    assert g2 > g1
-    assert fake.data[cm._GENERATION_KEY] == g2
+    (e1, g1), (e2, g2) = (re.fullmatch(r"null:([0-9a-f]{32}):(\d+):[0-9a-f]{32}", v).groups() for v in (first, second))
+    assert e1 == e2 == fake.data[cm._GENERATION_EPOCH_KEY]
+    assert int(g2) > int(g1)
+    assert fake.data[cm._GENERATION_KEY] == int(g2)
 
 
 @pytest.mark.parametrize("stored", [b"null", b"null:0123abcd"])
@@ -790,7 +801,7 @@ async def test_reload_absence_sentinels_expire_when_the_caller_asks_for_no_ttl(
     tombstones = {c.args[2]: c.args for c in evals if c.args[0] is cm._WRITE_TOMBSTONE_SCRIPT}
     snapshots = {c.args[2]: c.args for c in evals if c.args[0] is cm._WRITE_SNAPSHOT_CONFIG_SCRIPT}
     for action_id in unconfigured:
-        assert tombstones[f"integrationconfig.{integration_id}.{action_id}"][5] == ACTION_ABSENCE_SENTINEL_TTL_SECONDS
+        assert tombstones[f"integrationconfig.{integration_id}.{action_id}"][6] == ACTION_ABSENCE_SENTINEL_TTL_SECONDS
     for action_id in configured:
         # Real configs stay permanent: the events that change them invalidate them.
         assert snapshots[f"integrationconfig.{integration_id}.{action_id}"][5] == ""
@@ -814,7 +825,7 @@ async def test_reload_absence_sentinels_keep_an_explicit_caller_ttl(
     evals = mock_redis_empty.Redis.return_value.eval.call_args_list
     tombstones = {c.args[2]: c.args for c in evals if c.args[0] is cm._WRITE_TOMBSTONE_SCRIPT}
     for action_id in unconfigured:
-        assert tombstones[f"integrationconfig.{integration_id}.{action_id}"][5] == 60
+        assert tombstones[f"integrationconfig.{integration_id}.{action_id}"][6] == 60
 
 
 @pytest.mark.asyncio
@@ -1002,9 +1013,13 @@ async def test_absence_sentinels_carry_a_redis_issued_generation(integration_v2)
     await config_manager.delete_action_configuration(integration_id, "pull_events")
 
     sentinel = fake.data[f"integrationconfig.{integration_id}.pull_events"]
-    m = re.fullmatch(r"null:(\d+):[0-9a-f]{32}", sentinel)
+    m = re.fullmatch(r"null:([0-9a-f]{32}):(\d+):[0-9a-f]{32}", sentinel)
     assert m, sentinel
-    assert int(m.group(1)) == fake.data[cm._GENERATION_KEY]
+    # <epoch>:<generation>: the epoch is minted whenever the counter is found
+    # missing, so numbering that restarted after a flush or eviction is never
+    # compared with numbers from before it.
+    assert m.group(1) == fake.data[cm._GENERATION_EPOCH_KEY]
+    assert int(m.group(2)) == fake.data[cm._GENERATION_KEY]
     assert cm._is_absence_sentinel(sentinel) and cm._is_absence_sentinel(sentinel.encode())
 
 
@@ -1087,9 +1102,50 @@ async def test_replace_cached_entry_with_absence_writes_a_fresh_expiring_tombsto
     won = await config_manager.replace_cached_entry_with_absence(integration_id, "pull_events", observed='{"id": "x"}')
 
     assert won is True
-    (script, numkeys, key, counter, _hex, ttl, mode, expected), _ = client.eval.call_args
+    (script, numkeys, key, counter, epoch_key, _hex, ttl, mode, expected, _), _ = client.eval.call_args
     assert script is cm._WRITE_TOMBSTONE_SCRIPT
-    assert (numkeys, key, counter, ttl, mode, expected) == (
-        2, f"integrationconfig.{integration_id}.pull_events", cm._GENERATION_KEY,
+    assert (numkeys, key, counter, epoch_key, ttl, mode, expected) == (
+        3, f"integrationconfig.{integration_id}.pull_events", cm._GENERATION_KEY, cm._GENERATION_EPOCH_KEY,
         ACTION_ABSENCE_SENTINEL_TTL_SECONDS, "equals", '{"id": "x"}',
     )
+
+
+@pytest.mark.asyncio
+async def test_reload_preserves_a_tombstone_from_a_later_epoch_even_with_a_lower_generation(mocker, integration_v2):
+    """The counter is an ordinary Redis key. If the cache is flushed (or the
+    counter evicted) while a reload is in flight, a delete that follows
+    numbers from 1 again; compared by number alone, that fresh tombstone would
+    look older than the reload's generation and be overwritten with the stale
+    snapshot. Numbering restarts mint a new epoch, and a tombstone from a
+    different epoch is preserved conservatively."""
+    import asyncio
+    from app.services import config_manager as cm
+
+    manager = cm.IntegrationConfigurationManager()
+    fake = _FakeRedis()
+    manager.db_client = fake
+    integration_id = str(integration_v2.id)
+    configured_action = integration_v2.configurations[0].action.value
+    key = f"integrationconfig.{integration_id}.{configured_action}"
+    for _ in range(5):  # the counter is well ahead when the reload takes its number
+        await manager.delete_action_configuration(integration_id, "some_other_action")
+
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
+
+    async def slow_fetch(_integration_id):
+        fetch_started.set()
+        await release_fetch.wait()
+        return integration_v2
+
+    mocker.patch.object(manager, "_fetch_integration_from_gundi", slow_fetch)
+
+    reload = asyncio.create_task(manager._reload_integration_from_gundi(integration_id))
+    await fetch_started.wait()
+    fake.data.clear()  # the cache is flushed mid-fetch: counter, epoch and all
+    await manager.delete_action_configuration(integration_id, configured_action)  # numbering restarts at 1
+    tombstone = fake.data[key]
+    release_fetch.set()
+    await reload
+
+    assert fake.data[key] == tombstone, "a tombstone from another epoch is never overwritten by a snapshot"

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -774,3 +774,37 @@ async def test_replace_absence_sentinel_writes_only_while_the_sentinel_is_still_
 
     client.eval.return_value = async_return(0)
     assert await config_manager.replace_absence_sentinel(integration_id, "pull_observations", config=config) is False
+
+
+@pytest.mark.parametrize("cached", ["webhook-config", "sentinel"])
+@pytest.mark.asyncio
+async def test_a_legacy_permanent_webhook_entry_gets_the_default_ttl_on_its_next_hit(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2_with_webhook, cached,
+):
+    """Before the webhook key carried a TTL, the action path's reload
+    (ttl=None) wrote both real webhook configs and the "null" sentinel
+    permanently, and a cache hit never refreshes the key, so integrations with
+    such an entry would serve a stale or missing webhook configuration
+    indefinitely after rollout. A hit attaches the default TTL to an entry
+    that has none, in one server-side step (a separate TTL check and EXPIRE
+    could race a fresh write and clobber its expiry), whatever the value: a
+    real config that then expires is simply refreshed from the portal."""
+    from app.services.config_manager import WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS
+
+    client = mock_redis_empty.Redis.return_value
+    value = integration_v2_with_webhook.webhook_configuration.json() if cached == "webhook-config" else "null"
+    client.get.return_value = async_return(value.encode())
+    client.eval.return_value = async_return(1)
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2_with_webhook.id)
+
+    result = await config_manager.get_webhook_configuration(integration_id)
+
+    assert (result is None) == (cached == "sentinel")
+    assert not client.ttl.called and not client.expire.called, "must not be two separate commands"
+    (script, numkeys, key, ttl), _ = client.eval.call_args
+    assert (numkeys, key, ttl) == (1, f"integrationconfig.{integration_id}.webhook", WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS)
+    assert "TTL" in script and "EXPIRE" in script and "-1" in script
+    assert not mock_gundi_client_v2_class.return_value.get_integration_details.called

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -85,7 +85,7 @@ async def test_get_action_configuration_from_gundi(
 ):
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
-    _miss_once_then_serve_snapshot(mock_redis_empty.Redis.return_value, integration_v2)
+    _miss_until_the_snapshot_is_written(mock_redis_empty.Redis.return_value, integration_v2)
     config_manager = IntegrationConfigurationManager()
     integration_id = str(integration_v2.id)
     action_v2 = integration_v2.configurations[0].action
@@ -107,7 +107,7 @@ async def test_get_integration_details_with_empty_redis_db(
 ):
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
-    _miss_once_then_serve_snapshot(mock_redis_empty.Redis.return_value, integration_v2)
+    _miss_until_the_snapshot_is_written(mock_redis_empty.Redis.return_value, integration_v2)
     config_manager = IntegrationConfigurationManager()
     integration_id = str(integration_v2.id)
 
@@ -117,7 +117,9 @@ async def test_get_integration_details_with_empty_redis_db(
     assert isinstance(integration, Integration)
     assert len(integration.configurations) == len(integration_v2.configurations)
     assert integration.id == integration_v2.id
-    mock_gundi_client_v2_class.return_value.get_integration_details.assert_called_with(integration_id)
+    # One portal round trip: the summary miss reloads everything, and the
+    # action and webhook reads that follow hit the snapshot it wrote.
+    mock_gundi_client_v2_class.return_value.get_integration_details.assert_called_once_with(integration_id)
     for config in integration_v2.configurations:
         action_id = config.action.value
         mock_redis_empty.Redis.return_value.get.assert_any_call(f"integrationconfig.{integration_id}.{action_id}")
@@ -154,7 +156,7 @@ async def test_get_action_configuration_with_ttl(
 ):
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
-    _miss_once_then_serve_snapshot(mock_redis_empty.Redis.return_value, integration_v2)
+    _miss_until_the_snapshot_is_written(mock_redis_empty.Redis.return_value, integration_v2)
     config_manager = IntegrationConfigurationManager()
     integration_id = str(integration_v2.id)
     action_v2 = integration_v2.configurations[0].action
@@ -568,25 +570,42 @@ async def test_reload_writes_absence_sentinels_for_unconfigured_actions(
         assert not snapshots[f"integrationconfig.{integration_id}.{action_id}"][3].startswith("null")
 
 
-def _miss_once_then_serve_snapshot(client, integration):
-    """Make the stateless redis mock behave like Redis across a reload: the
-    first GET of a key misses, later GETs return what the reload's snapshot
-    would have written (a config's JSON, a bare sentinel for an unconfigured
-    action, the webhook sentinel). Lookups answer from the cache after a
-    reload, so the mock has to remember that the reload wrote."""
+def _miss_until_the_snapshot_is_written(client, integration):
+    """Make the stateless redis mock behave like Redis across a reload: every
+    GET misses until the reload has written its snapshot (the summary SET, or
+    a snapshot-script EVAL), and from then on every key answers with what that
+    snapshot holds (a config's JSON, a bare sentinel for an unconfigured action,
+    the webhook sentinel). One global miss, not one per key: a per-key miss
+    would let each first action read trigger another full reload and hide an
+    N+1 regression."""
+    from unittest.mock import DEFAULT
+    from app.services import config_manager as cm
+
     by_action = {c.action.value: c.json().encode() for c in integration.configurations}
-    seen = set()
+    state = {"populated": False}
 
     async def get(key):
-        if key not in seen:
-            seen.add(key)
+        if not state["populated"]:
             return None
-        action_id = key.rsplit(".", 1)[-1]
+        if key.startswith("integration."):
+            return cm.IntegrationSummary.from_integration(integration).json().encode()
         if key.endswith(".webhook"):
             return b"null"
-        return by_action.get(action_id, b"null")
+        return by_action.get(key.rsplit(".", 1)[-1], b"null")
+
+    def set_(key, *args, **kwargs):
+        if key.startswith("integration."):
+            state["populated"] = True
+        return DEFAULT  # the mock's own return value; calls are still recorded
+
+    def eval_(script, *args):
+        if script is cm._WRITE_SNAPSHOT_CONFIG_SCRIPT:
+            state["populated"] = True
+        return DEFAULT
 
     client.get.side_effect = get
+    client.set.side_effect = set_
+    client.eval.side_effect = eval_
 
 
 async def _fetch_started_or_failed(task, fetch_started):

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -4,6 +4,7 @@ import pytest
 
 from gundi_core.schemas.v2 import IntegrationSummary, IntegrationActionConfiguration, Integration, WebhookConfiguration
 from app.services.config_manager import (
+    ACTION_ABSENCE_SENTINEL_TTL_SECONDS,
     IntegrationConfigurationManager,
     WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS,
 )
@@ -634,6 +635,81 @@ async def test_deleting_an_action_configuration_records_its_absence(
     await config_manager.delete_action_configuration(integration_id, "pull_events")
 
     mock_redis_empty.Redis.return_value.set.assert_called_once_with(
-        f"integrationconfig.{integration_id}.pull_events", "null"
+        f"integrationconfig.{integration_id}.pull_events", "null", ACTION_ABSENCE_SENTINEL_TTL_SECONDS,
     )
     assert not mock_redis_empty.Redis.return_value.delete.called
+
+
+@pytest.mark.asyncio
+async def test_reload_absence_sentinels_expire_when_the_caller_asks_for_no_ttl(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """The action path caches with ttl=None. A permanent "null" is corrected
+    only by an ActionConfig* event for that action; if the Created event is
+    lost (the consumer swallows handler failures and acks), the action stays
+    "unconfigured" until someone flushes redis. A bounded sentinel misses
+    again after the TTL and the reload sees the portal's real config."""
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+    configured = {c.action.value for c in integration_v2.configurations}
+    unconfigured = {a.value for a in integration_v2.type.actions} - configured
+
+    await config_manager.get_integration(integration_id, ttl=None)
+
+    set_calls = {c.args[0]: c for c in mock_redis_empty.Redis.return_value.set.call_args_list}
+    for action_id in unconfigured:
+        call = set_calls[f"integrationconfig.{integration_id}.{action_id}"]
+        assert call.args[2] == ACTION_ABSENCE_SENTINEL_TTL_SECONDS
+    for action_id in configured:
+        # Real configs stay permanent: the events that change them invalidate them.
+        assert set_calls[f"integrationconfig.{integration_id}.{action_id}"].args[2] is None
+
+
+@pytest.mark.asyncio
+async def test_reload_absence_sentinels_keep_an_explicit_caller_ttl(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+    configured = {c.action.value for c in integration_v2.configurations}
+    unconfigured = {a.value for a in integration_v2.type.actions} - configured
+
+    await config_manager.get_integration(integration_id, ttl=60)
+
+    set_calls = {c.args[0]: c for c in mock_redis_empty.Redis.return_value.set.call_args_list}
+    for action_id in unconfigured:
+        assert set_calls[f"integrationconfig.{integration_id}.{action_id}"].args[2] == 60
+
+
+@pytest.mark.asyncio
+async def test_portal_reloads_are_blocked_on_the_ephemeral_path(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """A reference/auth handler running against a draft integration has no
+    portal row: a reload would 404 and spin GUNDI_API_RETRY for up to two
+    minutes on the request. Same guard _get_gundi_api_key applies, for the
+    same reason, so the invariant holds by construction rather than because
+    no handler happens to call the config manager today."""
+    from app.services.activity_logger import ephemeral_run
+    from app.services.gundi import EphemeralWriteBlocked
+
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+
+    token = ephemeral_run.set(True)
+    try:
+        with pytest.raises(EphemeralWriteBlocked):
+            await config_manager._reload_integration_from_gundi(integration_id)
+        with pytest.raises(EphemeralWriteBlocked):
+            await config_manager._reload_webhook_configuration_from_gundi(integration_id)
+    finally:
+        ephemeral_run.reset(token)
+
+    assert not mock_gundi_client_v2_class.called
+    assert not mock_redis_empty.Redis.return_value.set.called

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -1,3 +1,5 @@
+from app.conftest import async_return
+from unittest.mock import AsyncMock
 import pytest
 
 from gundi_core.schemas.v2 import IntegrationSummary, IntegrationActionConfiguration, Integration, WebhookConfiguration
@@ -339,7 +341,11 @@ async def test_get_webhook_configuration_caches_absence_sentinel(
 
     assert webhook_config is None
     # The absence is cached, so the next cold lookup won't reload from Gundi --
-    # but always with an expiry, so it can't outlive a webhook config being added.
+    # but always with an expiry even though this caller passed no TTL (the
+    # action path's full reload reaches here with ttl=None): there is no
+    # WebhookConfig* event to invalidate the sentinel on, so a permanent one
+    # would keep serving "no webhook" after an operator adds a config in the
+    # portal, breaking every delivery until the key was deleted by hand.
     mock_redis_empty.Redis.return_value.set.assert_any_call(
         f"integrationconfig.{integration_id}.webhook", "null", WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS
     )
@@ -362,28 +368,6 @@ async def test_get_webhook_configuration_reads_cached_absence_sentinel(
     assert webhook_config is None
     # Sentinel hit — no reload from the Gundi API.
     assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
-
-
-@pytest.mark.asyncio
-async def test_absence_sentinel_always_gets_a_ttl_even_when_caller_passes_none(
-        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
-):
-    """There is no WebhookConfigCreated event to invalidate the sentinel on, so a
-    permanent one would keep serving "no webhook" after an operator adds a
-    webhook config in the portal -- breaking every delivery until the key was
-    deleted by hand. execute_action reaches here with ttl=None."""
-    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
-    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
-    config_manager = IntegrationConfigurationManager()
-    integration_id = str(integration_v2.id)
-
-    await config_manager.get_webhook_configuration(integration_id, ttl=None)
-
-    mock_redis_empty.Redis.return_value.set.assert_any_call(
-        f"integrationconfig.{integration_id}.webhook",
-        "null",
-        WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS,
-    )
 
 
 @pytest.mark.asyncio
@@ -440,6 +424,83 @@ async def test_deleting_an_uncached_integration_still_drops_the_keys_it_can_name
 ):
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+
+    await config_manager.delete_integration(integration_id)
+
+    delete = mock_redis_empty.Redis.return_value.delete
+    assert delete.call_count == 1
+    assert set(delete.call_args.args) == {
+        f"integration.{integration_id}", f"integrationconfig.{integration_id}.webhook",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_integration_details_can_skip_the_webhook_key(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2, integration_v2_as_json,
+        pull_observations_config_as_json,
+):
+    """The webhook key is the only cache entry with a TTL nothing invalidates, so
+    it is the only one that can miss on a warm integration. The action runner
+    never reads it; letting it opt out keeps warm action runs off the portal."""
+    def cached(key):
+        if key.startswith("integration."):
+            return async_return(integration_v2_as_json)
+        if key.endswith(".webhook"):
+            return async_return(None)  # expired
+        return async_return(pull_observations_config_as_json)
+    mock_redis_empty.Redis.return_value.get.side_effect = cached
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+
+    integration = await config_manager.get_integration_details(str(integration_v2.id), include_webhook_config=False)
+
+    assert integration.webhook_configuration is None
+    assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
+
+
+@pytest.mark.asyncio
+async def test_redis_retry_backoff_does_not_block_the_event_loop(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """stamina's sync iterator sleeps with time.sleep between attempts; inside a
+    coroutine that freezes every other request on the worker for the length of
+    the back-off. Every Redis loop here must iterate asynchronously."""
+    import redis.asyncio as redis
+    calls = {"n": 0}
+    def flaky_get(key):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise redis.RedisError("flap")
+        return async_return(None)
+    mock_redis_empty.Redis.return_value.get.side_effect = flaky_get
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("time.sleep", side_effect=AssertionError("retry back-off blocked the event loop"))
+    mocker.patch("asyncio.sleep", AsyncMock())
+    config_manager = IntegrationConfigurationManager()
+
+    integration = await config_manager.get_integration(str(integration_v2.id))
+
+    assert integration.id == integration_v2.id
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_deleting_an_integration_survives_a_failed_summary_read(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """If the GET that looks up the action list exhausts its retries, the two
+    keys that can be named without it must still be deleted; otherwise the
+    IntegrationDeleted event is acked and the permanent summary key outlives
+    the integration."""
+    import redis.asyncio as redis
+    mock_redis_empty.Redis.return_value.get.side_effect = redis.RedisError("down")
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("asyncio.sleep", AsyncMock())
     config_manager = IntegrationConfigurationManager()
     integration_id = str(integration_v2.id)
 

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -891,3 +891,24 @@ async def test_a_legacy_permanent_webhook_entry_gets_the_default_ttl_on_its_next
     assert (numkeys, key, ttl) == (1, f"integrationconfig.{integration_id}.webhook", WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS)
     assert "TTL" in script and "EXPIRE" in script and "-1" in script
     assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
+
+
+@pytest.mark.asyncio
+async def test_invalidate_action_configuration_drops_the_key_so_the_next_lookup_reloads(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """The consumer's last resort after a lost compare-and-set race: rather
+    than write anything (which could overwrite a newer value or tombstone) or
+    leave a stale permanent config behind an acked event, drop the key. The
+    next lookup misses and rebuilds it from the portal, the source of truth."""
+    client = mock_redis_empty.Redis.return_value
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+
+    await config_manager.invalidate_action_configuration(integration_id, "pull_events")
+
+    client.delete.assert_called_once_with(f"integrationconfig.{integration_id}.pull_events")
+    assert not client.set.called and not client.eval.called
+    assert not mock_gundi_client_v2_class.return_value.get_integration_details.called

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -3,7 +3,7 @@ import pytest
 from gundi_core.schemas.v2 import IntegrationSummary, IntegrationActionConfiguration, Integration, WebhookConfiguration
 from app.services.config_manager import (
     IntegrationConfigurationManager,
-    NO_WEBHOOK_CONFIG_TTL_SECONDS,
+    WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS,
 )
 
 
@@ -341,7 +341,7 @@ async def test_get_webhook_configuration_caches_absence_sentinel(
     # The absence is cached, so the next cold lookup won't reload from Gundi --
     # but always with an expiry, so it can't outlive a webhook config being added.
     mock_redis_empty.Redis.return_value.set.assert_any_call(
-        f"integrationconfig.{integration_id}.webhook", "null", NO_WEBHOOK_CONFIG_TTL_SECONDS
+        f"integrationconfig.{integration_id}.webhook", "null", WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS
     )
 
 
@@ -382,17 +382,62 @@ async def test_absence_sentinel_always_gets_a_ttl_even_when_caller_passes_none(
     mock_redis_empty.Redis.return_value.set.assert_any_call(
         f"integrationconfig.{integration_id}.webhook",
         "null",
-        NO_WEBHOOK_CONFIG_TTL_SECONDS,
+        WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS,
     )
 
 
 @pytest.mark.asyncio
-async def test_deleting_an_integration_drops_its_webhook_key(
+async def test_present_webhook_config_gets_the_default_ttl_when_caller_passes_none(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class_for_webhooks, integration_v2_with_webhook,
+):
+    """Same reasoning as the sentinel: no WebhookConfig* event invalidates the
+    key, so an unbounded write from the action path (ttl=None) would serve a
+    stale config after an operator edits it -- and, since SET clears any TTL,
+    would also undo the webhook path's 60 s cache of the same key."""
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class_for_webhooks)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2_with_webhook.id)
+
+    webhook_config = await config_manager.get_webhook_configuration(integration_id, ttl=None)
+
+    assert webhook_config == integration_v2_with_webhook.webhook_configuration
+    mock_redis_empty.Redis.return_value.set.assert_any_call(
+        f"integrationconfig.{integration_id}.webhook",
+        integration_v2_with_webhook.webhook_configuration.json(),
+        WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS,
+    )
+
+
+@pytest.mark.asyncio
+async def test_deleting_an_integration_drops_every_derived_key_in_one_call(
+        mocker, mock_redis_with_integration_config, mock_gundi_client_v2_class, integration_v2,
+):
+    """The webhook key and the per-action config keys are addressed separately
+    from the integration key, so they would otherwise outlive their owner -- a
+    stale absence sentinel would be served to whatever integration next claimed
+    the id. One variadic DEL leaves no window in which some keys are gone and
+    others orphaned."""
+    mocker.patch("app.services.config_manager.redis", mock_redis_with_integration_config)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+
+    await config_manager.delete_integration(integration_id)
+
+    delete = mock_redis_with_integration_config.Redis.return_value.delete
+    assert delete.call_count == 1
+    deleted = set(delete.call_args.args)
+    assert f"integration.{integration_id}" in deleted
+    assert f"integrationconfig.{integration_id}.webhook" in deleted
+    expected_action_keys = {f"integrationconfig.{integration_id}.{a.value}" for a in integration_v2.type.actions}
+    assert expected_action_keys and expected_action_keys <= deleted
+
+
+@pytest.mark.asyncio
+async def test_deleting_an_uncached_integration_still_drops_the_keys_it_can_name(
         mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
 ):
-    """The webhook key is addressed separately from the integration key, so it
-    would otherwise outlive its owner -- and a stale absence sentinel would be
-    served to whatever integration next claimed the same id."""
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
     config_manager = IntegrationConfigurationManager()
@@ -400,6 +445,8 @@ async def test_deleting_an_integration_drops_its_webhook_key(
 
     await config_manager.delete_integration(integration_id)
 
-    deleted = [c.args[0] for c in mock_redis_empty.Redis.return_value.delete.call_args_list]
-    assert f"integration.{integration_id}" in deleted
-    assert f"integrationconfig.{integration_id}.webhook" in deleted
+    delete = mock_redis_empty.Redis.return_value.delete
+    assert delete.call_count == 1
+    assert set(delete.call_args.args) == {
+        f"integration.{integration_id}", f"integrationconfig.{integration_id}.webhook",
+    }

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -549,11 +549,60 @@ async def test_reload_writes_absence_sentinels_for_unconfigured_actions(
 
     await config_manager.get_integration(integration_id)
 
-    set_calls = {c.args[0]: c.args[1] for c in mock_redis_empty.Redis.return_value.set.call_args_list}
+    set_calls = {c.args[0]: c for c in mock_redis_empty.Redis.return_value.set.call_args_list}
     for action_id in unconfigured:
-        assert set_calls[f"integrationconfig.{integration_id}.{action_id}"] == "null"
+        call = set_calls[f"integrationconfig.{integration_id}.{action_id}"]
+        assert call.args[1] == "null"
+        assert call.kwargs.get("nx") is True, "absence sentinels must never replace an existing key"
     for action_id in configured:
-        assert set_calls[f"integrationconfig.{integration_id}.{action_id}"] != "null"
+        assert set_calls[f"integrationconfig.{integration_id}.{action_id}"].args[1] != "null"
+
+
+class _FakeRedis:
+    """Just enough of redis.asyncio for the reload/event interleaving test:
+    a dict with SET honouring nx."""
+    def __init__(self):
+        self.data = {}
+
+    async def get(self, key):
+        return self.data.get(key)
+
+    async def set(self, key, value, ex=None, nx=False):
+        if nx and key in self.data:
+            return None
+        self.data[key] = value
+        return True
+
+    async def delete(self, *keys):
+        return sum(self.data.pop(k, None) is not None for k in keys)
+
+
+@pytest.mark.asyncio
+async def test_stale_reload_does_not_overwrite_a_concurrently_created_action_config(
+        mocker, mock_gundi_client_v2_class, integration_v2, pull_observations_config_as_json,
+):
+    """Copilot on #102: a reload reads the portal before an action config exists,
+    the ActionConfigCreated event caches the new config, then the reload's
+    sentinel loop runs. The sentinel must not replace the config: nothing later
+    would correct a permanent "null" for an action the portal now has."""
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    fake = _FakeRedis()
+    config_manager.db_client = fake
+    integration_id = str(integration_v2.id)
+    configured = {c.action.value for c in integration_v2.configurations}
+    newly_created = next(a.value for a in integration_v2.type.actions if a.value not in configured)
+    created_key = f"integrationconfig.{integration_id}.{newly_created}"
+
+    # The portal snapshot the reload works from predates the creation...
+    reload = config_manager._reload_integration_from_gundi(integration_id)
+    # ...and the event handler's write lands before the reload's sentinel loop.
+    created = IntegrationActionConfiguration.parse_raw(pull_observations_config_as_json)
+    await config_manager.set_action_configuration(integration_id, newly_created, created)
+    await reload
+
+    assert fake.data[created_key] == created.json()
+    assert await config_manager.get_action_configuration(integration_id, newly_created) == created
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -716,45 +716,33 @@ async def test_portal_reloads_are_blocked_on_the_ephemeral_path(
 
 
 @pytest.mark.asyncio
-async def test_a_legacy_permanent_sentinel_gets_the_ttl_on_its_next_hit(
+async def test_a_legacy_permanent_sentinel_gets_the_ttl_on_its_next_hit_atomically(
         mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
 ):
     """Sentinels written before this release have no expiry, and the reload's
     NX write never touches an existing key, so without a read-time fix an
     integration already hit by the lost-event bug would stay "unconfigured"
-    after rollout. A hit on a sentinel with no TTL (redis TTL == -1) attaches
-    the bounded one; the sentinel still answers this lookup."""
+    after rollout. A hit on a sentinel attaches the bounded TTL, in one
+    server-side step: a separate TTL check and EXPIRE could race an
+    ActionConfigCreated write in between and put the TTL on the real config,
+    which must stay permanent. The value check, the "still permanent" check
+    and the expiry therefore run as one script that only touches a key still
+    holding the sentinel with no TTL; the sentinel still answers this lookup."""
     client = mock_redis_empty.Redis.return_value
     client.get.return_value = async_return(b"null")
-    client.ttl.return_value = async_return(-1)
-    client.expire.return_value = async_return(True)
+    client.eval.return_value = async_return(1)
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
     config_manager = IntegrationConfigurationManager()
     integration_id = str(integration_v2.id)
+    key = f"integrationconfig.{integration_id}.pull_events"
 
     config = await config_manager.get_action_configuration(integration_id, "pull_events")
 
     assert config is None
-    client.expire.assert_called_once_with(
-        f"integrationconfig.{integration_id}.pull_events", ACTION_ABSENCE_SENTINEL_TTL_SECONDS,
-    )
+    assert not client.ttl.called and not client.expire.called, "must not be two separate commands"
+    (script, numkeys, called_key, value, ttl), _ = client.eval.call_args
+    assert (numkeys, called_key, value, ttl) == (1, key, "null", ACTION_ABSENCE_SENTINEL_TTL_SECONDS)
+    # The script itself: expire only a key that still holds the sentinel and has no TTL.
+    assert "GET" in script and "TTL" in script and "EXPIRE" in script and "-1" in script
     assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
-
-
-@pytest.mark.asyncio
-async def test_an_expiring_sentinel_is_left_alone_on_a_hit(
-        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
-):
-    client = mock_redis_empty.Redis.return_value
-    client.get.return_value = async_return(b"null")
-    client.ttl.return_value = async_return(120)
-    client.expire.return_value = async_return(True)
-    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
-    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
-    config_manager = IntegrationConfigurationManager()
-
-    config = await config_manager.get_action_configuration(str(integration_v2.id), "pull_events")
-
-    assert config is None
-    assert not client.expire.called

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -550,15 +550,17 @@ async def test_reload_writes_absence_sentinels_for_unconfigured_actions(
 
     await config_manager.get_integration(integration_id)
 
-    set_calls = {c.args[0]: c for c in mock_redis_empty.Redis.return_value.set.call_args_list}
-    snapshot_writes = {c.args[2]: c for c in mock_redis_empty.Redis.return_value.eval.call_args_list}
+    from app.services import config_manager as cm
+    evals = mock_redis_empty.Redis.return_value.eval.call_args_list
+    tombstones = {c.args[2]: c.args for c in evals if c.args[0] is cm._WRITE_TOMBSTONE_SCRIPT}
+    snapshots = {c.args[2]: c.args for c in evals if c.args[0] is cm._WRITE_SNAPSHOT_CONFIG_SCRIPT}
     for action_id in unconfigured:
-        call = set_calls[f"integrationconfig.{integration_id}.{action_id}"]
-        assert call.args[1].startswith("null:"), "an absence sentinel with a per-write generation"
-        assert call.kwargs.get("nx") is True, "absence sentinels must never replace an existing key"
+        _, numkeys, _, counter, _hex, _ttl, mode, _ = tombstones[f"integrationconfig.{integration_id}.{action_id}"]
+        assert (numkeys, counter, mode) == (2, cm._GENERATION_KEY, "missing"), \
+            "a Redis-issued generation, and never replacing an existing key"
     for action_id in configured:
         # Written through the snapshot script, which preserves a newer tombstone.
-        assert not snapshot_writes[f"integrationconfig.{integration_id}.{action_id}"].args[3].startswith("null")
+        assert not snapshots[f"integrationconfig.{integration_id}.{action_id}"][3].startswith("null")
 
 
 class _FakeRedis:
@@ -583,14 +585,29 @@ class _FakeRedis:
     async def ttl(self, key):
         return -1 if key in self.data else -2
 
-    async def eval(self, script, numkeys, key, *args):
+    async def eval(self, script, numkeys, *keys_and_args):
         import re
         from app.services import config_manager as cm
+        keys, args = keys_and_args[:numkeys], keys_and_args[numkeys:]
+        key = keys[0]
         current = self.data.get(key)
+        if script is cm._NEXT_GENERATION_SCRIPT:
+            self.data[key] = int(self.data.get(key, 0)) + 1
+            return self.data[key]
+        if script is cm._WRITE_TOMBSTONE_SCRIPT:
+            counter = keys[1]
+            hex_part, ttl, mode, expected = args
+            if mode == "missing" and current is not None:
+                return 0
+            if mode == "equals" and current != expected:
+                return 0
+            self.data[counter] = int(self.data.get(counter, 0)) + 1
+            self.data[key] = f"null:{self.data[counter]}:{hex_part}"
+            return 1
         if script is cm._WRITE_SNAPSHOT_CONFIG_SCRIPT:
-            value, fetch_started_ns, ttl = args
+            value, fetch_generation, ttl = args
             m = re.match(r"^null:(\d+):", current) if isinstance(current, str) else None
-            if m and int(m.group(1)) >= int(fetch_started_ns):
+            if m and int(m.group(1)) > int(fetch_generation):
                 return 0
             self.data[key] = value
             return 1
@@ -661,9 +678,13 @@ async def test_deleting_an_action_configuration_records_its_absence(
 
     await config_manager.delete_action_configuration(integration_id, "pull_events")
 
-    (key, value, ttl), _ = mock_redis_empty.Redis.return_value.set.call_args
-    assert (key, ttl) == (f"integrationconfig.{integration_id}.pull_events", ACTION_ABSENCE_SENTINEL_TTL_SECONDS)
-    assert value.startswith("null:")
+    from app.services import config_manager as cm
+    (script, numkeys, key, counter, _hex, ttl, mode, _), _ = mock_redis_empty.Redis.return_value.eval.call_args
+    assert script is cm._WRITE_TOMBSTONE_SCRIPT
+    assert (numkeys, key, counter, ttl, mode) == (
+        2, f"integrationconfig.{integration_id}.pull_events", cm._GENERATION_KEY, ACTION_ABSENCE_SENTINEL_TTL_SECONDS, "any",
+    )
+    assert not mock_redis_empty.Redis.return_value.set.called
     assert not mock_redis_empty.Redis.return_value.delete.called
 
 
@@ -676,17 +697,25 @@ async def test_every_absence_sentinel_write_has_its_own_generation(
     new sentinel in between and both read "null", the recovery could not tell
     the newer tombstone from the one it observed and would resurrect the
     deleted config, permanently. Each write carries a generation instead."""
-    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
-    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    import re
+    from app.services import config_manager as cm
+
     config_manager = IntegrationConfigurationManager()
+    fake = _FakeRedis()
+    config_manager.db_client = fake
     integration_id = str(integration_v2.id)
+    key = f"integrationconfig.{integration_id}.pull_events"
 
     await config_manager.delete_action_configuration(integration_id, "pull_events")
+    first = fake.data[key]
     await config_manager.delete_action_configuration(integration_id, "pull_events")
+    second = fake.data[key]
 
-    first, second = [c.args[1] for c in mock_redis_empty.Redis.return_value.set.call_args_list]
-    assert first != second
-    assert first.startswith("null:") and second.startswith("null:")
+    # The generation is issued by Redis (one INCR shared by every writer), so
+    # ordering holds across runner instances regardless of their clocks.
+    g1, g2 = (int(re.fullmatch(r"null:(\d+):[0-9a-f]{32}", v).group(1)) for v in (first, second))
+    assert g2 > g1
+    assert fake.data[cm._GENERATION_KEY] == g2
 
 
 @pytest.mark.parametrize("stored", [b"null", b"null:0123abcd"])
@@ -735,10 +764,44 @@ async def test_read_cached_action_configuration_never_reloads_and_reports_what_t
     client.get.return_value = async_return(None)
     assert await config_manager.read_cached_action_configuration(integration_id, "pull_observations") == (None, None)
     assert not mock_gundi_client_v2_class.return_value.get_integration_details.called, "never reloads"
+
+
+@pytest.mark.asyncio
+async def test_reload_absence_sentinels_expire_when_the_caller_asks_for_no_ttl(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """The action path caches with ttl=None. A permanent sentinel is corrected
+    only by an ActionConfig* event for that action; if the Created event is
+    lost (the consumer swallows handler failures and acks), the action stays
+    "unconfigured" until someone flushes redis. A bounded sentinel misses
+    again after the TTL and the reload sees the portal's real config."""
+    from app.services import config_manager as cm
+
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+    configured = {c.action.value for c in integration_v2.configurations}
+    unconfigured = {a.value for a in integration_v2.type.actions} - configured
+
+    await config_manager.get_integration(integration_id, ttl=None)
+
+    evals = mock_redis_empty.Redis.return_value.eval.call_args_list
+    tombstones = {c.args[2]: c.args for c in evals if c.args[0] is cm._WRITE_TOMBSTONE_SCRIPT}
+    snapshots = {c.args[2]: c.args for c in evals if c.args[0] is cm._WRITE_SNAPSHOT_CONFIG_SCRIPT}
+    for action_id in unconfigured:
+        assert tombstones[f"integrationconfig.{integration_id}.{action_id}"][5] == ACTION_ABSENCE_SENTINEL_TTL_SECONDS
+    for action_id in configured:
+        # Real configs stay permanent: the events that change them invalidate them.
+        assert snapshots[f"integrationconfig.{integration_id}.{action_id}"][5] == ""
+
+
 @pytest.mark.asyncio
 async def test_reload_absence_sentinels_keep_an_explicit_caller_ttl(
         mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
 ):
+    from app.services import config_manager as cm
+
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
     config_manager = IntegrationConfigurationManager()
@@ -748,9 +811,10 @@ async def test_reload_absence_sentinels_keep_an_explicit_caller_ttl(
 
     await config_manager.get_integration(integration_id, ttl=60)
 
-    set_calls = {c.args[0]: c for c in mock_redis_empty.Redis.return_value.set.call_args_list}
+    evals = mock_redis_empty.Redis.return_value.eval.call_args_list
+    tombstones = {c.args[2]: c.args for c in evals if c.args[0] is cm._WRITE_TOMBSTONE_SCRIPT}
     for action_id in unconfigured:
-        assert set_calls[f"integrationconfig.{integration_id}.{action_id}"].args[2] == 60
+        assert tombstones[f"integrationconfig.{integration_id}.{action_id}"][5] == 60
 
 
 @pytest.mark.asyncio
@@ -918,3 +982,114 @@ async def test_a_legacy_permanent_webhook_entry_gets_the_default_ttl_on_its_next
     assert (numkeys, key, ttl) == (1, f"integrationconfig.{integration_id}.webhook", WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS)
     assert "TTL" in script and "EXPIRE" in script and "-1" in script
     assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
+
+
+@pytest.mark.asyncio
+async def test_absence_sentinels_carry_a_redis_issued_generation(integration_v2):
+    """The reload compares a tombstone's generation with the one it took before
+    its portal fetch, to tell a tombstone written while the fetch was in flight
+    (preserve it) from one that predates the fetch (the portal is newer;
+    overwrite it). Both numbers come from one Redis counter, so the ordering
+    holds across runner instances whatever their clocks say."""
+    import re
+    from app.services import config_manager as cm
+
+    config_manager = IntegrationConfigurationManager()
+    fake = _FakeRedis()
+    config_manager.db_client = fake
+    integration_id = str(integration_v2.id)
+
+    await config_manager.delete_action_configuration(integration_id, "pull_events")
+
+    sentinel = fake.data[f"integrationconfig.{integration_id}.pull_events"]
+    m = re.fullmatch(r"null:(\d+):[0-9a-f]{32}", sentinel)
+    assert m, sentinel
+    assert int(m.group(1)) == fake.data[cm._GENERATION_KEY]
+    assert cm._is_absence_sentinel(sentinel) and cm._is_absence_sentinel(sentinel.encode())
+
+
+@pytest.mark.asyncio
+async def test_reload_preserves_a_tombstone_written_while_its_fetch_was_in_flight(mocker, integration_v2):
+    """_reload_integration_from_gundi takes a generation, fetches the portal,
+    then writes each configured action. A concurrent ActionConfigDeleted that
+    lands between the fetch and the write leaves a tombstone with a higher
+    generation; an unconditional SET would replace it with the stale config,
+    permanently (the delete race the consumer now avoids, reachable through
+    any ordinary cache miss). The write refuses to overwrite a tombstone whose
+    generation is above the reload's."""
+    import asyncio
+    from app.services import config_manager as cm
+
+    manager = cm.IntegrationConfigurationManager()
+    fake = _FakeRedis()
+    manager.db_client = fake
+    integration_id = str(integration_v2.id)
+    configured_action = integration_v2.configurations[0].action.value
+    key = f"integrationconfig.{integration_id}.{configured_action}"
+
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
+
+    async def slow_fetch(_integration_id):
+        fetch_started.set()
+        await release_fetch.wait()
+        return integration_v2  # the pre-delete snapshot
+
+    mocker.patch.object(manager, "_fetch_integration_from_gundi", slow_fetch)
+
+    reload = asyncio.create_task(manager._reload_integration_from_gundi(integration_id))
+    await fetch_started.wait()
+    await manager.delete_action_configuration(integration_id, configured_action)  # the delete lands mid-fetch
+    tombstone = fake.data[key]
+    release_fetch.set()
+    await reload
+
+    assert fake.data[key] == tombstone, "the newer tombstone (higher generation) wins over the stale snapshot"
+    assert await manager.get_action_configuration(integration_id, configured_action) is None
+
+
+@pytest.mark.asyncio
+async def test_reload_overwrites_a_sentinel_that_predates_its_fetch(mocker, integration_v2):
+    """A sentinel written before the reload took its generation is older than
+    the snapshot (the lost-Created case the sentinel TTL exists for): the
+    portal's row wins."""
+    from app.services import config_manager as cm
+
+    manager = cm.IntegrationConfigurationManager()
+    fake = _FakeRedis()
+    manager.db_client = fake
+    integration_id = str(integration_v2.id)
+    configured = integration_v2.configurations[0]
+    key = f"integrationconfig.{integration_id}.{configured.action.value}"
+    await manager.delete_action_configuration(integration_id, configured.action.value)  # predates the fetch
+    mocker.patch.object(manager, "_fetch_integration_from_gundi", AsyncMock(return_value=integration_v2))
+
+    await manager._reload_integration_from_gundi(integration_id)
+
+    assert fake.data[key] == configured.json()
+
+
+@pytest.mark.asyncio
+async def test_replace_cached_entry_with_absence_writes_a_fresh_expiring_tombstone(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """The consumer's reconciliation, when the portal says the row is gone:
+    record the absence, but only over exactly the value it read."""
+    from app.services import config_manager as cm
+
+    client = mock_redis_empty.Redis.return_value
+    client.eval.return_value = async_return(1)
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+
+    won = await config_manager.replace_cached_entry_with_absence(integration_id, "pull_events", observed='{"id": "x"}')
+
+    assert won is True
+    (script, numkeys, key, counter, _hex, ttl, mode, expected), _ = client.eval.call_args
+    assert script is cm._WRITE_TOMBSTONE_SCRIPT
+    assert (numkeys, key, counter, ttl, mode, expected) == (
+        2, f"integrationconfig.{integration_id}.pull_events", cm._GENERATION_KEY,
+        ACTION_ABSENCE_SENTINEL_TTL_SECONDS, "equals", '{"id": "x"}',
+    )

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -1,7 +1,10 @@
 import pytest
 
 from gundi_core.schemas.v2 import IntegrationSummary, IntegrationActionConfiguration, Integration, WebhookConfiguration
-from app.services.config_manager import IntegrationConfigurationManager
+from app.services.config_manager import (
+    IntegrationConfigurationManager,
+    NO_WEBHOOK_CONFIG_TTL_SECONDS,
+)
 
 
 @pytest.mark.asyncio
@@ -335,9 +338,10 @@ async def test_get_webhook_configuration_caches_absence_sentinel(
     webhook_config = await config_manager.get_webhook_configuration(integration_id)
 
     assert webhook_config is None
-    # The absence is cached, so the next cold lookup won't reload from Gundi.
+    # The absence is cached, so the next cold lookup won't reload from Gundi --
+    # but always with an expiry, so it can't outlive a webhook config being added.
     mock_redis_empty.Redis.return_value.set.assert_any_call(
-        f"integrationconfig.{integration_id}.webhook", "null", None
+        f"integrationconfig.{integration_id}.webhook", "null", NO_WEBHOOK_CONFIG_TTL_SECONDS
     )
 
 
@@ -358,3 +362,44 @@ async def test_get_webhook_configuration_reads_cached_absence_sentinel(
     assert webhook_config is None
     # Sentinel hit — no reload from the Gundi API.
     assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
+
+
+@pytest.mark.asyncio
+async def test_absence_sentinel_always_gets_a_ttl_even_when_caller_passes_none(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """There is no WebhookConfigCreated event to invalidate the sentinel on, so a
+    permanent one would keep serving "no webhook" after an operator adds a
+    webhook config in the portal -- breaking every delivery until the key was
+    deleted by hand. execute_action reaches here with ttl=None."""
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+
+    await config_manager.get_webhook_configuration(integration_id, ttl=None)
+
+    mock_redis_empty.Redis.return_value.set.assert_any_call(
+        f"integrationconfig.{integration_id}.webhook",
+        "null",
+        NO_WEBHOOK_CONFIG_TTL_SECONDS,
+    )
+
+
+@pytest.mark.asyncio
+async def test_deleting_an_integration_drops_its_webhook_key(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """The webhook key is addressed separately from the integration key, so it
+    would otherwise outlive its owner -- and a stale absence sentinel would be
+    served to whatever integration next claimed the same id."""
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+
+    await config_manager.delete_integration(integration_id)
+
+    deleted = [c.args[0] for c in mock_redis_empty.Redis.return_value.delete.call_args_list]
+    assert f"integration.{integration_id}" in deleted
+    assert f"integrationconfig.{integration_id}.webhook" in deleted

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -713,3 +713,48 @@ async def test_portal_reloads_are_blocked_on_the_ephemeral_path(
 
     assert not mock_gundi_client_v2_class.called
     assert not mock_redis_empty.Redis.return_value.set.called
+
+
+@pytest.mark.asyncio
+async def test_a_legacy_permanent_sentinel_gets_the_ttl_on_its_next_hit(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """Sentinels written before this release have no expiry, and the reload's
+    NX write never touches an existing key, so without a read-time fix an
+    integration already hit by the lost-event bug would stay "unconfigured"
+    after rollout. A hit on a sentinel with no TTL (redis TTL == -1) attaches
+    the bounded one; the sentinel still answers this lookup."""
+    client = mock_redis_empty.Redis.return_value
+    client.get.return_value = async_return(b"null")
+    client.ttl.return_value = async_return(-1)
+    client.expire.return_value = async_return(True)
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+
+    config = await config_manager.get_action_configuration(integration_id, "pull_events")
+
+    assert config is None
+    client.expire.assert_called_once_with(
+        f"integrationconfig.{integration_id}.pull_events", ACTION_ABSENCE_SENTINEL_TTL_SECONDS,
+    )
+    assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
+
+
+@pytest.mark.asyncio
+async def test_an_expiring_sentinel_is_left_alone_on_a_hit(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    client = mock_redis_empty.Redis.return_value
+    client.get.return_value = async_return(b"null")
+    client.ttl.return_value = async_return(120)
+    client.expire.return_value = async_return(True)
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+
+    config = await config_manager.get_action_configuration(str(integration_v2.id), "pull_events")
+
+    assert config is None
+    assert not client.expire.called

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -553,10 +553,10 @@ async def test_reload_writes_absence_sentinels_for_unconfigured_actions(
     set_calls = {c.args[0]: c for c in mock_redis_empty.Redis.return_value.set.call_args_list}
     for action_id in unconfigured:
         call = set_calls[f"integrationconfig.{integration_id}.{action_id}"]
-        assert call.args[1] == "null"
+        assert call.args[1].startswith("null:"), "an absence sentinel with a per-write generation"
         assert call.kwargs.get("nx") is True, "absence sentinels must never replace an existing key"
     for action_id in configured:
-        assert set_calls[f"integrationconfig.{integration_id}.{action_id}"].args[1] != "null"
+        assert not set_calls[f"integrationconfig.{integration_id}.{action_id}"].args[1].startswith("null")
 
 
 class _FakeRedis:
@@ -634,10 +634,68 @@ async def test_deleting_an_action_configuration_records_its_absence(
 
     await config_manager.delete_action_configuration(integration_id, "pull_events")
 
-    mock_redis_empty.Redis.return_value.set.assert_called_once_with(
-        f"integrationconfig.{integration_id}.pull_events", "null", ACTION_ABSENCE_SENTINEL_TTL_SECONDS,
-    )
+    (key, value, ttl), _ = mock_redis_empty.Redis.return_value.set.call_args
+    assert (key, ttl) == (f"integrationconfig.{integration_id}.pull_events", ACTION_ABSENCE_SENTINEL_TTL_SECONDS)
+    assert value.startswith("null:")
     assert not mock_redis_empty.Redis.return_value.delete.called
+
+
+@pytest.mark.asyncio
+async def test_every_absence_sentinel_write_has_its_own_generation(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """A recovery reads a sentinel, fetches the portal, then replaces the
+    sentinel if it is still there. If a concurrent ActionConfigDeleted wrote a
+    new sentinel in between and both read "null", the recovery could not tell
+    the newer tombstone from the one it observed and would resurrect the
+    deleted config, permanently. Each write carries a generation instead."""
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+
+    await config_manager.delete_action_configuration(integration_id, "pull_events")
+    await config_manager.delete_action_configuration(integration_id, "pull_events")
+
+    first, second = [c.args[1] for c in mock_redis_empty.Redis.return_value.set.call_args_list]
+    assert first != second
+    assert first.startswith("null:") and second.startswith("null:")
+
+
+@pytest.mark.parametrize("stored", [b"null", b"null:0123abcd"])
+@pytest.mark.asyncio
+async def test_any_generation_of_the_sentinel_reads_as_absence(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2, stored,
+):
+    # Legacy sentinels are the bare value; both shapes mean "the portal has no
+    # config for this action" and neither triggers a reload.
+    client = mock_redis_empty.Redis.return_value
+    client.get.return_value = async_return(stored)
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+
+    assert await config_manager.get_action_configuration(str(integration_v2.id), "pull_events") is None
+    assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
+
+
+@pytest.mark.asyncio
+async def test_read_absence_sentinel_returns_the_exact_stored_value_or_none(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2, pull_observations_config_as_json,
+):
+    client = mock_redis_empty.Redis.return_value
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+
+    client.get.return_value = async_return(b"null:0123abcd")
+    assert await config_manager.read_absence_sentinel(integration_id, "pull_events") == "null:0123abcd"
+    client.get.return_value = async_return(pull_observations_config_as_json.encode())
+    assert await config_manager.read_absence_sentinel(integration_id, "pull_events") is None
+    client.get.return_value = async_return(None)
+    assert await config_manager.read_absence_sentinel(integration_id, "pull_events") is None
+    assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
 
 
 @pytest.mark.asyncio
@@ -742,7 +800,8 @@ async def test_a_legacy_permanent_sentinel_gets_the_ttl_on_its_next_hit_atomical
     assert config is None
     assert not client.ttl.called and not client.expire.called, "must not be two separate commands"
     (script, numkeys, called_key, value, ttl), _ = client.eval.call_args
-    assert (numkeys, called_key, value, ttl) == (1, key, "null", ACTION_ABSENCE_SENTINEL_TTL_SECONDS)
+    assert (numkeys, called_key, value, ttl) == (1, key, "null", ACTION_ABSENCE_SENTINEL_TTL_SECONDS), \
+        "the script compares against the value this read observed"
     # The script itself: expire only a key that still holds the sentinel and has no TTL.
     assert "GET" in script and "TTL" in script and "EXPIRE" in script and "-1" in script
     assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
@@ -764,16 +823,24 @@ async def test_replace_absence_sentinel_writes_only_while_the_sentinel_is_still_
     integration_id = str(integration_v2.id)
     config = IntegrationActionConfiguration.parse_raw(pull_observations_config_as_json)
 
-    won = await config_manager.replace_absence_sentinel(integration_id, "pull_observations", config=config)
+    won = await config_manager.replace_absence_sentinel(
+        integration_id, "pull_observations", config=config, observed="null:0123abcd",
+    )
 
     assert won is True
     (script, numkeys, key, sentinel, value), _ = client.eval.call_args
-    assert (numkeys, key, sentinel, value) == (1, f"integrationconfig.{integration_id}.pull_observations", "null", config.json())
+    # The exact generation the caller observed, so a newer tombstone written by
+    # a concurrent ActionConfigDeleted does not compare equal and wins.
+    assert (numkeys, key, sentinel, value) == (
+        1, f"integrationconfig.{integration_id}.pull_observations", "null:0123abcd", config.json(),
+    )
     assert "GET" in script and "SET" in script
     assert not client.set.called
 
     client.eval.return_value = async_return(0)
-    assert await config_manager.replace_absence_sentinel(integration_id, "pull_observations", config=config) is False
+    assert await config_manager.replace_absence_sentinel(
+        integration_id, "pull_observations", config=config, observed="null:0123abcd",
+    ) is False
 
 
 @pytest.mark.parametrize("cached", ["webhook-config", "sentinel"])

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -688,7 +688,8 @@ async def test_read_cached_action_configuration_never_reloads_and_reports_what_t
     could observe a fresh tombstone from a concurrent ActionConfigDeleted, and
     (b) never fall through to the full portal reload, whose unconditional SETs
     of configured actions would overwrite a tombstone written after the
-    reload's fetch. Three answers: a config, a sentinel, or nothing cached."""
+    reload's fetch. Three answers, each with the exact stored value as the
+    token to compare-and-set against: a config, a sentinel, or nothing."""
     client = mock_redis_empty.Redis.return_value
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
@@ -700,8 +701,9 @@ async def test_read_cached_action_configuration_never_reloads_and_reports_what_t
     assert client.get.call_count == 1, "one read establishes both the absence and the generation"
 
     client.get.return_value = async_return(pull_observations_config_as_json.encode())
-    config, sentinel = await config_manager.read_cached_action_configuration(integration_id, "pull_observations")
-    assert (config.json(), sentinel) == (pull_observations_config_as_json, None)
+    config, token = await config_manager.read_cached_action_configuration(integration_id, "pull_observations")
+    assert (config.json(), token) == (pull_observations_config_as_json, pull_observations_config_as_json), \
+        "the raw stored value, so an update can compare-and-set against exactly what it read"
 
     client.get.return_value = async_return(None)
     assert await config_manager.read_cached_action_configuration(integration_id, "pull_observations") == (None, None)
@@ -789,17 +791,17 @@ async def test_a_legacy_permanent_sentinel_gets_the_ttl_on_its_next_hit_atomical
 
 
 @pytest.mark.asyncio
-async def test_replace_absence_sentinel_requires_the_exact_observed_generation(
+async def test_replace_cached_entry_requires_the_exact_observed_value(
         mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2, pull_observations_config_as_json,
 ):
-    """The consumer's recovery reads the portal, then writes. If another
-    delivery replaced the sentinel in between, this write must not land on top
-    of it, so the value check and the SET are one script. The key must equal
-    the generation observed: an expired key is not a match either, because a
-    newer tombstone written during a slow fetch can itself have expired by
-    the time the script runs, and treating "missing" as a match would then
-    install the stale config. The return value tells the caller whether its
-    value won."""
+    """Every consumer write is read-modify-write: it must not land on top of a
+    value another concurrent delivery wrote in between, so the value check and
+    the SET are one script, and the key must equal exactly what the caller
+    read, a sentinel generation or a config's raw JSON. An expired key is not
+    a match either: a newer tombstone written during a slow fetch can itself
+    have expired by the time the script runs, and treating "missing" as a
+    match would install the stale config. The return value tells the caller
+    whether its value won."""
     client = mock_redis_empty.Redis.return_value
     client.eval.return_value = async_return(1)
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
@@ -808,7 +810,7 @@ async def test_replace_absence_sentinel_requires_the_exact_observed_generation(
     integration_id = str(integration_v2.id)
     config = IntegrationActionConfiguration.parse_raw(pull_observations_config_as_json)
 
-    won = await config_manager.replace_absence_sentinel(
+    won = await config_manager.replace_cached_entry(
         integration_id, "pull_observations", config=config, observed="null:0123abcd",
     )
 
@@ -822,9 +824,17 @@ async def test_replace_absence_sentinel_requires_the_exact_observed_generation(
     assert not client.set.called
 
     client.eval.return_value = async_return(0)
-    assert await config_manager.replace_absence_sentinel(
+    assert await config_manager.replace_cached_entry(
         integration_id, "pull_observations", config=config, observed="null:0123abcd",
     ) is False
+
+    # The same primitive updates a real configuration against its raw JSON.
+    client.eval.return_value = async_return(1)
+    stale_raw = '{"id": "x"}'
+    assert await config_manager.replace_cached_entry(
+        integration_id, "pull_observations", config=config, observed=stale_raw,
+    ) is True
+    assert client.eval.call_args.args[3] == stale_raw
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -94,7 +94,9 @@ async def test_get_action_configuration_from_gundi(
 
     assert action_config
     assert isinstance(action_config, IntegrationActionConfiguration)
-    mock_redis_empty.Redis.return_value.get.assert_called_once_with(f"integrationconfig.{integration_id}.{action_id}")
+    # Two reads: the miss, and the answer from the cache after the reload (a
+    # delete that landed during the fetch must win over the fetched row).
+    assert mock_redis_empty.Redis.return_value.get.call_count == 2
     mock_gundi_client_v2_class.return_value.get_integration_details.assert_called_once_with(integration_id)
 
 
@@ -563,6 +565,18 @@ async def test_reload_writes_absence_sentinels_for_unconfigured_actions(
         assert not snapshots[f"integrationconfig.{integration_id}.{action_id}"][3].startswith("null")
 
 
+async def _fetch_started_or_failed(task, fetch_started):
+    """Wait for a reload (or lookup) task to reach its portal fetch; if the task
+    fails before that, surface the failure instead of waiting forever."""
+    import asyncio
+    waiter = asyncio.ensure_future(fetch_started.wait())
+    done, _ = await asyncio.wait({task, waiter}, return_when=asyncio.FIRST_COMPLETED)
+    if task in done and not fetch_started.is_set():
+        waiter.cancel()
+        task.result()  # raises the task's exception
+        raise AssertionError("task finished without fetching")
+
+
 @pytest.fixture
 def generations_on(mocker):
     """Generated tombstones are opt-in until every replica runs a tolerant
@@ -762,10 +776,11 @@ async def test_read_cached_action_configuration_never_reloads_and_reports_what_t
     """The consumer's recovery compares-and-sets against what it saw in the
     cache, so its read must (a) come from one Redis GET, since a second read
     could observe a fresh tombstone from a concurrent ActionConfigDeleted, and
-    (b) never fall through to the full portal reload, whose unconditional SETs
-    of configured actions would overwrite a tombstone written after the
-    reload's fetch. Three answers, each with the exact stored value as the
-    token to compare-and-set against: a config, a sentinel, or nothing."""
+    (b) never fall through to the full portal reload: the recovery needs the
+    exact token the cache held when it looked, and a reload rewrites the cache
+    from a snapshot before returning. Three answers, each with the exact
+    stored value as the token to compare-and-set against: a config, a
+    sentinel, or nothing."""
     client = mock_redis_empty.Redis.return_value
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
@@ -1062,7 +1077,7 @@ async def test_reload_preserves_a_tombstone_written_while_its_fetch_was_in_fligh
     mocker.patch.object(manager, "_fetch_integration_from_gundi", slow_fetch)
 
     reload = asyncio.create_task(manager._reload_integration_from_gundi(integration_id))
-    await fetch_started.wait()
+    await _fetch_started_or_failed(reload, fetch_started)
     await manager.delete_action_configuration(integration_id, configured_action)  # the delete lands mid-fetch
     tombstone = fake.data[key]
     release_fetch.set()
@@ -1150,7 +1165,7 @@ async def test_reload_preserves_a_tombstone_from_a_later_epoch_even_with_a_lower
     mocker.patch.object(manager, "_fetch_integration_from_gundi", slow_fetch)
 
     reload = asyncio.create_task(manager._reload_integration_from_gundi(integration_id))
-    await fetch_started.wait()
+    await _fetch_started_or_failed(reload, fetch_started)
     fake.data.clear()  # the cache is flushed mid-fetch: counter, epoch and all
     await manager.delete_action_configuration(integration_id, configured_action)  # numbering restarts at 1
     tombstone = fake.data[key]
@@ -1182,3 +1197,37 @@ async def test_by_default_tombstones_are_the_bare_value_every_replica_can_read(i
     assert fake.data[key] == "null"
     assert cm._GENERATION_KEY not in fake.data, "no counter traffic while generations are off"
     assert await config_manager.get_action_configuration(integration_id, "pull_events") is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_that_reloads_returns_the_cache_winner_not_the_fetched_row(generations_on, mocker, integration_v2):
+    """A lookup misses, reloads, and a delete lands during the reload's fetch.
+    The tombstone wins the cache race, but the reload's caller must not be
+    handed the pre-delete portal row anyway: the action runner would execute
+    the deleted action once, from a value the cache itself no longer holds.
+    After writing, the lookup answers from the cache."""
+    import asyncio
+    from app.services import config_manager as cm
+
+    manager = cm.IntegrationConfigurationManager()
+    fake = _FakeRedis()
+    manager.db_client = fake
+    integration_id = str(integration_v2.id)
+    configured_action = integration_v2.configurations[0].action.value
+
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
+
+    async def slow_fetch(_integration_id):
+        fetch_started.set()
+        await release_fetch.wait()
+        return integration_v2  # the pre-delete snapshot
+
+    mocker.patch.object(manager, "_fetch_integration_from_gundi", slow_fetch)
+
+    lookup = asyncio.create_task(manager.get_action_configuration(integration_id, configured_action))
+    await _fetch_started_or_failed(lookup, fetch_started)
+    await manager.delete_action_configuration(integration_id, configured_action)
+    release_fetch.set()
+
+    assert await lookup is None, "the cached tombstone, not the stale snapshot's row"

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -160,12 +160,12 @@ async def test_get_action_configuration_with_ttl(
 
     assert action_config
     assert isinstance(action_config, IntegrationActionConfiguration)
-    # Verify that set was called with TTL for action config
-    mock_redis_empty.Redis.return_value.set.assert_any_call(
-        f"integrationconfig.{integration_id}.{action_id}",
-        action_config.json(),
-        ttl
-    )
+    # Verify the configured action was written through the snapshot script
+    # with the caller's TTL (the script preserves a newer tombstone, so this
+    # write is an EVAL rather than a plain SET).
+    snapshot_writes = {c.args[2]: c.args for c in mock_redis_empty.Redis.return_value.eval.call_args_list}
+    _, _, _, written_json, _, written_ttl = snapshot_writes[f"integrationconfig.{integration_id}.{action_id}"]
+    assert (written_json, written_ttl) == (action_config.json(), ttl)
     # Verify that integration was also saved with TTL
     mock_redis_empty.Redis.return_value.set.assert_any_call(
         f"integration.{integration_id}",
@@ -551,17 +551,20 @@ async def test_reload_writes_absence_sentinels_for_unconfigured_actions(
     await config_manager.get_integration(integration_id)
 
     set_calls = {c.args[0]: c for c in mock_redis_empty.Redis.return_value.set.call_args_list}
+    snapshot_writes = {c.args[2]: c for c in mock_redis_empty.Redis.return_value.eval.call_args_list}
     for action_id in unconfigured:
         call = set_calls[f"integrationconfig.{integration_id}.{action_id}"]
         assert call.args[1].startswith("null:"), "an absence sentinel with a per-write generation"
         assert call.kwargs.get("nx") is True, "absence sentinels must never replace an existing key"
     for action_id in configured:
-        assert not set_calls[f"integrationconfig.{integration_id}.{action_id}"].args[1].startswith("null")
+        # Written through the snapshot script, which preserves a newer tombstone.
+        assert not snapshot_writes[f"integrationconfig.{integration_id}.{action_id}"].args[3].startswith("null")
 
 
 class _FakeRedis:
-    """Just enough of redis.asyncio for the reload/event interleaving test:
-    a dict with SET honouring nx."""
+    """Just enough of redis.asyncio for the reload/event interleaving tests: a
+    dict with SET honouring nx, and an eval that emulates the module's scripts
+    (matched by identity) so the interleavings exercise their real decisions."""
     def __init__(self):
         self.data = {}
 
@@ -576,6 +579,30 @@ class _FakeRedis:
 
     async def delete(self, *keys):
         return sum(self.data.pop(k, None) is not None for k in keys)
+
+    async def ttl(self, key):
+        return -1 if key in self.data else -2
+
+    async def eval(self, script, numkeys, key, *args):
+        import re
+        from app.services import config_manager as cm
+        current = self.data.get(key)
+        if script is cm._WRITE_SNAPSHOT_CONFIG_SCRIPT:
+            value, fetch_started_ns, ttl = args
+            m = re.match(r"^null:(\d+):", current) if isinstance(current, str) else None
+            if m and int(m.group(1)) >= int(fetch_started_ns):
+                return 0
+            self.data[key] = value
+            return 1
+        if script is cm._REPLACE_CACHED_ENTRY_SCRIPT:
+            observed, value = args[0], args[1]
+            if current != observed:
+                return 0
+            self.data[key] = value
+            return 1
+        if script is cm._EXPIRE_LEGACY_SENTINEL_SCRIPT:
+            return 0
+        raise AssertionError(f"unexpected script: {script[:40]}")
 
 
 @pytest.mark.asyncio
@@ -815,9 +842,9 @@ async def test_replace_cached_entry_requires_the_exact_observed_value(
     )
 
     assert won is True
-    (script, numkeys, key, sentinel, value), _ = client.eval.call_args
-    assert (numkeys, key, sentinel, value) == (
-        1, f"integrationconfig.{integration_id}.pull_observations", "null:0123abcd", config.json(),
+    (script, numkeys, key, sentinel, value, ttl), _ = client.eval.call_args
+    assert (numkeys, key, sentinel, value, ttl) == (
+        1, f"integrationconfig.{integration_id}.pull_observations", "null:0123abcd", config.json(), "",
     )
     assert "GET" in script and "SET" in script
     assert "false" not in script, "a missing (expired) key must not count as the observed sentinel"
@@ -890,25 +917,4 @@ async def test_a_legacy_permanent_webhook_entry_gets_the_default_ttl_on_its_next
     (script, numkeys, key, ttl), _ = client.eval.call_args
     assert (numkeys, key, ttl) == (1, f"integrationconfig.{integration_id}.webhook", WEBHOOK_CONFIG_DEFAULT_TTL_SECONDS)
     assert "TTL" in script and "EXPIRE" in script and "-1" in script
-    assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
-
-
-@pytest.mark.asyncio
-async def test_invalidate_action_configuration_drops_the_key_so_the_next_lookup_reloads(
-        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
-):
-    """The consumer's last resort after a lost compare-and-set race: rather
-    than write anything (which could overwrite a newer value or tombstone) or
-    leave a stale permanent config behind an acked event, drop the key. The
-    next lookup misses and rebuilds it from the portal, the source of truth."""
-    client = mock_redis_empty.Redis.return_value
-    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
-    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
-    config_manager = IntegrationConfigurationManager()
-    integration_id = str(integration_v2.id)
-
-    await config_manager.invalidate_action_configuration(integration_id, "pull_events")
-
-    client.delete.assert_called_once_with(f"integrationconfig.{integration_id}.pull_events")
-    assert not client.set.called and not client.eval.called
     assert not mock_gundi_client_v2_class.return_value.get_integration_details.called

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -511,3 +511,80 @@ async def test_deleting_an_integration_survives_a_failed_summary_read(
     assert set(delete.call_args.args) == {
         f"integration.{integration_id}", f"integrationconfig.{integration_id}.webhook",
     }
+
+
+@pytest.mark.asyncio
+async def test_webhook_key_miss_refreshes_only_the_webhook_key(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2_with_webhook,
+):
+    """The webhook key expires on its own; refreshing it through the full reload
+    would rewrite the summary and action keys with the webhook path's ttl=60,
+    downgrading the action path's permanent keys and sending the next action
+    run back to the portal."""
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    mock_gundi_client_v2_class.return_value.get_integration_details = mocker.AsyncMock(return_value=integration_v2_with_webhook)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2_with_webhook.id)
+
+    await config_manager.get_webhook_configuration(integration_id, ttl=60)
+
+    written = [c.args[0] for c in mock_redis_empty.Redis.return_value.set.call_args_list]
+    assert written == [f"integrationconfig.{integration_id}.webhook"]
+
+
+@pytest.mark.asyncio
+async def test_reload_writes_absence_sentinels_for_unconfigured_actions(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """An integration configured for only some of its type's actions must not
+    reload from the Gundi API on every run because the others keep missing."""
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+    configured = {c.action.value for c in integration_v2.configurations}
+    unconfigured = {a.value for a in integration_v2.type.actions} - configured
+    assert unconfigured, "fixture must declare an action without a configuration"
+
+    await config_manager.get_integration(integration_id)
+
+    set_calls = {c.args[0]: c.args[1] for c in mock_redis_empty.Redis.return_value.set.call_args_list}
+    for action_id in unconfigured:
+        assert set_calls[f"integrationconfig.{integration_id}.{action_id}"] == "null"
+    for action_id in configured:
+        assert set_calls[f"integrationconfig.{integration_id}.{action_id}"] != "null"
+
+
+@pytest.mark.asyncio
+async def test_cached_action_absence_returns_none_without_reloading(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    mock_redis_empty.Redis.return_value.get.return_value = async_return(b"null")
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+
+    config = await config_manager.get_action_configuration(str(integration_v2.id), "pull_events")
+
+    assert config is None
+    assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
+
+
+@pytest.mark.asyncio
+async def test_deleting_an_action_configuration_records_its_absence(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """A dropped key would miss on the next lookup and reload the whole
+    integration from the Gundi API, which would then report the same absence."""
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+
+    await config_manager.delete_action_configuration(integration_id, "pull_events")
+
+    mock_redis_empty.Redis.return_value.set.assert_called_once_with(
+        f"integrationconfig.{integration_id}.pull_events", "null"
+    )
+    assert not mock_redis_empty.Redis.return_value.delete.called

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -680,14 +680,15 @@ async def test_any_generation_of_the_sentinel_reads_as_absence(
 
 
 @pytest.mark.asyncio
-async def test_get_action_configuration_and_sentinel_returns_the_sentinel_from_the_same_read(
+async def test_read_cached_action_configuration_never_reloads_and_reports_what_the_cache_holds(
         mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2, pull_observations_config_as_json,
 ):
-    """The consumer's recovery compares-and-sets against the sentinel it saw.
-    That value must come from the very read that established the absence: a
-    second read could observe a fresh tombstone written by a concurrent
-    ActionConfigDeleted in between, and the compare-and-set would then succeed
-    against the newer tombstone and resurrect the deleted configuration."""
+    """The consumer's recovery compares-and-sets against what it saw in the
+    cache, so its read must (a) come from one Redis GET, since a second read
+    could observe a fresh tombstone from a concurrent ActionConfigDeleted, and
+    (b) never fall through to the full portal reload, whose unconditional SETs
+    of configured actions would overwrite a tombstone written after the
+    reload's fetch. Three answers: a config, a sentinel, or nothing cached."""
     client = mock_redis_empty.Redis.return_value
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
     mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
@@ -695,45 +696,16 @@ async def test_get_action_configuration_and_sentinel_returns_the_sentinel_from_t
     integration_id = str(integration_v2.id)
 
     client.get.return_value = async_return(b"null:0123abcd")
-    assert await config_manager.get_action_configuration_and_sentinel(integration_id, "pull_events") == (None, "null:0123abcd")
+    assert await config_manager.read_cached_action_configuration(integration_id, "pull_events") == (None, "null:0123abcd")
     assert client.get.call_count == 1, "one read establishes both the absence and the generation"
-    assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
 
     client.get.return_value = async_return(pull_observations_config_as_json.encode())
-    config, sentinel = await config_manager.get_action_configuration_and_sentinel(integration_id, "pull_observations")
+    config, sentinel = await config_manager.read_cached_action_configuration(integration_id, "pull_observations")
     assert (config.json(), sentinel) == (pull_observations_config_as_json, None)
 
     client.get.return_value = async_return(None)
-    config, sentinel = await config_manager.get_action_configuration_and_sentinel(integration_id, "pull_observations")
-    assert mock_gundi_client_v2_class.return_value.get_integration_details.called, "a miss still reloads from the portal"
-    assert sentinel is None
-@pytest.mark.asyncio
-async def test_reload_absence_sentinels_expire_when_the_caller_asks_for_no_ttl(
-        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
-):
-    """The action path caches with ttl=None. A permanent "null" is corrected
-    only by an ActionConfig* event for that action; if the Created event is
-    lost (the consumer swallows handler failures and acks), the action stays
-    "unconfigured" until someone flushes redis. A bounded sentinel misses
-    again after the TTL and the reload sees the portal's real config."""
-    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
-    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
-    config_manager = IntegrationConfigurationManager()
-    integration_id = str(integration_v2.id)
-    configured = {c.action.value for c in integration_v2.configurations}
-    unconfigured = {a.value for a in integration_v2.type.actions} - configured
-
-    await config_manager.get_integration(integration_id, ttl=None)
-
-    set_calls = {c.args[0]: c for c in mock_redis_empty.Redis.return_value.set.call_args_list}
-    for action_id in unconfigured:
-        call = set_calls[f"integrationconfig.{integration_id}.{action_id}"]
-        assert call.args[2] == ACTION_ABSENCE_SENTINEL_TTL_SECONDS
-    for action_id in configured:
-        # Real configs stay permanent: the events that change them invalidate them.
-        assert set_calls[f"integrationconfig.{integration_id}.{action_id}"].args[2] is None
-
-
+    assert await config_manager.read_cached_action_configuration(integration_id, "pull_observations") == (None, None)
+    assert not mock_gundi_client_v2_class.return_value.get_integration_details.called, "never reloads"
 @pytest.mark.asyncio
 async def test_reload_absence_sentinels_keep_an_explicit_caller_ttl(
         mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
@@ -817,13 +789,17 @@ async def test_a_legacy_permanent_sentinel_gets_the_ttl_on_its_next_hit_atomical
 
 
 @pytest.mark.asyncio
-async def test_replace_absence_sentinel_writes_only_while_the_sentinel_is_still_there(
+async def test_replace_absence_sentinel_requires_the_exact_observed_generation(
         mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2, pull_observations_config_as_json,
 ):
-    """The consumer's Updated-after-sentinel recovery reads the portal, then
-    writes. If another delivery replaced the sentinel in between, this write
-    must not land on top of it, so the value check and the SET are one script;
-    the return value tells the caller whether its value won."""
+    """The consumer's recovery reads the portal, then writes. If another
+    delivery replaced the sentinel in between, this write must not land on top
+    of it, so the value check and the SET are one script. The key must equal
+    the generation observed: an expired key is not a match either, because a
+    newer tombstone written during a slow fetch can itself have expired by
+    the time the script runs, and treating "missing" as a match would then
+    install the stale config. The return value tells the caller whether its
+    value won."""
     client = mock_redis_empty.Redis.return_value
     client.eval.return_value = async_return(1)
     mocker.patch("app.services.config_manager.redis", mock_redis_empty)
@@ -838,12 +814,11 @@ async def test_replace_absence_sentinel_writes_only_while_the_sentinel_is_still_
 
     assert won is True
     (script, numkeys, key, sentinel, value), _ = client.eval.call_args
-    # The exact generation the caller observed, so a newer tombstone written by
-    # a concurrent ActionConfigDeleted does not compare equal and wins.
     assert (numkeys, key, sentinel, value) == (
         1, f"integrationconfig.{integration_id}.pull_observations", "null:0123abcd", config.json(),
     )
     assert "GET" in script and "SET" in script
+    assert "false" not in script, "a missing (expired) key must not count as the observed sentinel"
     assert not client.set.called
 
     client.eval.return_value = async_return(0)
@@ -852,6 +827,28 @@ async def test_replace_absence_sentinel_writes_only_while_the_sentinel_is_still_
     ) is False
 
 
+@pytest.mark.asyncio
+async def test_install_action_configuration_if_missing_is_a_single_conditional_write(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2, pull_observations_config_as_json,
+):
+    """Cold-cache recovery: the consumer saw nothing cached, fetched the portal
+    row, and installs it only if the key is still missing (SET NX), so a
+    tombstone or config written meanwhile wins. Permanent, like every real
+    configuration; the caller learns whether its write happened."""
+    client = mock_redis_empty.Redis.return_value
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+    config = IntegrationActionConfiguration.parse_raw(pull_observations_config_as_json)
+
+    client.set.return_value = async_return(True)
+    assert await config_manager.install_action_configuration_if_missing(integration_id, "pull_observations", config=config) is True
+    client.set.assert_called_once_with(f"integrationconfig.{integration_id}.pull_observations", config.json(), None, nx=True)
+    assert not client.eval.called
+
+    client.set.return_value = async_return(None)  # redis: NX not applied
+    assert await config_manager.install_action_configuration_if_missing(integration_id, "pull_observations", config=config) is False
 @pytest.mark.parametrize("cached", ["webhook-config", "sentinel"])
 @pytest.mark.asyncio
 async def test_a_legacy_permanent_webhook_entry_gets_the_default_ttl_on_its_next_hit(

--- a/app/services/tests/test_config_manager.py
+++ b/app/services/tests/test_config_manager.py
@@ -746,3 +746,31 @@ async def test_a_legacy_permanent_sentinel_gets_the_ttl_on_its_next_hit_atomical
     # The script itself: expire only a key that still holds the sentinel and has no TTL.
     assert "GET" in script and "TTL" in script and "EXPIRE" in script and "-1" in script
     assert not mock_gundi_client_v2_class.return_value.get_integration_details.called
+
+
+@pytest.mark.asyncio
+async def test_replace_absence_sentinel_writes_only_while_the_sentinel_is_still_there(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2, pull_observations_config_as_json,
+):
+    """The consumer's Updated-after-sentinel recovery reads the portal, then
+    writes. If another delivery replaced the sentinel in between, this write
+    must not land on top of it, so the value check and the SET are one script;
+    the return value tells the caller whether its value won."""
+    client = mock_redis_empty.Redis.return_value
+    client.eval.return_value = async_return(1)
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    config_manager = IntegrationConfigurationManager()
+    integration_id = str(integration_v2.id)
+    config = IntegrationActionConfiguration.parse_raw(pull_observations_config_as_json)
+
+    won = await config_manager.replace_absence_sentinel(integration_id, "pull_observations", config=config)
+
+    assert won is True
+    (script, numkeys, key, sentinel, value), _ = client.eval.call_args
+    assert (numkeys, key, sentinel, value) == (1, f"integrationconfig.{integration_id}.pull_observations", "null", config.json())
+    assert "GET" in script and "SET" in script
+    assert not client.set.called
+
+    client.eval.return_value = async_return(0)
+    assert await config_manager.replace_absence_sentinel(integration_id, "pull_observations", config=config) is False

--- a/app/services/tests/test_diagnostic_url_validation.py
+++ b/app/services/tests/test_diagnostic_url_validation.py
@@ -42,6 +42,12 @@ async def test_ipv6_multicast_is_blocked(mocker):
     # Caught by the explicit blocklist only: ipaddress reports the deprecated
     # IPv6 site-local range as is_global, so the check above misses it.
     "fec0::1",
+    # Also explicit-list only on the Python the image runs (3.10): is_global's
+    # view of the IANA special-purpose registries was corrected in 3.13.
+    "192.0.0.8",          # IPv4 dummy address (IETF protocol assignments block)
+    "192.88.99.1",        # deprecated 6to4 relay anycast
+    "64:ff9b:1::1",       # local-use IPv4/IPv6 translation
+    "2002:c000:204::1",   # 6to4
 ])
 @pytest.mark.asyncio
 async def test_special_use_addresses_are_blocked_by_is_global_or_the_explicit_list(mocker, ip):

--- a/app/services/tests/test_diagnostic_url_validation.py
+++ b/app/services/tests/test_diagnostic_url_validation.py
@@ -48,6 +48,9 @@ async def test_ipv6_multicast_is_blocked(mocker):
     "192.88.99.1",        # deprecated 6to4 relay anycast
     "64:ff9b:1::1",       # local-use IPv4/IPv6 translation
     "2002:c000:204::1",   # 6to4
+    # Registry entries newer than any pinned-era ipaddress knows about.
+    "3fff::1",            # documentation (RFC 9637)
+    "5f00::1",            # SRv6 SIDs (RFC 9602)
 ])
 @pytest.mark.asyncio
 async def test_special_use_addresses_are_blocked_by_is_global_or_the_explicit_list(mocker, ip):

--- a/app/services/tests/test_diagnostic_url_validation.py
+++ b/app/services/tests/test_diagnostic_url_validation.py
@@ -171,3 +171,27 @@ def test_redact_url_survives_garbage():
     from app.services.webhooks import _redact_url
 
     assert _redact_url("not a url at all") == "<no-host>"
+
+
+@pytest.mark.asyncio
+async def test_forward_failure_log_does_not_carry_the_url_secret(mocker, caplog):
+    """httpx embeds the request URL in its error text; logging str(e) would put
+    the path secret _redact_url hides straight back into the WARNING."""
+    import logging
+    import httpx
+    import app.services.webhooks as webhooks
+
+    secret_url = "https://hooks.slack.com/services/T000/B000/XXXXSECRET"
+    _mock_resolution(mocker, "93.184.216.34")
+    request = httpx.Request("POST", secret_url)
+    client = mocker.MagicMock()
+    client.post = AsyncMock(side_effect=httpx.HTTPStatusError(
+        f"Client error '404 Not Found' for url '{secret_url}'", request=request, response=httpx.Response(404, request=request),
+    ))
+    mocker.patch.object(webhooks, "_get_diagnostic_client", return_value=client)
+    caplog.set_level(logging.WARNING, logger="app.services.webhooks")
+
+    await webhooks.forward_payload_to_diagnostic_url(destination_url=secret_url, integration_id="abc", json_content={"a": 1})
+
+    assert "XXXXSECRET" not in caplog.text
+    assert "hooks.slack.com" in caplog.text and "HTTP 404" in caplog.text

--- a/app/services/tests/test_diagnostic_url_validation.py
+++ b/app/services/tests/test_diagnostic_url_validation.py
@@ -96,3 +96,37 @@ async def test_close_diagnostic_client_drains_in_flight_forwards(mocker):
     await closing
     assert finished[0] is True and finished[1] == "closed"
     assert mock_client.aclose.called
+
+
+@pytest.mark.parametrize(
+    "url, secret",
+    [
+        ("https://hooks.slack.com/services/T00000000/B00000000/abcdefSECRET", "abcdefSECRET"),
+        ("https://discord.com/api/webhooks/123456789/xyzSECRETtoken", "xyzSECRETtoken"),
+        ("https://user:pw@example.com/hook?token=querySECRET", "querySECRET"),
+    ],
+)
+def test_redact_url_drops_path_userinfo_and_query(url, secret):
+    """Slack, Discord and Teams incoming webhooks put the shared secret in the
+    URL *path*, so keeping the path would leak the credential this function
+    exists to protect."""
+    from app.services.webhooks import _redact_url
+
+    redacted = _redact_url(url)
+
+    assert secret not in redacted
+    assert "pw" not in redacted
+    # The host is still there, which is what makes the log line useful.
+    assert redacted in ("hooks.slack.com", "discord.com", "example.com")
+
+
+def test_redact_url_keeps_host_and_port():
+    from app.services.webhooks import _redact_url
+
+    assert _redact_url("https://example.com:8443/a/b?c=d") == "example.com:8443"
+
+
+def test_redact_url_survives_garbage():
+    from app.services.webhooks import _redact_url
+
+    assert _redact_url("not a url at all") == "<no-host>"

--- a/app/services/tests/test_diagnostic_url_validation.py
+++ b/app/services/tests/test_diagnostic_url_validation.py
@@ -98,6 +98,47 @@ async def test_close_diagnostic_client_drains_in_flight_forwards(mocker):
     assert mock_client.aclose.called
 
 
+@pytest.mark.asyncio
+async def test_close_diagnostic_client_cancels_forwards_that_outlive_the_drain_budget(mocker):
+    """An unbounded drain would hold lifespan shutdown until the platform's
+    SIGKILL, so the aclose() it protects would never run anyway."""
+    import app.services.webhooks as webhooks
+
+    async def _stuck():
+        await asyncio.Event().wait()
+
+    mock_client = mocker.MagicMock()
+    mock_client.aclose = mocker.AsyncMock()
+    mocker.patch.object(webhooks, "_diagnostic_client", mock_client)
+    mocker.patch.object(webhooks, "_SHUTDOWN_DRAIN_TIMEOUT_SECONDS", 0.05)
+    task = webhooks._spawn_background_task(_stuck())
+
+    await asyncio.wait_for(webhooks.close_diagnostic_client(), timeout=2)
+
+    assert task.cancelled()
+    assert mock_client.aclose.called
+    assert task not in webhooks._background_tasks
+
+
+@pytest.mark.asyncio
+async def test_hung_dns_resolution_is_rejected_not_awaited_forever(mocker):
+    """httpx's timeout does not cover getaddrinfo, which runs in the default
+    executor with no deadline; a hung resolver would pin the forward task (and
+    the shutdown drain) indefinitely."""
+    import app.services.webhooks as webhooks
+
+    async def _never(*args, **kwargs):
+        await asyncio.Event().wait()
+
+    mock_loop = mocker.MagicMock()
+    mock_loop.getaddrinfo = _never
+    mocker.patch("app.services.webhooks.asyncio.get_running_loop", return_value=mock_loop)
+    mocker.patch.object(webhooks, "_DNS_RESOLUTION_TIMEOUT_SECONDS", 0.05)
+
+    with pytest.raises(ValueError, match="Timed out resolving"):
+        await asyncio.wait_for(_validate_diagnostic_url("https://slow.example/hook"), timeout=2)
+
+
 @pytest.mark.parametrize(
     "url, secret",
     [

--- a/app/services/tests/test_diagnostic_url_validation.py
+++ b/app/services/tests/test_diagnostic_url_validation.py
@@ -6,15 +6,8 @@ import pytest
 from app.services.webhooks import _validate_diagnostic_url
 
 
-def _addrinfo(ip):
-    # Matches the (family, type, proto, canonname, sockaddr) shape returned by getaddrinfo.
-    return [(None, None, None, None, (ip, 443))]
-
-
 def _mock_resolution(mocker, ip):
-    mock_loop = mocker.MagicMock()
-    mock_loop.getaddrinfo = AsyncMock(return_value=_addrinfo(ip))
-    mocker.patch("app.services.url_policy.asyncio.get_running_loop", return_value=mock_loop)
+    mocker.patch("app.services.url_policy._resolve_addresses", AsyncMock(return_value=[ip]))
 
 
 @pytest.mark.asyncio
@@ -40,15 +33,18 @@ async def test_ipv6_multicast_is_blocked(mocker):
 
 
 @pytest.mark.parametrize("ip", [
+    # Caught by ip.is_global being False: not in the explicit blocklist, but not
+    # routable on the public internet either. A finite blocklist alone leaves
+    # these open.
     "198.18.0.1",    # benchmarking (RFC 2544), often routed internally
     "192.0.2.10",    # TEST-NET-1 documentation range
     "2001:db8::1",   # IPv6 documentation range
-    "fec0::1",       # deprecated IPv6 site-local; ipaddress still reports it is_global
+    # Caught by the explicit blocklist only: ipaddress reports the deprecated
+    # IPv6 site-local range as is_global, so the check above misses it.
+    "fec0::1",
 ])
 @pytest.mark.asyncio
-async def test_non_global_special_use_addresses_are_blocked(mocker, ip):
-    # Not in the explicit blocklist, but not routable on the public internet
-    # either (ip.is_global is False): a finite blocklist alone leaves these open.
+async def test_special_use_addresses_are_blocked_by_is_global_or_the_explicit_list(mocker, ip):
     _mock_resolution(mocker, ip)
     with pytest.raises(ValueError, match="private or reserved"):
         await _validate_diagnostic_url("https://example.com/hook")

--- a/app/services/tests/test_diagnostic_url_validation.py
+++ b/app/services/tests/test_diagnostic_url_validation.py
@@ -39,6 +39,20 @@ async def test_ipv6_multicast_is_blocked(mocker):
         await _validate_diagnostic_url("https://example.com/hook")
 
 
+@pytest.mark.parametrize("ip", [
+    "198.18.0.1",    # benchmarking (RFC 2544), often routed internally
+    "192.0.2.10",    # TEST-NET-1 documentation range
+    "2001:db8::1",   # IPv6 documentation range
+])
+@pytest.mark.asyncio
+async def test_non_global_special_use_addresses_are_blocked(mocker, ip):
+    # Not in the explicit blocklist, but not routable on the public internet
+    # either (ip.is_global is False): a finite blocklist alone leaves these open.
+    _mock_resolution(mocker, ip)
+    with pytest.raises(ValueError, match="private or reserved"):
+        await _validate_diagnostic_url("https://example.com/hook")
+
+
 @pytest.mark.asyncio
 async def test_public_address_is_allowed(mocker):
     _mock_resolution(mocker, "93.184.216.34")

--- a/app/services/tests/test_diagnostic_url_validation.py
+++ b/app/services/tests/test_diagnostic_url_validation.py
@@ -56,6 +56,23 @@ async def test_special_use_addresses_are_blocked_by_is_global_or_the_explicit_li
         await _validate_diagnostic_url("https://example.com/hook")
 
 
+@pytest.mark.parametrize("url", [
+    # A fullwidth "@" (U+FF20) in the authority: urlparse raises a ValueError
+    # that quotes the whole netloc, userinfo included.
+    "https://user:SECRET＠example.com/hook",
+    # An unterminated IPv6 literal fails inside urlparse too.
+    "https://user:SECRET@[::1/hook",
+])
+@pytest.mark.asyncio
+async def test_unparseable_url_is_rejected_without_echoing_the_authority(mocker, url):
+    # Both callers treat the policy's ValueError as safe, policy-authored text
+    # (the ephemeral path returns it with expose_message=True; diagnostic
+    # forwarding logs it), so the parser's own message must never pass through.
+    with pytest.raises(ValueError, match="could not be parsed") as info:
+        await _validate_diagnostic_url(url)
+    assert "SECRET" not in str(info.value)
+
+
 @pytest.mark.asyncio
 async def test_public_address_is_allowed(mocker):
     _mock_resolution(mocker, "93.184.216.34")

--- a/app/services/tests/test_diagnostic_url_validation.py
+++ b/app/services/tests/test_diagnostic_url_validation.py
@@ -43,6 +43,7 @@ async def test_ipv6_multicast_is_blocked(mocker):
     "198.18.0.1",    # benchmarking (RFC 2544), often routed internally
     "192.0.2.10",    # TEST-NET-1 documentation range
     "2001:db8::1",   # IPv6 documentation range
+    "fec0::1",       # deprecated IPv6 site-local; ipaddress still reports it is_global
 ])
 @pytest.mark.asyncio
 async def test_non_global_special_use_addresses_are_blocked(mocker, ip):

--- a/app/services/tests/test_diagnostic_url_validation.py
+++ b/app/services/tests/test_diagnostic_url_validation.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -42,3 +43,56 @@ async def test_ipv6_multicast_is_blocked(mocker):
 async def test_public_address_is_allowed(mocker):
     _mock_resolution(mocker, "93.184.216.34")
     await _validate_diagnostic_url("https://example.com/hook")
+
+
+@pytest.mark.asyncio
+async def test_background_forward_task_is_strongly_referenced(mocker):
+    """asyncio holds only a weak reference to a running task, so a bare
+    ensure_future() can be garbage-collected mid-flight and disappear silently."""
+    import app.services.webhooks as webhooks
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow():
+        started.set()
+        await release.wait()
+
+    task = webhooks._spawn_background_task(_slow())
+    await started.wait()
+    assert task in webhooks._background_tasks
+
+    release.set()
+    await task
+    # The done callback must drop the reference so the set can't grow forever.
+    assert task not in webhooks._background_tasks
+
+
+@pytest.mark.asyncio
+async def test_close_diagnostic_client_drains_in_flight_forwards(mocker):
+    """Closing the shared client out from under an in-flight forward would fail
+    every request still on the wire."""
+    import app.services.webhooks as webhooks
+
+    finished = []
+    release = asyncio.Event()
+
+    async def _slow():
+        await release.wait()
+        finished.append(True)
+
+    mock_client = mocker.MagicMock()
+    mock_client.aclose = mocker.AsyncMock(
+        side_effect=lambda: finished.append("closed")
+    )
+    mocker.patch.object(webhooks, "_diagnostic_client", mock_client)
+
+    webhooks._spawn_background_task(_slow())
+    closing = asyncio.ensure_future(webhooks.close_diagnostic_client())
+    await asyncio.sleep(0)  # let close() reach the drain
+    assert not finished, "client closed before the in-flight forward finished"
+
+    release.set()
+    await closing
+    assert finished[0] is True and finished[1] == "closed"
+    assert mock_client.aclose.called

--- a/app/services/tests/test_diagnostic_url_validation.py
+++ b/app/services/tests/test_diagnostic_url_validation.py
@@ -14,7 +14,7 @@ def _addrinfo(ip):
 def _mock_resolution(mocker, ip):
     mock_loop = mocker.MagicMock()
     mock_loop.getaddrinfo = AsyncMock(return_value=_addrinfo(ip))
-    mocker.patch("app.services.webhooks.asyncio.get_running_loop", return_value=mock_loop)
+    mocker.patch("app.services.url_policy.asyncio.get_running_loop", return_value=mock_loop)
 
 
 @pytest.mark.asyncio
@@ -125,15 +125,15 @@ async def test_hung_dns_resolution_is_rejected_not_awaited_forever(mocker):
     """httpx's timeout does not cover getaddrinfo, which runs in the default
     executor with no deadline; a hung resolver would pin the forward task (and
     the shutdown drain) indefinitely."""
-    import app.services.webhooks as webhooks
+    import app.services.url_policy as url_policy
 
     async def _never(*args, **kwargs):
         await asyncio.Event().wait()
 
     mock_loop = mocker.MagicMock()
     mock_loop.getaddrinfo = _never
-    mocker.patch("app.services.webhooks.asyncio.get_running_loop", return_value=mock_loop)
-    mocker.patch.object(webhooks, "_DNS_RESOLUTION_TIMEOUT_SECONDS", 0.05)
+    mocker.patch("app.services.url_policy.asyncio.get_running_loop", return_value=mock_loop)
+    mocker.patch.object(url_policy, "DNS_RESOLUTION_TIMEOUT_SECONDS", 0.05)
 
     with pytest.raises(ValueError, match="Timed out resolving"):
         await asyncio.wait_for(_validate_diagnostic_url("https://slow.example/hook"), timeout=2)

--- a/app/services/tests/test_errors.py
+++ b/app/services/tests/test_errors.py
@@ -10,7 +10,9 @@ from app.services.errors import (
     IntegrationConnectionError,
     IntegrationRateLimitError,
     IntegrationBadResponseError,
+    IntegrationConfigurationError,
     classify_error,
+    format_classified_error,
     format_error_message,
     source_status_code,
 )
@@ -23,6 +25,7 @@ from app.services.errors import (
         (IntegrationConnectionError, "connectivity", "Could not reach the provider"),
         (IntegrationRateLimitError, "rate_limit", "Rate limited by the provider"),
         (IntegrationBadResponseError, "bad_response", "Unexpected response from the provider"),
+        (IntegrationConfigurationError, "configuration", "Invalid configuration"),
     ],
 )
 def test_integration_error_subclasses_define_category(exception_class, expected_type, expected_title):
@@ -161,6 +164,20 @@ def test_format_omits_http_suffix_without_status_code():
     exc = IntegrationConnectionError("DNS lookup failed")
 
     assert format_error_message(exc) == "Could not reach the provider — DNS lookup failed"
+
+
+def test_format_can_omit_the_message_segment():
+    # The ephemeral path renders the same ClassifiedError without the message,
+    # which may carry str(exc) from the source. One renderer, one switch.
+    exc = IntegrationAuthError("TrackIt rejected the credentials", status_code=401)
+
+    assert format_classified_error(classify_error(exc), include_message=False) == "Authentication failed (HTTP 401)"
+
+
+def test_format_without_message_keeps_the_title_when_there_is_no_status():
+    exc = IntegrationConnectionError("DNS lookup failed")
+
+    assert format_classified_error(classify_error(exc), include_message=False) == "Could not reach the provider"
 
 
 def test_classify_builtin_timeout_as_connectivity():

--- a/app/services/tests/test_errors.py
+++ b/app/services/tests/test_errors.py
@@ -12,6 +12,7 @@ from app.services.errors import (
     IntegrationBadResponseError,
     classify_error,
     format_error_message,
+    source_status_code,
 )
 
 
@@ -171,6 +172,30 @@ def test_classify_builtin_timeout_as_connectivity():
         classified = classify_error(exc)
         assert classified is not None
         assert classified.error_type == "connectivity"
+
+
+@pytest.mark.parametrize(
+    "exc,expected",
+    [
+        (_http_status_error(404), 404),
+        (IntegrationAuthError("nope", status_code=401), 401),
+        (IntegrationAuthError("nope"), None),
+        (ValueError("no response here"), None),
+    ],
+)
+def test_source_status_code_reads_every_carrier(exc, expected):
+    assert source_status_code(exc) == expected
+
+
+@pytest.mark.parametrize("junk", ["401", True, 4.01, None])
+def test_source_status_code_ignores_non_int_status(junk):
+    # Connector hierarchies pre-set status_code freely; anything that is not
+    # an int reads as unknown instead of raising later on a comparison.
+    exc = IntegrationBadResponseError("odd")
+    exc.status_code = junk
+
+    assert source_status_code(exc) is None
+    assert classify_error(exc).status_code is None
 
 
 def test_classify_error_reads_aiohttp_response_status():

--- a/app/services/tests/test_errors.py
+++ b/app/services/tests/test_errors.py
@@ -1,5 +1,4 @@
 import asyncio
-from unittest.mock import MagicMock
 
 import aiohttp
 import httpx
@@ -199,41 +198,25 @@ def test_source_status_code_ignores_non_int_status(junk):
     assert classify_error(exc).status_code is None
 
 
-def test_classify_error_reads_aiohttp_response_status():
-    # aiohttp carries the status on .status, not .response.status_code; the
-    # classifier must give its 401/403/429/5xx the same verdict httpx gets.
-    import aiohttp
+@pytest.mark.parametrize(
+    "status, expected_type",
+    [(401, "auth"), (403, "auth"), (429, "rate_limit"), (503, "bad_response")],
+)
+def test_classify_error_reads_aiohttp_response_status(status, expected_type):
+    # aiohttp carries the status on .status, not .response.status_code, and has
+    # no .response at all; the classifier must give its 401/403/429/5xx the
+    # same verdict httpx gets, or every aiohttp connector's HTTP failures go
+    # unclassified.
     from multidict import CIMultiDict, CIMultiDictProxy
     from yarl import URL
-    from app.services.errors import classify_error
 
     request_info = aiohttp.RequestInfo(
         url=URL("https://source.example/me"), method="GET",
         headers=CIMultiDictProxy(CIMultiDict()), real_url=URL("https://source.example/me"),
     )
-    exc = aiohttp.ClientResponseError(request_info, (), status=429, message="Too Many Requests")
+    exc = aiohttp.ClientResponseError(request_info, (), status=status, message="boom")
 
     classified = classify_error(exc)
-
-    assert classified is not None
-    assert classified.error_type == "rate_limit"
-    assert classified.status_code == 429
-
-def _aiohttp_response_error(status: int, message: str) -> aiohttp.ClientResponseError:
-    return aiohttp.ClientResponseError(
-        request_info=MagicMock(), history=(), status=status, message=message
-    )
-
-
-@pytest.mark.parametrize(
-    "status, expected_type",
-    [(401, "auth"), (403, "auth"), (429, "rate_limit"), (503, "bad_response")],
-)
-def test_classify_aiohttp_response_error_by_status_attribute(status, expected_type):
-    """aiohttp.ClientResponseError carries the code on the exception itself as
-    `.status` and has no `.response` at all, so a `.status_code`-only lookup
-    leaves every aiohttp connector's HTTP failures unclassified."""
-    classified = classify_error(_aiohttp_response_error(status, "boom"))
 
     assert classified is not None
     assert classified.error_type == expected_type

--- a/app/services/tests/test_errors.py
+++ b/app/services/tests/test_errors.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import MagicMock
 
 import aiohttp
 import httpx
@@ -217,3 +218,23 @@ def test_classify_error_reads_aiohttp_response_status():
     assert classified is not None
     assert classified.error_type == "rate_limit"
     assert classified.status_code == 429
+
+def _aiohttp_response_error(status: int, message: str) -> aiohttp.ClientResponseError:
+    return aiohttp.ClientResponseError(
+        request_info=MagicMock(), history=(), status=status, message=message
+    )
+
+
+@pytest.mark.parametrize(
+    "status, expected_type",
+    [(401, "auth"), (403, "auth"), (429, "rate_limit"), (503, "bad_response")],
+)
+def test_classify_aiohttp_response_error_by_status_attribute(status, expected_type):
+    """aiohttp.ClientResponseError carries the code on the exception itself as
+    `.status` and has no `.response` at all, so a `.status_code`-only lookup
+    leaves every aiohttp connector's HTTP failures unclassified."""
+    classified = classify_error(_aiohttp_response_error(status, "boom"))
+
+    assert classified is not None
+    assert classified.error_type == expected_type
+    assert classified.status_code == status

--- a/app/services/tests/test_errors.py
+++ b/app/services/tests/test_errors.py
@@ -171,3 +171,24 @@ def test_classify_builtin_timeout_as_connectivity():
         classified = classify_error(exc)
         assert classified is not None
         assert classified.error_type == "connectivity"
+
+
+def test_classify_error_reads_aiohttp_response_status():
+    # aiohttp carries the status on .status, not .response.status_code; the
+    # classifier must give its 401/403/429/5xx the same verdict httpx gets.
+    import aiohttp
+    from multidict import CIMultiDict, CIMultiDictProxy
+    from yarl import URL
+    from app.services.errors import classify_error
+
+    request_info = aiohttp.RequestInfo(
+        url=URL("https://source.example/me"), method="GET",
+        headers=CIMultiDictProxy(CIMultiDict()), real_url=URL("https://source.example/me"),
+    )
+    exc = aiohttp.ClientResponseError(request_info, (), status=429, message="Too Many Requests")
+
+    classified = classify_error(exc)
+
+    assert classified is not None
+    assert classified.error_type == "rate_limit"
+    assert classified.status_code == 429

--- a/app/services/tests/test_gundi_api.py
+++ b/app/services/tests/test_gundi_api.py
@@ -182,8 +182,10 @@ def test_gundi_api_retry_policy_is_explicit_and_reachable():
 
 
 def test_all_gundi_api_calls_share_one_retry_policy():
-    """Five call sites previously repeated the same decorator by hand, which is
-    how the wait curve and the stop condition drifted apart in the first place."""
+    """Six call sites previously repeated the same decorator by hand, which is
+    how the wait curve and the stop condition drifted apart in the first place.
+    Five are the helpers in gundi.py; the sixth is the webhook path's
+    integration lookup, which retries the same Gundi API inline."""
     import re
     from pathlib import Path
 
@@ -191,3 +193,8 @@ def test_all_gundi_api_calls_share_one_retry_policy():
     decorators = re.findall(r"@stamina\.retry\((.*?)\)\n", source)
     assert decorators, "expected retry-decorated functions in app/services/gundi.py"
     assert all(d.strip() == "**GUNDI_API_RETRY" for d in decorators), decorators
+
+    webhooks_source = Path("app/services/webhooks.py").read_text()
+    contexts = re.findall(r"stamina\.retry_context\((.*?)\)", webhooks_source)
+    assert contexts, "expected a retry_context in app/services/webhooks.py"
+    assert all(c.strip() == "**GUNDI_API_RETRY" for c in contexts), contexts

--- a/app/services/tests/test_gundi_api.py
+++ b/app/services/tests/test_gundi_api.py
@@ -151,3 +151,43 @@ async def test_gundi_helpers_block_on_ephemeral_run(fn_and_args):
             await fn(**args)
     finally:
         ephemeral_run.reset(token)
+
+
+def test_gundi_api_retry_policy_is_explicit_and_reachable():
+    """stamina combines `attempts` and `timeout` with stop_any(), so the tighter
+    one wins. Its defaults (attempts=10, timeout=45s) silently truncate a long
+    backoff: with wait_initial=10 the 45s budget is spent after ~3 attempts and
+    wait_max is never reached. Both bounds must be declared explicitly, and the
+    timeout must be wide enough for the declared wait curve to actually play out."""
+    from app.services.gundi import GUNDI_API_RETRY
+
+    attempts = GUNDI_API_RETRY["attempts"]
+    timeout = GUNDI_API_RETRY["timeout"]
+    wait_initial = GUNDI_API_RETRY["wait_initial"]
+    wait_max = GUNDI_API_RETRY["wait_max"]
+    assert attempts is not None and timeout is not None
+
+    # Worst case (no jitter contribution needed -- jitter only adds delay), how
+    # many attempts fit inside the timeout?
+    elapsed, fits = 0.0, 1
+    while fits < attempts:
+        elapsed += min(wait_initial * (2 ** (fits - 1)), wait_max)
+        if elapsed >= timeout:
+            break
+        fits += 1
+    assert fits >= 5, (
+        f"retry budget allows only {fits} attempts before the {timeout}s timeout; "
+        "the declared backoff is mostly unreachable"
+    )
+
+
+def test_all_gundi_api_calls_share_one_retry_policy():
+    """Five call sites previously repeated the same decorator by hand, which is
+    how the wait curve and the stop condition drifted apart in the first place."""
+    import re
+    from pathlib import Path
+
+    source = Path("app/services/gundi.py").read_text()
+    decorators = re.findall(r"@stamina\.retry\((.*?)\)\n", source)
+    assert decorators, "expected retry-decorated functions in app/services/gundi.py"
+    assert all(d.strip() == "**GUNDI_API_RETRY" for d in decorators), decorators

--- a/app/services/tests/test_gundi_api.py
+++ b/app/services/tests/test_gundi_api.py
@@ -1,5 +1,13 @@
 import pytest
-from app.services.gundi import send_events_to_gundi, send_observations_to_gundi, send_event_attachments_to_gundi
+from app.services.gundi import (
+    send_events_to_gundi,
+    send_observations_to_gundi,
+    send_event_attachments_to_gundi,
+    send_messages_to_gundi,
+    _get_gundi_api_key,
+    EphemeralWriteBlocked,
+)
+from app.services.activity_logger import ephemeral_run
 
 
 @pytest.mark.asyncio
@@ -121,3 +129,25 @@ async def test_send_observations_to_gundi(
     assert len(response) == 2
     assert mock_gundi_sensors_client_class.called
     mock_gundi_sensors_client_class.return_value.post_observations.assert_called_once_with(data=observations)
+
+
+@pytest.mark.parametrize("fn_and_args", [
+    (send_events_to_gundi, {"events": [], "integration_id": "id"}),
+    (send_observations_to_gundi, {"observations": [], "integration_id": "id"}),
+    (send_event_attachments_to_gundi, {"event_id": "e", "attachments": [], "integration_id": "id"}),
+    (send_messages_to_gundi, {"messages": [], "integration_id": "id"}),
+    (_get_gundi_api_key, {"integration_id": "id"}),
+])
+@pytest.mark.asyncio
+async def test_gundi_helpers_block_on_ephemeral_run(fn_and_args):
+    # A reference handler running against a draft integration must not be
+    # able to move data through Gundi (design invariant: reference actions
+    # are read-only). Each entry point checks the contextvar and raises
+    # before doing any I/O.
+    fn, args = fn_and_args
+    token = ephemeral_run.set(True)
+    try:
+        with pytest.raises(EphemeralWriteBlocked):
+            await fn(**args)
+    finally:
+        ephemeral_run.reset(token)

--- a/app/services/tests/test_gundi_api.py
+++ b/app/services/tests/test_gundi_api.py
@@ -214,6 +214,16 @@ def test_all_gundi_api_helpers_share_one_retry_policy():
     assert all(d == "**GUNDI_API_RETRY" for d in decorators), decorators
 
 
+def test_api_key_lookup_is_not_retried_on_its_own():
+    """_get_gundi_api_key runs inside the send helpers' retry; a decorator of
+    its own would nest a second GUNDI_API_RETRY inside the first and restart
+    the inner attempts on every outer one, so a failing portal would cost up to
+    36 calls instead of 6 and blow the loop-overhead bound the tests above pin."""
+    assert not hasattr(_get_gundi_api_key, "__wrapped__")
+    for helper in (send_events_to_gundi, send_observations_to_gundi, send_event_attachments_to_gundi, send_messages_to_gundi):
+        assert hasattr(helper, "__wrapped__"), helper.__name__
+
+
 @pytest.mark.asyncio
 async def test_config_manager_reload_uses_the_shared_gundi_retry_policy(
         mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,

--- a/app/services/tests/test_gundi_api.py
+++ b/app/services/tests/test_gundi_api.py
@@ -1,3 +1,7 @@
+from unittest.mock import AsyncMock
+import httpx
+from pathlib import Path
+import re
 import pytest
 from app.services.gundi import (
     send_events_to_gundi,
@@ -153,48 +157,106 @@ async def test_gundi_helpers_block_on_ephemeral_run(fn_and_args):
         ephemeral_run.reset(token)
 
 
-def test_gundi_api_retry_policy_is_explicit_and_reachable():
+def _worst_case_waits(policy: dict) -> list:
+    """The sleeps tenacity performs between attempts when every jitter draw is
+    maximal: min(initial * 2**n + jitter, max) for n = 0 .. attempts-2."""
+    return [
+        min(policy["wait_initial"] * 2 ** n + policy["wait_jitter"], policy["wait_max"])
+        for n in range(policy["attempts"] - 1)
+    ]
+
+
+def test_gundi_api_retry_policy_reaches_every_declared_attempt():
     """stamina combines `attempts` and `timeout` with stop_any(), so the tighter
-    one wins. Its defaults (attempts=10, timeout=45s) silently truncate a long
-    backoff: with wait_initial=10 the 45s budget is spent after ~3 attempts and
-    wait_max is never reached. Both bounds must be declared explicitly, and the
-    timeout must be wide enough for the declared wait curve to actually play out."""
+    one wins. A policy whose waits add up to more than its timeout declares
+    attempts (and a wait_max) it can never reach; the effective policy is then
+    whatever the timeout happens to allow, which is how the old 10-20-40 s
+    curve silently ran three attempts under stamina's default 45 s budget."""
     from app.services.gundi import GUNDI_API_RETRY
 
-    attempts = GUNDI_API_RETRY["attempts"]
-    timeout = GUNDI_API_RETRY["timeout"]
-    wait_initial = GUNDI_API_RETRY["wait_initial"]
-    wait_max = GUNDI_API_RETRY["wait_max"]
-    assert attempts is not None and timeout is not None
+    assert GUNDI_API_RETRY["attempts"] and GUNDI_API_RETRY["timeout"], "both stops must be explicit"
+    waits = _worst_case_waits(GUNDI_API_RETRY)
 
-    # Worst case (no jitter contribution needed -- jitter only adds delay), how
-    # many attempts fit inside the timeout?
-    elapsed, fits = 0.0, 1
-    while fits < attempts:
-        elapsed += min(wait_initial * (2 ** (fits - 1)), wait_max)
-        if elapsed >= timeout:
-            break
-        fits += 1
-    assert fits >= 5, (
-        f"retry budget allows only {fits} attempts before the {timeout}s timeout; "
-        "the declared backoff is mostly unreachable"
+    # Even with maximal jitter and instant calls, every declared attempt runs.
+    assert sum(waits) <= GUNDI_API_RETRY["timeout"], (
+        f"waits total {sum(waits)}s, more than the {GUNDI_API_RETRY['timeout']}s budget: "
+        f"only part of the declared {GUNDI_API_RETRY['attempts']} attempts can ever run"
     )
+    # wait_max is a real cap on the curve, not a decorative number.
+    assert waits[-1] == GUNDI_API_RETRY["wait_max"]
 
 
-def test_all_gundi_api_calls_share_one_retry_policy():
-    """Six call sites previously repeated the same decorator by hand, which is
-    how the wait curve and the stop condition drifted apart in the first place.
-    Five are the helpers in gundi.py; the sixth is the webhook path's
-    integration lookup, which retries the same Gundi API inline."""
-    import re
-    from pathlib import Path
+def test_gundi_api_retry_worst_case_fits_inside_one_request():
+    """tenacity's stop_after_delay is checked after a failed attempt and then the
+    full wait is slept, so one failing call can hold its caller for up to
+    timeout + wait_max, plus the request itself. PubSub messages are processed
+    inline in the push request by default (PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND
+    is False), so that ceiling has to leave room under the push ack deadline
+    and Cloud Run's default 300 s request timeout for the handler's own work."""
+    from app.services.gundi import GUNDI_API_RETRY
 
-    source = Path("app/services/gundi.py").read_text()
-    decorators = re.findall(r"@stamina\.retry\((.*?)\)\n", source)
-    assert decorators, "expected retry-decorated functions in app/services/gundi.py"
-    assert all(d.strip() == "**GUNDI_API_RETRY" for d in decorators), decorators
+    ceiling = GUNDI_API_RETRY["timeout"] + GUNDI_API_RETRY["wait_max"]
+    assert ceiling <= 150, f"a single failing Gundi call may hold a request for {ceiling}s"
 
-    webhooks_source = Path("app/services/webhooks.py").read_text()
-    contexts = re.findall(r"stamina\.retry_context\((.*?)\)", webhooks_source)
-    assert contexts, "expected a retry_context in app/services/webhooks.py"
-    assert all(c.strip() == "**GUNDI_API_RETRY" for c in contexts), contexts
+
+_SERVICES_DIR = Path(__file__).resolve().parents[1]
+
+
+def test_all_gundi_api_helpers_share_one_retry_policy():
+    """The helpers used to repeat the same decorator by hand, which is how the
+    wait curve and the stop condition drifted apart in the first place. Source
+    inspection is the only way to check decorators applied at import time; the
+    config-manager reload is checked behaviourally below."""
+    source = (_SERVICES_DIR / "gundi.py").read_text()
+    decorators = re.findall(r"@stamina\.retry\(\s*([^)]*?)\s*\)", source)
+    assert decorators, "expected retry-decorated functions in gundi.py"
+    assert all(d == "**GUNDI_API_RETRY" for d in decorators), decorators
+
+
+@pytest.mark.asyncio
+async def test_config_manager_reload_uses_the_shared_gundi_retry_policy(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    """_reload_integration_from_gundi is a Gundi API call like the helpers; its
+    retry must be the same policy, checked by spying on the call rather than
+    grepping source."""
+    import stamina
+    from app.services.config_manager import IntegrationConfigurationManager
+    from app.services.gundi import GUNDI_API_RETRY
+
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    spy = mocker.spy(stamina, "retry_context")
+
+    await IntegrationConfigurationManager().get_integration(str(integration_v2.id))
+
+    http_policies = [c.kwargs for c in spy.call_args_list if c.kwargs.get("on") is httpx.HTTPError]
+    assert http_policies, "expected the reload to retry on httpx.HTTPError"
+    assert all(kw == GUNDI_API_RETRY for kw in http_policies), http_policies
+
+
+@pytest.mark.asyncio
+async def test_webhook_integration_lookup_does_not_add_its_own_retry_loop(mocker):
+    """get_integration used to wrap get_integration_details in a second retry
+    loop. The reload inside already retries the same call, so the two nested
+    multiplicatively; worse, the outer loop iterated stamina synchronously
+    inside a coroutine, sleeping the whole event loop between attempts. One
+    call to get_integration_details per lookup, and the failure is reported."""
+    from unittest.mock import MagicMock
+    import app.services.webhooks as webhooks
+    from gundi_core.events import IntegrationWebhookFailed
+
+    lookup = mocker.patch.object(
+        webhooks.config_manager, "get_integration_details",
+        AsyncMock(side_effect=httpx.ConnectError("portal unreachable")),
+    )
+    publish = mocker.patch.object(webhooks, "publish_event", AsyncMock())
+    request = MagicMock()
+    request.headers = {"x-gundi-integration-id": "abc-123"}
+    request.query_params = {}
+
+    integration = await webhooks.get_integration(request)
+
+    assert integration is None
+    assert lookup.await_count == 1
+    assert isinstance(publish.call_args.kwargs["event"], IntegrationWebhookFailed)

--- a/app/services/tests/test_gundi_api.py
+++ b/app/services/tests/test_gundi_api.py
@@ -186,17 +186,18 @@ def test_gundi_api_retry_policy_reaches_every_declared_attempt():
     assert waits[-1] == GUNDI_API_RETRY["wait_max"]
 
 
-def test_gundi_api_retry_worst_case_fits_inside_one_request():
+def test_gundi_api_retry_loop_overhead_is_bounded():
     """tenacity's stop_after_delay is checked after a failed attempt and then the
-    full wait is slept, so one failing call can hold its caller for up to
-    timeout + wait_max, plus the request itself. PubSub messages are processed
-    inline in the push request by default (PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND
-    is False), so that ceiling has to leave room under the push ack deadline
-    and Cloud Run's default 300 s request timeout for the handler's own work."""
+    full wait is slept, so the retry loop's own overhead for one failing call is
+    bounded by timeout + wait_max. This does not include the requests: the
+    sensors client's httpx timeout is 120 s per attempt, so a hanging API adds
+    up to that per attempt on top. PubSub messages are processed inline in the
+    push request by default (PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND is False),
+    so the loop's share of the budget has to stay small."""
     from app.services.gundi import GUNDI_API_RETRY
 
-    ceiling = GUNDI_API_RETRY["timeout"] + GUNDI_API_RETRY["wait_max"]
-    assert ceiling <= 150, f"a single failing Gundi call may hold a request for {ceiling}s"
+    overhead = GUNDI_API_RETRY["timeout"] + GUNDI_API_RETRY["wait_max"]
+    assert overhead <= 150, f"the retry loop alone may hold a request for {overhead}s before any request time"
 
 
 _SERVICES_DIR = Path(__file__).resolve().parents[1]

--- a/app/services/tests/test_gundi_api.py
+++ b/app/services/tests/test_gundi_api.py
@@ -8,6 +8,7 @@ from app.services.gundi import (
     send_observations_to_gundi,
     send_event_attachments_to_gundi,
     send_messages_to_gundi,
+    update_event_in_gundi,
     _get_gundi_api_key,
     EphemeralWriteBlocked,
 )
@@ -140,6 +141,7 @@ async def test_send_observations_to_gundi(
     (send_observations_to_gundi, {"observations": [], "integration_id": "id"}),
     (send_event_attachments_to_gundi, {"event_id": "e", "attachments": [], "integration_id": "id"}),
     (send_messages_to_gundi, {"messages": [], "integration_id": "id"}),
+    (update_event_in_gundi, {"gundi_object_id": "g", "changes": {}, "integration_id": "id"}),
     (_get_gundi_api_key, {"integration_id": "id"}),
 ])
 @pytest.mark.asyncio

--- a/app/services/tests/test_self_registration.py
+++ b/app/services/tests/test_self_registration.py
@@ -784,3 +784,57 @@ async def test_crontab_schedule_decorator(
         tz_offset=0
     )
     assert action_pull_observations.crontab_schedule == expected_schedule
+
+
+def test_action_type_enum_has_reference():
+    from app.services.core import ActionTypeEnum
+
+    assert ActionTypeEnum.REFERENCE.value == "reference"
+
+
+def _dummy_reference_handlers():
+    from app.actions.core import ReferenceActionConfiguration
+
+    class DummyQuery(ReferenceActionConfiguration):
+        pass
+
+    async def action_list_dummy(integration, action_config: DummyQuery):
+        return {"options": []}
+
+    return {"list_dummy": (action_list_dummy, DummyQuery, None)}
+
+
+@pytest.mark.asyncio
+async def test_reference_actions_skipped_from_registration_by_default(mocker):
+    # Same gate the earthranger and inaturalist forks ship: until the platform
+    # accepts the "reference" action type, reference actions stay out of the
+    # registered type so they never land as "generic".
+    from unittest.mock import AsyncMock, MagicMock
+    from app.services import self_registration
+
+    mocker.patch.object(self_registration, "action_handlers", _dummy_reference_handlers())
+    gundi_client = MagicMock()
+    gundi_client.register_integration_type = AsyncMock(return_value={})
+
+    await self_registration.register_integration_in_gundi(gundi_client, type_slug="my_tracker")
+
+    data = gundi_client.register_integration_type.call_args.args[0]
+    assert data["actions"] == []
+
+
+@pytest.mark.asyncio
+async def test_reference_actions_registered_with_reference_type_when_enabled(mocker):
+    from unittest.mock import AsyncMock, MagicMock
+    from app.services import self_registration
+
+    mocker.patch.object(self_registration, "action_handlers", _dummy_reference_handlers())
+    mocker.patch.object(self_registration, "REGISTER_REFERENCE_ACTIONS", True)
+    gundi_client = MagicMock()
+    gundi_client.register_integration_type = AsyncMock(return_value={})
+
+    await self_registration.register_integration_in_gundi(gundi_client, type_slug="my_tracker")
+
+    data = gundi_client.register_integration_type.call_args.args[0]
+    assert [a["value"] for a in data["actions"]] == ["list_dummy"]
+    assert data["actions"][0]["type"] == "reference"
+    assert data["actions"][0]["is_periodic_action"] is False

--- a/app/services/tests/test_self_registration.py
+++ b/app/services/tests/test_self_registration.py
@@ -805,30 +805,14 @@ def _dummy_reference_handlers():
 
 
 @pytest.mark.asyncio
-async def test_reference_actions_skipped_from_registration_by_default(mocker):
-    # Same gate the earthranger and inaturalist forks ship: until the platform
-    # accepts the "reference" action type, reference actions stay out of the
-    # registered type so they never land as "generic".
+async def test_reference_actions_are_registered_with_the_reference_type(mocker):
+    # The platform accepts the "reference" action type, so reference actions
+    # always register, and with their own type rather than "generic" (which
+    # the runner's ephemeral whitelist would otherwise be the only guard for).
     from unittest.mock import AsyncMock, MagicMock
     from app.services import self_registration
 
     mocker.patch.object(self_registration, "action_handlers", _dummy_reference_handlers())
-    gundi_client = MagicMock()
-    gundi_client.register_integration_type = AsyncMock(return_value={})
-
-    await self_registration.register_integration_in_gundi(gundi_client, type_slug="my_tracker")
-
-    data = gundi_client.register_integration_type.call_args.args[0]
-    assert data["actions"] == []
-
-
-@pytest.mark.asyncio
-async def test_reference_actions_registered_with_reference_type_when_enabled(mocker):
-    from unittest.mock import AsyncMock, MagicMock
-    from app.services import self_registration
-
-    mocker.patch.object(self_registration, "action_handlers", _dummy_reference_handlers())
-    mocker.patch.object(self_registration, "REGISTER_REFERENCE_ACTIONS", True)
     gundi_client = MagicMock()
     gundi_client.register_integration_type = AsyncMock(return_value={})
 

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -208,3 +208,61 @@ async def test_set_state_noops_on_ephemeral_run(mocker, mock_redis):
         ephemeral_run.reset(token)
 
     mock_redis.Redis.return_value.set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_if_absent_noops_on_ephemeral_run(mocker, mock_redis):
+    # Same invariant as set_state: no Redis writes under a synthetic
+    # integration id. Returns False ("not set by this call") so a throttle
+    # caller treats the window as already taken and stays quiet.
+    from app.services.activity_logger import ephemeral_run
+    mocker.patch("app.services.state.redis", mock_redis)
+    state_manager = IntegrationStateManager()
+
+    token = ephemeral_run.set(True)
+    try:
+        was_set = await state_manager.set_if_absent(
+            integration_id="synthetic-uuid", action_id="pull_observations", ttl_seconds=60,
+        )
+    finally:
+        ephemeral_run.reset(token)
+
+    assert was_set is False
+    mock_redis.Redis.return_value.set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_state_noops_on_ephemeral_run(mocker, mock_redis):
+    from app.services.activity_logger import ephemeral_run
+    mocker.patch("app.services.state.redis", mock_redis)
+    state_manager = IntegrationStateManager()
+
+    token = ephemeral_run.set(True)
+    try:
+        await state_manager.delete_state(integration_id="synthetic-uuid", action_id="pull_observations")
+    finally:
+        ephemeral_run.reset(token)
+
+    mock_redis.Redis.return_value.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_state_noops_leave_a_debug_trace(mocker, mock_redis, caplog):
+    # A handler that writes then reads state in the same ephemeral run gets
+    # {} back and fails in a way that looks unrelated; the log line is the
+    # only clue that the write was suppressed.
+    import logging
+    from app.services.activity_logger import ephemeral_run
+    mocker.patch("app.services.state.redis", mock_redis)
+    state_manager = IntegrationStateManager()
+    caplog.set_level(logging.DEBUG, logger="app.services.state")
+
+    token = ephemeral_run.set(True)
+    try:
+        await state_manager.set_state(
+            integration_id="synthetic-uuid", action_id="auth", state={"token": "t"},
+        )
+    finally:
+        ephemeral_run.reset(token)
+
+    assert any("ephemeral" in r.getMessage().lower() for r in caplog.records)

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -185,3 +185,26 @@ async def test_delete_state_source_state(mocker, mock_redis, integration_v2, moc
     mock_redis.Redis.return_value.delete.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.{source_id}"
     )
+
+
+@pytest.mark.asyncio
+async def test_set_state_noops_on_ephemeral_run(mocker, mock_redis):
+    # Ephemeral runs synthesize a fresh integration id per call. Persisting
+    # state under it would create a permanent orphan (this key carries no
+    # TTL). set_state must silently no-op so a well-meaning-but-buggy
+    # reference or auth handler can't leak watermarks into Redis.
+    from app.services.activity_logger import ephemeral_run
+    mocker.patch("app.services.state.redis", mock_redis)
+    state_manager = IntegrationStateManager()
+
+    token = ephemeral_run.set(True)
+    try:
+        await state_manager.set_state(
+            integration_id="synthetic-uuid",
+            action_id="pull_observations",
+            state={"last_execution": "irrelevant"},
+        )
+    finally:
+        ephemeral_run.reset(token)
+
+    mock_redis.Redis.return_value.set.assert_not_called()

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -266,3 +266,29 @@ async def test_ephemeral_state_noops_leave_a_debug_trace(mocker, mock_redis, cap
         ephemeral_run.reset(token)
 
     assert any("ephemeral" in r.getMessage().lower() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_state_redis_retry_backoff_does_not_block_the_event_loop(mocker, mock_redis, integration_v2):
+    """stamina's sync iterator sleeps with time.sleep between attempts; inside a
+    coroutine that freezes every other request on the worker. All four state
+    calls must iterate asynchronously."""
+    from unittest.mock import AsyncMock
+    import redis.asyncio as redis
+    from app.conftest import async_return
+    from app.services.state import IntegrationStateManager
+    calls = {"n": 0}
+    def flaky_get(key):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise redis.RedisError("flap")
+        return async_return(None)
+    mock_redis.Redis.return_value.get.side_effect = flaky_get
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("time.sleep", side_effect=AssertionError("retry back-off blocked the event loop"))
+    mocker.patch("asyncio.sleep", AsyncMock())
+
+    state = await IntegrationStateManager().get_state(str(integration_v2.id), "pull_observations")
+
+    assert state == {}
+    assert calls["n"] == 2

--- a/app/services/url_policy.py
+++ b/app/services/url_policy.py
@@ -28,6 +28,7 @@ BLOCKED_NETWORKS = [
     ipaddress.ip_network("192.168.0.0/16"),   # RFC 1918 private
     ipaddress.ip_network("169.254.0.0/16"),   # link-local / cloud metadata (AWS, GCP)
     ipaddress.ip_network("fe80::/10"),        # IPv6 link-local
+    ipaddress.ip_network("fec0::/10"),        # deprecated IPv6 site-local; ipaddress still reports it is_global
     ipaddress.ip_network("fc00::/7"),         # IPv6 unique local
     ipaddress.ip_network("0.0.0.0/8"),        # unspecified
     ipaddress.ip_network("100.64.0.0/10"),    # carrier-grade NAT

--- a/app/services/url_policy.py
+++ b/app/services/url_policy.py
@@ -48,6 +48,11 @@ BLOCKED_NETWORKS = [
     ipaddress.ip_network("192.175.48.0/24"),  # direct delegation AS112
     ipaddress.ip_network("64:ff9b:1::/48"),   # local-use IPv4/IPv6 translation
     ipaddress.ip_network("2002::/16"),        # 6to4
+    # Registry entries newer than any pinned-era ipaddress knows about. The
+    # IANA special-purpose registries are the source of truth for this list;
+    # re-check them when bumping the Python image.
+    ipaddress.ip_network("3fff::/20"),        # documentation (RFC 9637)
+    ipaddress.ip_network("5f00::/16"),        # SRv6 SIDs (RFC 9602)
 ]
 
 

--- a/app/services/url_policy.py
+++ b/app/services/url_policy.py
@@ -1,0 +1,79 @@
+"""Outbound URL policy: refuse a URL that would make the runner connect to a
+loopback, private, link-local (cloud metadata) or otherwise reserved address.
+
+Shared by the diagnostic-URL forwarding in webhooks.py and, when
+EPHEMERAL_BASE_URL_BLOCK_PRIVATE_ADDRESSES is on, the draft base_url check on
+the ephemeral path in action_runner.py.
+
+This is a best-effort defence. httpx re-resolves DNS at request time, so a
+rebinding attack can still reach a private address after the check passes
+(TOCTOU); restrict outbound network access at the infrastructure level as
+well for a complete mitigation.
+"""
+import asyncio
+import ipaddress
+from typing import Iterable
+from urllib.parse import urlparse
+
+# Bound on the resolver call. httpx's timeout is per phase of its own request
+# and does not cover getaddrinfo, which runs in the default executor with no
+# deadline of its own.
+DNS_RESOLUTION_TIMEOUT_SECONDS = 5.0
+
+BLOCKED_NETWORKS = [
+    ipaddress.ip_network("127.0.0.0/8"),    # loopback
+    ipaddress.ip_network("::1/128"),          # IPv6 loopback
+    ipaddress.ip_network("10.0.0.0/8"),       # RFC 1918 private
+    ipaddress.ip_network("172.16.0.0/12"),    # RFC 1918 private
+    ipaddress.ip_network("192.168.0.0/16"),   # RFC 1918 private
+    ipaddress.ip_network("169.254.0.0/16"),   # link-local / cloud metadata (AWS, GCP)
+    ipaddress.ip_network("fe80::/10"),        # IPv6 link-local
+    ipaddress.ip_network("fc00::/7"),         # IPv6 unique local
+    ipaddress.ip_network("0.0.0.0/8"),        # unspecified
+    ipaddress.ip_network("100.64.0.0/10"),    # carrier-grade NAT
+    ipaddress.ip_network("224.0.0.0/4"),      # multicast
+    ipaddress.ip_network("240.0.0.0/4"),      # reserved
+    ipaddress.ip_network("::/128"),           # IPv6 unspecified
+    ipaddress.ip_network("ff00::/8"),         # IPv6 multicast
+]
+
+
+async def validate_outbound_url(url: str, *, allowlist: Iterable[str] = (), what: str = "URL") -> None:
+    """Raise ValueError unless `url` is https, has a hostname, is in `allowlist`
+    when one is given, and resolves only to public addresses.
+
+    `what` names the URL in the messages ("diagnostic URL", "draft base_url");
+    they carry the hostname and the resolved address, never the URL's path,
+    query or userinfo, so they are safe to surface.
+    """
+    lead = what[:1].upper() + what[1:]
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise ValueError(f"{lead} scheme '{parsed.scheme}' is not allowed; only 'https' is permitted.")
+    hostname = (parsed.hostname or "").rstrip(".").lower()
+    if not hostname:
+        raise ValueError(f"{lead} has no hostname.")
+    allowed = [h.rstrip(".").lower() for h in allowlist]
+    if allowed and hostname not in allowed:
+        raise ValueError(f"{lead} hostname '{hostname}' is not in the configured allowlist.")
+    loop = asyncio.get_running_loop()
+    try:
+        addr_infos = await asyncio.wait_for(
+            loop.getaddrinfo(hostname, None), timeout=DNS_RESOLUTION_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        raise ValueError(
+            f"Timed out resolving {what} hostname '{hostname}' after {DNS_RESOLUTION_TIMEOUT_SECONDS:g}s."
+        )
+    except OSError as e:
+        raise ValueError(f"Cannot resolve {what} hostname '{hostname}': {e}")
+    for _, _, _, _, sockaddr in addr_infos:
+        ip = ipaddress.ip_address(sockaddr[0])
+        # An IPv4-mapped IPv6 address (::ffff:a.b.c.d) parses as IPv6 and would
+        # sail past the IPv4 blocklist entries; check the embedded IPv4 instead.
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
+            ip = ip.ipv4_mapped
+        if any(ip in net for net in BLOCKED_NETWORKS):
+            raise ValueError(
+                f"{lead} resolves to a private or reserved address ({ip}), which is blocked to prevent SSRF."
+            )

--- a/app/services/url_policy.py
+++ b/app/services/url_policy.py
@@ -36,6 +36,18 @@ BLOCKED_NETWORKS = [
     ipaddress.ip_network("240.0.0.0/4"),      # reserved
     ipaddress.ip_network("::/128"),           # IPv6 unspecified
     ipaddress.ip_network("ff00::/8"),         # IPv6 multicast
+    # IANA special-purpose ranges that ipaddress.is_global still reports as
+    # global on the Python the image runs (3.10; corrected in 3.13). Listed so
+    # the policy does not depend on the interpreter's registry. 192.0.0.0/24 is
+    # blocked whole: its two globally reachable anycast hosts (.9, .10) are
+    # not addresses a source system lives at.
+    ipaddress.ip_network("192.0.0.0/24"),     # IETF protocol assignments (incl. the dummy 192.0.0.8)
+    ipaddress.ip_network("192.31.196.0/24"),  # AS112-v4
+    ipaddress.ip_network("192.52.193.0/24"),  # AMT
+    ipaddress.ip_network("192.88.99.0/24"),   # deprecated 6to4 relay anycast
+    ipaddress.ip_network("192.175.48.0/24"),  # direct delegation AS112
+    ipaddress.ip_network("64:ff9b:1::/48"),   # local-use IPv4/IPv6 translation
+    ipaddress.ip_network("2002::/16"),        # 6to4
 ]
 
 

--- a/app/services/url_policy.py
+++ b/app/services/url_policy.py
@@ -73,7 +73,11 @@ async def validate_outbound_url(url: str, *, allowlist: Iterable[str] = (), what
         # sail past the IPv4 blocklist entries; check the embedded IPv4 instead.
         if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
             ip = ip.ipv4_mapped
-        if any(ip in net for net in BLOCKED_NETWORKS):
+        # The explicit blocklist names the ranges an operator expects to see;
+        # is_global catches the rest of the special-use space (benchmarking,
+        # documentation and other IANA-reserved ranges are often routed
+        # internally) so the check means "public addresses only" literally.
+        if not ip.is_global or any(ip in net for net in BLOCKED_NETWORKS):
             raise ValueError(
                 f"{lead} resolves to a private or reserved address ({ip}), which is blocked to prevent SSRF."
             )

--- a/app/services/url_policy.py
+++ b/app/services/url_policy.py
@@ -39,6 +39,18 @@ BLOCKED_NETWORKS = [
 ]
 
 
+async def _resolve_addresses(hostname: str) -> list:
+    """Every address `hostname` resolves to, as strings, within
+    DNS_RESOLUTION_TIMEOUT_SECONDS. Tests replace this function rather than
+    asyncio.get_running_loop: patching that module attribute also reaches the
+    test client's own event loop machinery."""
+    loop = asyncio.get_running_loop()
+    addr_infos = await asyncio.wait_for(
+        loop.getaddrinfo(hostname, None), timeout=DNS_RESOLUTION_TIMEOUT_SECONDS,
+    )
+    return [sockaddr[0] for _, _, _, _, sockaddr in addr_infos]
+
+
 async def validate_outbound_url(url: str, *, allowlist: Iterable[str] = (), what: str = "URL") -> None:
     """Raise ValueError unless `url` is https, has a hostname, is in `allowlist`
     when one is given, and resolves only to public addresses.
@@ -57,19 +69,16 @@ async def validate_outbound_url(url: str, *, allowlist: Iterable[str] = (), what
     allowed = [h.rstrip(".").lower() for h in allowlist]
     if allowed and hostname not in allowed:
         raise ValueError(f"{lead} hostname '{hostname}' is not in the configured allowlist.")
-    loop = asyncio.get_running_loop()
     try:
-        addr_infos = await asyncio.wait_for(
-            loop.getaddrinfo(hostname, None), timeout=DNS_RESOLUTION_TIMEOUT_SECONDS,
-        )
+        addresses = await _resolve_addresses(hostname)
     except asyncio.TimeoutError:
         raise ValueError(
             f"Timed out resolving {what} hostname '{hostname}' after {DNS_RESOLUTION_TIMEOUT_SECONDS:g}s."
         )
     except OSError as e:
         raise ValueError(f"Cannot resolve {what} hostname '{hostname}': {e}")
-    for _, _, _, _, sockaddr in addr_infos:
-        ip = ipaddress.ip_address(sockaddr[0])
+    for address in addresses:
+        ip = ipaddress.ip_address(address)
         # An IPv4-mapped IPv6 address (::ffff:a.b.c.d) parses as IPv6 and would
         # sail past the IPv4 blocklist entries; check the embedded IPv4 instead.
         if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:

--- a/app/services/url_policy.py
+++ b/app/services/url_policy.py
@@ -72,10 +72,17 @@ async def validate_outbound_url(url: str, *, allowlist: Iterable[str] = (), what
     query or userinfo, so they are safe to surface.
     """
     lead = what[:1].upper() + what[1:]
-    parsed = urlparse(url)
+    try:
+        parsed = urlparse(url)
+        hostname = (parsed.hostname or "").rstrip(".").lower()
+    except ValueError:
+        # The parser's own message quotes the authority it choked on, userinfo
+        # included (e.g. a fullwidth "@" fails NFKC validation with the whole
+        # netloc in the text). Callers treat this function's ValueErrors as
+        # safe, policy-authored text, so never let that message through.
+        raise ValueError(f"{lead} could not be parsed.") from None
     if parsed.scheme != "https":
         raise ValueError(f"{lead} scheme '{parsed.scheme}' is not allowed; only 'https' is permitted.")
-    hostname = (parsed.hostname or "").rstrip(".").lower()
     if not hostname:
         raise ValueError(f"{lead} has no hostname.")
     allowed = [h.rstrip(".").lower() for h in allowlist]

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -1,7 +1,6 @@
 import asyncio
 import datetime
 import importlib
-import ipaddress
 import logging
 from urllib.parse import urlparse
 import httpx
@@ -13,6 +12,7 @@ from gundi_core.events import IntegrationWebhookFailed, WebhookExecutionFailed
 from app.services.utils import DyntamicFactory
 from app.webhooks.core import get_webhook_handler, DynamicSchemaConfig, HexStringConfig, GenericJsonPayload
 from app.services.config_manager import IntegrationConfigurationManager
+from app.services.url_policy import validate_outbound_url
 
 config_manager = IntegrationConfigurationManager()
 logger = logging.getLogger(__name__)
@@ -44,10 +44,6 @@ def _spawn_background_task(coro) -> asyncio.Task:
 # period (Cloud Run and Kubernetes default to 10 s, then SIGKILL), or the
 # aclose() the drain protects never runs at all.
 _SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 5.0
-# Bound on the resolver call in _validate_diagnostic_url. httpx's timeout=10.0
-# is per phase of its own request and does not cover getaddrinfo, which runs
-# in the default executor with no deadline of its own.
-_DNS_RESOLUTION_TIMEOUT_SECONDS = 5.0
 
 
 async def close_diagnostic_client() -> None:
@@ -70,69 +66,11 @@ async def close_diagnostic_client() -> None:
         await _diagnostic_client.aclose()
         _diagnostic_client = None
 
-_BLOCKED_NETWORKS = [
-    ipaddress.ip_network("127.0.0.0/8"),    # loopback
-    ipaddress.ip_network("::1/128"),          # IPv6 loopback
-    ipaddress.ip_network("10.0.0.0/8"),       # RFC 1918 private
-    ipaddress.ip_network("172.16.0.0/12"),    # RFC 1918 private
-    ipaddress.ip_network("192.168.0.0/16"),   # RFC 1918 private
-    ipaddress.ip_network("169.254.0.0/16"),   # link-local / cloud metadata (AWS, GCP)
-    ipaddress.ip_network("fe80::/10"),        # IPv6 link-local
-    ipaddress.ip_network("fc00::/7"),         # IPv6 unique local
-    ipaddress.ip_network("0.0.0.0/8"),        # unspecified
-    ipaddress.ip_network("100.64.0.0/10"),    # carrier-grade NAT
-    ipaddress.ip_network("224.0.0.0/4"),      # multicast
-    ipaddress.ip_network("240.0.0.0/4"),      # reserved
-    ipaddress.ip_network("::/128"),           # IPv6 unspecified
-    ipaddress.ip_network("ff00::/8"),         # IPv6 multicast
-]
-
-
 async def _validate_diagnostic_url(url: str) -> None:
-    """Raise ValueError if url fails SSRF safety checks.
-
-    Note: this validation is a best-effort defence. Because DNS is re-resolved
-    by httpx at request time, a DNS-rebinding attack could cause the actual
-    connection to reach a private address even after this check passes (TOCTOU).
-    Operators should also restrict outbound network access at the infrastructure
-    level for a complete mitigation.
-    """
-    parsed = urlparse(url)
-    if parsed.scheme != "https":
-        raise ValueError(
-            f"Diagnostic URL scheme '{parsed.scheme}' is not allowed; only 'https' is permitted."
-        )
-    hostname = (parsed.hostname or "").rstrip(".").lower()
-    if not hostname:
-        raise ValueError("Diagnostic URL has no hostname.")
-    allowlist = settings.DIAGNOSTIC_URL_ALLOWLIST
-    if allowlist and hostname not in [h.rstrip(".").lower() for h in allowlist]:
-        raise ValueError(
-            f"Diagnostic URL hostname '{hostname}' is not in the configured allowlist."
-        )
-    loop = asyncio.get_running_loop()
-    try:
-        addr_infos = await asyncio.wait_for(
-            loop.getaddrinfo(hostname, None), timeout=_DNS_RESOLUTION_TIMEOUT_SECONDS,
-        )
-    except asyncio.TimeoutError:
-        raise ValueError(
-            f"Timed out resolving diagnostic URL hostname '{hostname}' "
-            f"after {_DNS_RESOLUTION_TIMEOUT_SECONDS:g}s."
-        )
-    except OSError as e:
-        raise ValueError(f"Cannot resolve diagnostic URL hostname '{hostname}': {e}")
-    for _, _, _, _, sockaddr in addr_infos:
-        ip = ipaddress.ip_address(sockaddr[0])
-        # An IPv4-mapped IPv6 address (::ffff:a.b.c.d) parses as IPv6 and would
-        # sail past the IPv4 blocklist entries; check the embedded IPv4 instead.
-        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
-            ip = ip.ipv4_mapped
-        if any(ip in net for net in _BLOCKED_NETWORKS):
-            raise ValueError(
-                f"Diagnostic URL resolves to a private or reserved address ({ip}), "
-                "which is blocked to prevent SSRF."
-            )
+    """Raise ValueError if url fails the SSRF safety checks (see url_policy):
+    https only, a hostname, in DIAGNOSTIC_URL_ALLOWLIST when one is set, and
+    resolving only to public addresses."""
+    await validate_outbound_url(url, allowlist=settings.DIAGNOSTIC_URL_ALLOWLIST, what="diagnostic URL")
 
 
 def _redact_url(url: str) -> str:

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -109,14 +109,20 @@ async def _validate_diagnostic_url(url: str) -> None:
 
 
 def _redact_url(url: str) -> str:
-    """Host and path only — diagnostic URLs can carry credentials or tokens
-    in the userinfo or query string, which must not reach the logs."""
+    """Host only — diagnostic URLs can carry credentials or tokens in the
+    userinfo, the query string, or the path, none of which may reach the logs.
+
+    The path is deliberately dropped rather than kept: Slack, Discord and Teams
+    incoming webhooks all put the shared secret *in the path*
+    (https://hooks.slack.com/services/T.../B.../<secret>), so keeping it would
+    leak the very credential this function exists to protect.
+    """
     try:
         parsed = urlparse(url)
         host = parsed.hostname or "<no-host>"
         if parsed.port:
             host = f"{host}:{parsed.port}"
-        return f"{host}{parsed.path}"
+        return host
     except Exception:
         return "<unparseable url>"
 

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -176,9 +176,18 @@ async def forward_payload_to_diagnostic_url(
             f"for integration '{integration_id}'. Status: {response.status_code}"
         )
     except Exception as e:
+        # Never str(e) for transport/status errors: httpx embeds the request URL
+        # in its messages, path secret included, which would undo _redact_url.
+        # ValueError is ours (the SSRF/allowlist checks) and names only the host.
+        if isinstance(e, httpx.HTTPStatusError):
+            detail = f"HTTPStatusError: HTTP {e.response.status_code}"
+        elif isinstance(e, ValueError):
+            detail = f"ValueError: {e}"
+        else:
+            detail = type(e).__name__
         logger.warning(
             f"Diagnostic forwarding to '{_redact_url(destination_url)}' failed for integration "
-            f"'{integration_id}': {type(e).__name__}: {e}"
+            f"'{integration_id}': {detail}"
         )
 
 

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -27,8 +27,25 @@ def _get_diagnostic_client() -> httpx.AsyncClient:
     return _diagnostic_client
 
 
+# asyncio keeps only a weak reference to a running task, so a fire-and-forget
+# task can be garbage-collected mid-flight and vanish without a trace. Hold a
+# strong reference until it finishes.
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _spawn_background_task(coro) -> asyncio.Task:
+    task = asyncio.ensure_future(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
+
+
 async def close_diagnostic_client() -> None:
     global _diagnostic_client
+    # Drain in-flight forwards first; closing the client out from under them
+    # would fail every request still on the wire.
+    if _background_tasks:
+        await asyncio.gather(*list(_background_tasks), return_exceptions=True)
     if _diagnostic_client is not None:
         await _diagnostic_client.aclose()
         _diagnostic_client = None
@@ -185,7 +202,7 @@ async def process_webhook(request: Request):
             json_content["hex_format"] = json_content.get("hex_format", parsed_config.hex_format)
         # Forward raw payload to diagnostic URL before any transformation or validation
         if diag_url := getattr(parsed_config, "diagnostic_destination_url", None):
-            asyncio.ensure_future(
+            _spawn_background_task(
                 forward_payload_to_diagnostic_url(
                     destination_url=diag_url,
                     integration_id=str(integration.id),

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -14,6 +14,7 @@ from gundi_core.events import IntegrationWebhookFailed, WebhookExecutionFailed
 from app.services.utils import DyntamicFactory
 from app.webhooks.core import get_webhook_handler, DynamicSchemaConfig, HexStringConfig, GenericJsonPayload
 from app.services.config_manager import IntegrationConfigurationManager
+from app.services.gundi import GUNDI_API_RETRY
 
 config_manager = IntegrationConfigurationManager()
 logger = logging.getLogger(__name__)
@@ -163,7 +164,10 @@ async def get_integration(request):
     if integration_id:
         try:
             # Retry on httpx.HTTPError (StatusError, Timeout, ConnectError, etc.)
-            for attempt in stamina.retry_context(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0):
+            # with the same explicit policy as the Gundi API helpers: this is
+            # a Gundi API call too, and the hand-copied decorator it replaces
+            # had the same unreachable backoff (see GUNDI_API_RETRY).
+            for attempt in stamina.retry_context(**GUNDI_API_RETRY):
                 with attempt:
                     # Cache the integration details and webhook config for 60 seconds. 
                     # ToDo: Refactor to event-driven webhook config updates (as in actions)

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -5,7 +5,6 @@ import ipaddress
 import logging
 from urllib.parse import urlparse
 import httpx
-import stamina
 from fastapi import Request
 from app import settings
 from app.services.activity_logger import log_activity, publish_event
@@ -14,7 +13,6 @@ from gundi_core.events import IntegrationWebhookFailed, WebhookExecutionFailed
 from app.services.utils import DyntamicFactory
 from app.webhooks.core import get_webhook_handler, DynamicSchemaConfig, HexStringConfig, GenericJsonPayload
 from app.services.config_manager import IntegrationConfigurationManager
-from app.services.gundi import GUNDI_API_RETRY
 
 config_manager = IntegrationConfigurationManager()
 logger = logging.getLogger(__name__)
@@ -41,12 +39,33 @@ def _spawn_background_task(coro) -> asyncio.Task:
     return task
 
 
+# How long lifespan shutdown waits for in-flight diagnostic forwards before
+# cancelling them. Must stay well inside the platform's termination grace
+# period (Cloud Run and Kubernetes default to 10 s, then SIGKILL), or the
+# aclose() the drain protects never runs at all.
+_SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 5.0
+# Bound on the resolver call in _validate_diagnostic_url. httpx's timeout=10.0
+# is per phase of its own request and does not cover getaddrinfo, which runs
+# in the default executor with no deadline of its own.
+_DNS_RESOLUTION_TIMEOUT_SECONDS = 5.0
+
+
 async def close_diagnostic_client() -> None:
     global _diagnostic_client
     # Drain in-flight forwards first; closing the client out from under them
-    # would fail every request still on the wire.
-    if _background_tasks:
-        await asyncio.gather(*list(_background_tasks), return_exceptions=True)
+    # would fail every request still on the wire. Bounded: a hung resolver or
+    # an unresponsive diagnostic endpoint must not hold shutdown open.
+    pending = list(_background_tasks)
+    if pending:
+        _, still_pending = await asyncio.wait(pending, timeout=_SHUTDOWN_DRAIN_TIMEOUT_SECONDS)
+        if still_pending:
+            logger.warning(
+                f"Cancelling {len(still_pending)} diagnostic forward(s) still in flight "
+                f"{_SHUTDOWN_DRAIN_TIMEOUT_SECONDS:g}s into shutdown."
+            )
+            for task in still_pending:
+                task.cancel()
+            await asyncio.gather(*still_pending, return_exceptions=True)
     if _diagnostic_client is not None:
         await _diagnostic_client.aclose()
         _diagnostic_client = None
@@ -93,7 +112,14 @@ async def _validate_diagnostic_url(url: str) -> None:
         )
     loop = asyncio.get_running_loop()
     try:
-        addr_infos = await loop.getaddrinfo(hostname, None)
+        addr_infos = await asyncio.wait_for(
+            loop.getaddrinfo(hostname, None), timeout=_DNS_RESOLUTION_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        raise ValueError(
+            f"Timed out resolving diagnostic URL hostname '{hostname}' "
+            f"after {_DNS_RESOLUTION_TIMEOUT_SECONDS:g}s."
+        )
     except OSError as e:
         raise ValueError(f"Cannot resolve diagnostic URL hostname '{hostname}': {e}")
     for _, _, _, _, sockaddr in addr_infos:
@@ -163,15 +189,14 @@ async def get_integration(request):
     integration_id = consumer_integration or request.headers.get("x-gundi-integration-id") or request.query_params.get("integration_id")
     if integration_id:
         try:
-            # Retry on httpx.HTTPError (StatusError, Timeout, ConnectError, etc.)
-            # with the same explicit policy as the Gundi API helpers: this is
-            # a Gundi API call too, and the hand-copied decorator it replaces
-            # had the same unreachable backoff (see GUNDI_API_RETRY).
-            for attempt in stamina.retry_context(**GUNDI_API_RETRY):
-                with attempt:
-                    # Cache the integration details and webhook config for 60 seconds. 
-                    # ToDo: Refactor to event-driven webhook config updates (as in actions)
-                    integration = await config_manager.get_integration_details(integration_id, ttl=60)
+            # No retry loop here: on a cache miss get_integration_details reloads
+            # from the Gundi API under GUNDI_API_RETRY already, and the loop this
+            # replaced nested a second policy on top of it (multiplying the wall
+            # time) while iterating stamina synchronously inside a coroutine,
+            # which sleeps the whole event loop between attempts.
+            # Cache the integration details and webhook config for 60 seconds.
+            # ToDo: Refactor to event-driven webhook config updates (as in actions)
+            integration = await config_manager.get_integration_details(integration_id, ttl=60)
         except Exception as e:
             error_message = f"Error retrieving integration '{integration_id}': {type(e).__name__}: {e}"
             logger.exception(error_message)

--- a/app/settings/base.py
+++ b/app/settings/base.py
@@ -91,3 +91,13 @@ DIAGNOSTIC_URL_ALLOWLIST = env.list("DIAGNOSTIC_URL_ALLOWLIST", [])
 # its callers should not (see app/services/url_policy.py for the caveats).
 EPHEMERAL_BASE_URL_BLOCK_PRIVATE_ADDRESSES = env.bool("EPHEMERAL_BASE_URL_BLOCK_PRIVATE_ADDRESSES", False)
 EPHEMERAL_BASE_URL_ALLOWLIST = env.list("EPHEMERAL_BASE_URL_ALLOWLIST", [])
+
+# Config cache: write absence sentinels with a Redis-issued generation
+# ("null:<epoch>:<n>:<hex>") instead of the bare "null". The generation lets a
+# concurrent delete's tombstone win over an in-flight reload's stale snapshot
+# and over the consumer's recovery writes (see config_manager). Off by default
+# because a rolling deployment runs old and new replicas side by side, and a
+# replica on a release without the tolerant reader parses anything but the
+# bare "null" as a configuration and fails every lookup of that action. Roll
+# a release with the reader out everywhere first, then turn this on.
+CONFIG_CACHE_SENTINEL_GENERATIONS = env.bool("CONFIG_CACHE_SENTINEL_GENERATIONS", False)

--- a/app/settings/base.py
+++ b/app/settings/base.py
@@ -66,6 +66,10 @@ REGISTER_ON_START = env.bool("REGISTER_ON_START", False)
 INTEGRATION_TYPE_SLUG = env.str("INTEGRATION_TYPE_SLUG", None)  # Define a string id here e.g. "my_tracker"
 INTEGRATION_TYPE_NAME = env.str("INTEGRATION_TYPE_NAME", None)  # Display name e.g. "My Tracker"; defaults to a name derived from the slug
 INTEGRATION_SERVICE_URL = env.str("INTEGRATION_SERVICE_URL", None)  # Define a string id here e.g. "my_tracker"
+# Reference actions register with type "reference" only once the platform
+# accepts that value; until then they stay out of the registered type rather
+# than landing as "generic". Same gate the forks ship.
+REGISTER_REFERENCE_ACTIONS = env.bool("REGISTER_REFERENCE_ACTIONS", False)
 PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND = env.bool("PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND", False)
 PROCESS_WEBHOOKS_IN_BACKGROUND = env.bool("PROCESS_WEBHOOKS_IN_BACKGROUND", True)
 MAX_ACTION_EXECUTION_TIME = env.int("MAX_ACTION_EXECUTION_TIME", 60 * 9)  # 10 minutes is the maximum ack timeout

--- a/app/settings/base.py
+++ b/app/settings/base.py
@@ -80,3 +80,14 @@ TRIGGER_ACTIONS_ALWAYS_SYNC = env.bool("TRIGGER_ACTIONS_ALWAYS_SYNC", False)
 # When non-empty, only the listed hostnames are permitted as diagnostic destinations.
 # Example: "diagnostics.example.com,hooks.example.org"
 DIAGNOSTIC_URL_ALLOWLIST = env.list("DIAGNOSTIC_URL_ALLOWLIST", [])
+
+# SSRF protection for the ephemeral (draft-integration) path. The draft's
+# base_url is request-controlled and reaches the connector's HTTP client
+# unchanged, so with this on it must be https, resolve only to public
+# addresses and, when the allowlist is non-empty, name one of those hosts.
+# Off by default: a saved integration's base_url is operator-supplied with no
+# host policy either, and the endpoint is reachable only by callers who can
+# already reach the runner. Turn it on where the runner can reach addresses
+# its callers should not (see app/services/url_policy.py for the caveats).
+EPHEMERAL_BASE_URL_BLOCK_PRIVATE_ADDRESSES = env.bool("EPHEMERAL_BASE_URL_BLOCK_PRIVATE_ADDRESSES", False)
+EPHEMERAL_BASE_URL_ALLOWLIST = env.list("EPHEMERAL_BASE_URL_ALLOWLIST", [])

--- a/app/settings/base.py
+++ b/app/settings/base.py
@@ -66,10 +66,6 @@ REGISTER_ON_START = env.bool("REGISTER_ON_START", False)
 INTEGRATION_TYPE_SLUG = env.str("INTEGRATION_TYPE_SLUG", None)  # Define a string id here e.g. "my_tracker"
 INTEGRATION_TYPE_NAME = env.str("INTEGRATION_TYPE_NAME", None)  # Display name e.g. "My Tracker"; defaults to a name derived from the slug
 INTEGRATION_SERVICE_URL = env.str("INTEGRATION_SERVICE_URL", None)  # Define a string id here e.g. "my_tracker"
-# Reference actions register with type "reference" only once the platform
-# accepts that value; until then they stay out of the registered type rather
-# than landing as "generic". Same gate the forks ship.
-REGISTER_REFERENCE_ACTIONS = env.bool("REGISTER_REFERENCE_ACTIONS", False)
 PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND = env.bool("PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND", False)
 PROCESS_WEBHOOKS_IN_BACKGROUND = env.bool("PROCESS_WEBHOOKS_IN_BACKGROUND", True)
 MAX_ACTION_EXECUTION_TIME = env.int("MAX_ACTION_EXECUTION_TIME", 60 * 9)  # 10 minutes is the maximum ack timeout

--- a/docs/actions/index.md
+++ b/docs/actions/index.md
@@ -1,6 +1,6 @@
 # Actions
 
-The runner implements seven actions in `app/actions/handlers.py` as `action_*` functions
+The runner implements nine actions in `app/actions/handlers.py` as `action_*` functions
 with a matching config model in `app/actions/configurations.py`. All of them self-register
 unconditionally; the reference actions register with `"type": "reference"`.
 
@@ -10,7 +10,7 @@ unconditionally; the reference actions register with `"type": "reference"`.
 | [`pull_events`](pull-events.md) | pull | ER events + note/field updates → Gundi events & event updates. |
 | [`pull_observations`](pull-observations.md) | pull | ER subject tracking → Gundi observations. |
 | [`show_permissions`](show-permissions.md) | generic / diagnostic | Show what the account can access and the UUIDs the pull actions need. |
-| [`list_event_types`, `list_event_type_fields`, `list_event_field_values`](reference-actions.md) | reference | Config-time lookups for the Gundi portal's mapping forms. |
+| [`list_event_types`, `list_event_categories`, `list_event_type_fields`, `list_event_field_values`, `list_subject_types`](reference-actions.md) | reference | Config-time lookups for the Gundi portal's mapping forms. |
 
 **Typical setup order:** run `auth` to confirm credentials → run `show_permissions` to discover event-type
 / category slugs and subject-group UUIDs → configure and enable `pull_events` / `pull_observations` with

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,11 +52,13 @@ The ER **base URL** comes from the integration record, not this config.
 
 See [State & scheduling](state-and-scheduling.md) for watermark, backfill, and scheduling semantics.
 
-## `ListEventTypesQuery` / `ListEventTypeFieldsQuery` / `ListEventFieldValuesQuery` — reference actions
+## `List*Query` models — reference actions
 
 | Model | Field | Type | Notes |
 |-------|-------|------|-------|
 | `ListEventTypesQuery` | — | — | No fields; lists every event type visible to this integration's credentials. |
+| `ListEventCategoriesQuery` | — | — | No fields; lists every event category visible to this integration's credentials. |
+| `ListSubjectTypesQuery` | — | — | No fields; lists the subject subtypes observed on the site, grouped by subject type. |
 | `ListEventTypeFieldsQuery` | `event_type` | string | ER event-type slug (e.g. `rhino_carcass`). Unknown slug → error. |
 | `ListEventFieldValuesQuery` | `event_type` | string | Same as above. |
 | `ListEventFieldValuesQuery` | `field_key` | string | Field key from that event type's schema. Unknown key → error. |
@@ -68,7 +70,7 @@ for what they return and how the portal uses them.
 
 ### Reference-action registration
 
-`list_event_types`, `list_event_type_fields`, `list_event_field_values`, and `list_subject_types` always
-register with `"type": "reference"` when this runner self-registers with Gundi. The former
+`list_event_types`, `list_event_categories`, `list_event_type_fields`, `list_event_field_values`, and
+`list_subject_types` always register with `"type": "reference"` when this runner self-registers with Gundi. The former
 `REGISTER_REFERENCE_ACTIONS` gate was removed once the Gundi API accepted that type
 ([PADAS/cdip#461](https://github.com/PADAS/cdip/pull/461)); setting the variable now has no effect.

--- a/local/.gitignore
+++ b/local/.gitignore
@@ -1,1 +1,2 @@
 .env.local
+docker-compose.override.yml

--- a/requirements-base.in
+++ b/requirements-base.in
@@ -1,5 +1,7 @@
 # Base dependencies. Don't edit or override this file.
 # Use requirements.in to add integration-specific dependencies instead.
+# imported directly by app/services/errors.py for exception classification
+aiohttp
 environs~=9.5.0
 pydantic~=1.10.15
 fastapi~=0.103.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,9 @@
 aiohappyeyeballs==2.7.1
     # via aiohttp
 aiohttp==3.14.3
-    # via gcloud-aio-auth
+    # via
+    #   -r requirements-base.in
+    #   gcloud-aio-auth
 aiosignal==1.4.0
     # via aiohttp
 anyio==3.7.1


### PR DESCRIPTION
## Summary

Merges the template into EarthRanger: the 38 commits behind the ephemeral reference-action path and shared retry policy, plus the follow-ups from reviewing this very sync (PADAS/gundi-integration-action-runner#103, merged after five Copilot rounds). The runner can now execute reference and auth actions ephemerally against a draft integration (no stored config row, no state writes, no PubSub, redacted errors), every Gundi API call shares one bounded retry policy, and two silent config-loss paths in the cache are closed.

## Behavior change: reference actions now always register

The template dropped the `REGISTER_REFERENCE_ACTIONS` gate because cdip accepts `"type": "reference"` (PADAS/cdip#461). This PR follows it: the ER setting, the flag-era tests, and the docs describing the gate are removed. On the next self-registration in any environment, all five reference actions register with the reference type. Nothing has to be flipped in stage or prod; the variable is simply ignored now.

## What the second template merge adds

- Absence sentinels expire after five minutes, and legacy permanent ones pick up the TTL on their next hit, so a lost `ActionConfigCreated` no longer leaves an action permanently unconfigured.
- An `ActionConfigUpdated` that hits a sentinel recovers from the portal through a compare-and-set instead of raising and being acked away.
- `IntegrationConfigurationError` lets a connector forward a vouched-for guard message on the ephemeral path as a 422. ER's own guards will move onto it in a follow-up.
- `EPHEMERAL_BASE_URL_BLOCK_PRIVATE_ADDRESSES` (default off) plus `EPHEMERAL_BASE_URL_ALLOWLIST` refuse a draft `base_url` that is not https or resolves to a private, reserved or IANA special-use address. This answers the open Copilot thread on this PR about the draft URL; it stays off unless a deployment turns it on.

## Conflict resolutions (first merge)

| File | Resolution |
|---|---|
| `action_runner.py`, `self_registration.py` | Template-owned; taken from upstream wholesale. |
| `actions/core.py` | Upstream docstring, plus ER's `ReferenceOption` / `ReferenceDataResponse` models that the handlers import. |
| `services/gundi.py` | Kept ER's `update_event_in_gundi`, now on the shared `GUNDI_API_RETRY` policy and guarded on the ephemeral path like its neighbours. |
| `requirements.txt` | Kept ours and regenerated with the uv command in the header. `aiohttp` became a direct dependency upstream; no version moved. |

A third merge brings PADAS/gundi-integration-action-runner#104, from Copilot's review of the second merge here: the URL policy no longer lets `urlparse`'s own message (which quotes the authority, userinfo included) through, and legacy permanent webhook cache entries pick up the default TTL on their next hit. A fourth merge brings PADAS/gundi-integration-action-runner#105, the concurrency model for the action-config cache that grew out of reviewing the third merge here: every consumer write is a compare-and-set, absence sentinels carry Redis-issued generations (opt-in via `CONFIG_CACHE_SENTINEL_GENERATIONS`, off by default so a rolling deployment stays safe; turn it on per deployment once this release has rolled out everywhere), reloads preserve tombstones newer than their fetch, and lookups answer from the cache after a reload. The second, third and fourth merges had no conflicts. After both, the only files that still differ from the template are intentional ER additions: the event-update PATCH helper, the reference response models, and ER-specific tests.

## Validation

- `pytest app`: 438 passed (403 after the third merge, 399 after the second, 374 after the first, 373 before).
- `mkdocs build --strict` (what the docs workflow runs) passes with the edited pages.

Related: PADAS/gundi-integration-action-runner#98, PADAS/gundi-integration-action-runner#101, PADAS/gundi-integration-action-runner#89, PADAS/gundi-integration-action-runner#102, PADAS/gundi-integration-action-runner#103, PADAS/gundi-integration-action-runner#104, PADAS/gundi-integration-action-runner#105, GUNDI-5598

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiRFpnqiEX9VeEJk5DD8ck