### PR TITLE
fix: actionable EarthRanger errors on the reference-action path

### DIFF
--- a/app/actions/er_schema.py
+++ b/app/actions/er_schema.py
@@ -151,23 +151,38 @@ def parse_er_event_schema(raw: dict) -> List[ERField]:
     return fields
 
 
+def er_site_root(base_url: str) -> str:
+    """`scheme://hostname` of an EarthRanger site URL (dropping any port), the
+    convention every AsyncERClient construction site uses.
+
+    Schemeless or empty base_urls do occur in Gundi (see the _ensure_scheme
+    guard in gundi-integration-cmore's CLI); urlparse leaves hostname None for
+    them, which would otherwise build a "https://None/..." URL. That is a
+    configuration error, and the URL itself stays out of the message: it is a
+    submitted value that may carry a token in its path or query.
+    """
+    url_parse = urlparse(base_url or "")
+    if not url_parse.hostname:
+        raise IntegrationConfigurationError("Site URL is empty or invalid.")
+    return f"{url_parse.scheme}://{url_parse.hostname}"
+
+
 async def fetch_prerendered_event_schema(er_client, base_url: str, event_type: str) -> dict:
     """GET the v2 pre-rendered event-type schema (pre_render + s_format=enum inline
     each choice field's values, so no separate choices fetch is needed). erclient
     doesn't model this /schema sub-resource, so we call it directly with the
     client's own auth headers (works for both token and username/password auth)."""
-    url_parse = urlparse(base_url)
-    if not url_parse.hostname:
-        # Schemeless base_urls do occur in Gundi (see the _ensure_scheme guard in
-        # gundi-integration-cmore's CLI); urlparse leaves hostname None for them,
-        # which would otherwise build a "https://None/..." URL. A configuration
-        # error, worded like handlers._build_er_client's; the URL is a submitted
-        # value and stays out of the message.
-        raise IntegrationConfigurationError("Site URL is empty or invalid.")
-    # scheme://hostname (dropping any port) is the deliberate convention — it
-    # matches every AsyncERClient construction site in handlers.py.
-    url = f"{url_parse.scheme}://{url_parse.hostname}/api/v2.0/activity/eventtypes/{quote(event_type, safe='')}/schema"
-    headers = await er_client.auth_headers()
+    url = f"{er_site_root(base_url)}/api/v2.0/activity/eventtypes/{quote(event_type, safe='')}/schema"
+    try:
+        headers = await er_client.auth_headers()
+    except httpx.HTTPStatusError as e:
+        # auth_headers() runs outside erclient's _call wrapper here, so a login
+        # failure (the token endpoint's 400 invalid_grant, or a 401) would
+        # escape as a raw httpx error carrying the login request body, which
+        # for a username/password integration is the password. Apply the same
+        # mapping _call does, so it comes out as an ERClientException like
+        # every other failure and is translated downstream.
+        er_client._handle_http_status_error("oauth2/token", "POST", e, request_url=str(e.request.url))
     async with httpx.AsyncClient(headers=headers, timeout=30.0) as http:
         resp = await http.get(url, params={"pre_render": "true", "s_format": "enum"})
         resp.raise_for_status()

--- a/app/actions/er_schema.py
+++ b/app/actions/er_schema.py
@@ -162,7 +162,9 @@ def er_site_root(base_url: str) -> str:
     submitted value that may carry a token in its path or query.
     """
     url_parse = urlparse(base_url or "")
-    if not url_parse.hostname:
+    if not (url_parse.scheme and url_parse.hostname):
+        # A scheme-relative "//host" has a hostname but would yield "://host",
+        # which fails later as a connectivity error instead of this one.
         raise IntegrationConfigurationError("Site URL is empty or invalid.")
     return f"{url_parse.scheme}://{url_parse.hostname}"
 

--- a/app/actions/er_schema.py
+++ b/app/actions/er_schema.py
@@ -173,16 +173,13 @@ async def fetch_prerendered_event_schema(er_client, base_url: str, event_type: s
     doesn't model this /schema sub-resource, so we call it directly with the
     client's own auth headers (works for both token and username/password auth)."""
     url = f"{er_site_root(base_url)}/api/v2.0/activity/eventtypes/{quote(event_type, safe='')}/schema"
-    try:
-        headers = await er_client.auth_headers()
-    except httpx.HTTPStatusError as e:
-        # auth_headers() runs outside erclient's _call wrapper here, so a login
-        # failure (the token endpoint's 400 invalid_grant, or a 401) would
-        # escape as a raw httpx error carrying the login request body, which
-        # for a username/password integration is the password. Apply the same
-        # mapping _call does, so it comes out as an ERClientException like
-        # every other failure and is translated downstream.
-        er_client._handle_http_status_error("oauth2/token", "POST", e, request_url=str(e.request.url))
+    # auth_headers() runs outside erclient's _call wrapper here, so a login
+    # failure (the token endpoint's 400 invalid_grant, or a 401) comes out as
+    # the raw httpx error for the token URL, carrying the login request body
+    # (for a username/password integration, the password). It is not mapped
+    # here: every caller runs inside the reference path's translation, which
+    # recognises token-URL failures and keeps the request out of its message.
+    headers = await er_client.auth_headers()
     async with httpx.AsyncClient(headers=headers, timeout=30.0) as http:
         resp = await http.get(url, params={"pre_render": "true", "s_format": "enum"})
         resp.raise_for_status()

--- a/app/actions/er_schema.py
+++ b/app/actions/er_schema.py
@@ -35,6 +35,8 @@ from urllib.parse import quote, urlparse
 
 import httpx
 
+from app.services.errors import IntegrationConfigurationError
+
 
 @dataclass
 class ERChoice:
@@ -158,8 +160,10 @@ async def fetch_prerendered_event_schema(er_client, base_url: str, event_type: s
     if not url_parse.hostname:
         # Schemeless base_urls do occur in Gundi (see the _ensure_scheme guard in
         # gundi-integration-cmore's CLI); urlparse leaves hostname None for them,
-        # which would otherwise build a "https://None/..." URL.
-        raise ValueError(f"Site URL is empty or invalid: '{base_url}'")
+        # which would otherwise build a "https://None/..." URL. A configuration
+        # error, worded like handlers._build_er_client's; the URL is a submitted
+        # value and stays out of the message.
+        raise IntegrationConfigurationError("Site URL is empty or invalid.")
     # scheme://hostname (dropping any port) is the deliberate convention — it
     # matches every AsyncERClient construction site in handlers.py.
     url = f"{url_parse.scheme}://{url_parse.hostname}/api/v2.0/activity/eventtypes/{quote(event_type, safe='')}/schema"

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -5,7 +5,7 @@ import time
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Optional
 from urllib.parse import urlparse
 
 import httpx
@@ -68,20 +68,12 @@ ER_EVENT_FILTER_KEY_BY_DATE_FIELD = {
 async def action_auth(integration: Integration, action_config: AuthenticateConfig):
     auth_config = action_config
     try:
-        site_root = er_site_root(integration.base_url)
+        client = _build_er_client(integration, auth_config=auth_config)
     except IntegrationConfigurationError as e:
         # action_auth reports failures inside a normal result, which nothing in
         # the runner redacts; the helper's message keeps the URL out.
         return {"valid_credentials": False, "error": e.message}
-    async with AsyncERClient(
-            service_root=f"{site_root}/api/v1.0",
-            username=auth_config.username,
-            password=auth_config.password.get_secret_value() if auth_config.password else None,
-            token=auth_config.token.get_secret_value() if auth_config.token else None,
-            token_url=f"{site_root}/oauth2/token",
-            client_id="das_web_client",
-            connect_timeout=DEFAULT_CONNECT_TIMEOUT_SECONDS,
-    ) as er_client:
+    async with client as er_client:
         try:
             if auth_config.authentication_type == ERAuthenticationType.TOKEN:
                 if not auth_config.token:
@@ -322,20 +314,12 @@ async def action_show_permissions(integration: Integration, action_config: ShowP
     }
     auth_config = get_authentication_config(integration=integration)
     try:
-        site_root = er_site_root(integration.base_url)
+        client = _build_er_client(integration, auth_config=auth_config)
     except IntegrationConfigurationError as e:
         response["data"]["User Details"]["error"] = e.message
         return response
 
-    async with AsyncERClient(
-            service_root=f"{site_root}/api/v1.0",
-            username=auth_config.username,
-            password=auth_config.password.get_secret_value() if auth_config.password else None,
-            token=auth_config.token.get_secret_value() if auth_config.token else None,
-            token_url=f"{site_root}/oauth2/token",
-            client_id="das_web_client",
-            connect_timeout=DEFAULT_CONNECT_TIMEOUT_SECONDS,
-    ) as er_client:
+    async with client as er_client:
         try:  # Get user details and global permissions from the users/me endpoint
             if auth_config.authentication_type == ERAuthenticationType.TOKEN:
                 er_user_details = await er_client.get_me()
@@ -348,19 +332,10 @@ async def action_show_permissions(integration: Integration, action_config: ShowP
             else:
                 response["data"]["User Details"]["error"] = "Please select an valid authentication method."
                 return response
-        except ERClientBadCredentials:
-            response["data"]["User Details"]["error"] = "Invalid credentials. Please provide a valid credentials in the authentication config."
-            return response
-        except httpx.HTTPStatusError as e:
-            try:  # ToDo: Handle this inside the er-client and raise ERClientBadCredentials
-                json_response = e.response.json()
-            except (ValueError, AttributeError):
-                json_response = {}
-            error_details = json_response.get("error_description") or response.text
-            response["data"]["User Details"]["error"] = f"ER status {e.response.status_code}: {error_details}"
-            return response
-        except Exception as e:
-            response["data"]["User Details"]["error"] = f"Error retrieving user details: {type(e).__name__}:{e}"
+        except (ERClientException, httpx.HTTPError) as e:
+            # Same fixed texts as action_auth: str(e) carries ER's response
+            # body or our login request, neither of which belongs in the card.
+            response["data"]["User Details"]["error"] = _as_integration_error(e).message
             return response  # Cannot continue without a valid user/token
         response["data"]["User Details"] = _extract_user_details(er_user_details=er_user_details)
         user_global_permissions = er_user_details.get("permissions", {})
@@ -423,16 +398,7 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
         "pull_events: integration.base_url=%r → er_ui_root=%r",
         integration.base_url, er_ui_root,
     )
-    site_root = er_site_root(integration.base_url)
-    er_client = AsyncERClient(
-        service_root=f"{site_root}/api/v1.0",
-        username=auth_config.username or None,
-        password=auth_config.password.get_secret_value() if auth_config.password else None,
-        token=auth_config.token.get_secret_value() if auth_config.token else None,
-        token_url=f"{site_root}/oauth2/token",
-        client_id="das_web_client",
-        connect_timeout=DEFAULT_CONNECT_TIMEOUT_SECONDS,
-    )
+    er_client = _build_er_client(integration, auth_config=auth_config)
     # Prepare filters to extract Data Since last execution
     state = await state_manager.get_state(
         integration_id=integration_id, action_id="pull_events"
@@ -669,16 +635,7 @@ async def action_pull_observations(integration: Integration, action_config: Pull
     execution_timestamp = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
     pull_config = action_config
     auth_config = get_authentication_config(integration=integration)
-    site_root = er_site_root(integration.base_url)
-    er_client = AsyncERClient(
-        service_root=f"{site_root}/api/v1.0",
-        username=auth_config.username or None,
-        password=auth_config.password.get_secret_value() if auth_config.password else None,
-        token=auth_config.token.get_secret_value() if auth_config.token else None,
-        token_url=f"{site_root}/oauth2/token",
-        client_id="das_web_client",
-        connect_timeout=DEFAULT_CONNECT_TIMEOUT_SECONDS,
-    )
+    er_client = _build_er_client(integration, auth_config=auth_config)
 
     start_monotonic = time.monotonic()
     soft_budget = settings.MAX_ACTION_EXECUTION_TIME * BUDGET_FRACTION
@@ -1187,6 +1144,13 @@ class EventTypeMaps:
     v2_slugs: set = field(default_factory=set)
 
 
+def _failure_summary(exc: Exception) -> str:
+    """Type and status only, for log lines about best-effort ER calls: str(exc)
+    carries ER's response body (or, for a login failure, our request)."""
+    status = getattr(exc, "status_code", None) or getattr(getattr(exc, "response", None), "status_code", None)
+    return f"{type(exc).__name__} (status {status})" if status else type(exc).__name__
+
+
 async def _fetch_event_type_maps(er_client, *, strict_v2: bool = False) -> EventTypeMaps:
     """Build slug→display, slug→type_id, and category_slug→category_id maps.
 
@@ -1215,28 +1179,18 @@ async def _fetch_event_type_maps(er_client, *, strict_v2: bool = False) -> Event
     """
     maps = EventTypeMaps()
 
-    try:
-        v1_types = await er_client.get_event_types(version=VERSION_1_0)
-    except Exception as e:
-        logger.warning(
-            "Could not fetch ER v1 event types: %s: %s. "
-            "Slug→UUID resolution will fall back to v2-only results.",
-            type(e).__name__, e,
-        )
-    else:
-        for et in _as_list(v1_types):
-            if isinstance(et, dict):
-                _absorb_event_type(maps, et, with_category=True)
-
+    # v2 first: on the reference path it is the load-bearing fetch, and running
+    # it after the best-effort v1 fetch meant a wrong password or a down site
+    # paid the identical failure twice (two token round trips, or two connect
+    # timeouts) before the error surfaced.
     try:
         v2_types = await er_client.get_event_types(version=VERSION_2_0)
     except Exception as e:
         if strict_v2:
             raise
         logger.warning(
-            "Could not fetch ER v2 event types: %s: %s. "
-            "Slug→UUID resolution will fall back to v1-only results.",
-            type(e).__name__, e,
+            "Could not fetch ER v2 event types: %s. Slug→UUID resolution will fall back to v1-only results.",
+            _failure_summary(e),
         )
     else:
         for et in _as_list(v2_types):
@@ -1245,6 +1199,18 @@ async def _fetch_event_type_maps(er_client, *, strict_v2: bool = False) -> Event
             if isinstance(et, dict):
                 _absorb_event_type(maps, et, with_category=False, is_v2=True)
 
+    try:
+        v1_types = await er_client.get_event_types(version=VERSION_1_0)
+    except Exception as e:
+        logger.warning(
+            "Could not fetch ER v1 event types: %s. Slug→UUID resolution will fall back to v2-only results.",
+            _failure_summary(e),
+        )
+    else:
+        for et in _as_list(v1_types):
+            if isinstance(et, dict):
+                _absorb_event_type(maps, et, with_category=True)
+
     # If we got no category UUIDs from the v1 event types (e.g. ER has only
     # v2 types defined), the canonical categories endpoint fills the gap.
     if not maps.category_id_by_slug:
@@ -1252,9 +1218,8 @@ async def _fetch_event_type_maps(er_client, *, strict_v2: bool = False) -> Event
             categories = await er_client.get_event_categories()
         except Exception as e:
             logger.warning(
-                "Could not fetch ER event categories: %s: %s. "
-                "event_category filter slugs will not resolve.",
-                type(e).__name__, e,
+                "Could not fetch ER event categories: %s. event_category filter slugs will not resolve.",
+                _failure_summary(e),
             )
         else:
             for cat in _as_list(categories):
@@ -1461,11 +1426,14 @@ def transform_observations_to_gundi_schema(observations, resolver=None):
 # docs/superpowers/specs/2026-07-31-reference-data-config-ui-design.md).
 # ---------------------------------------------------------------------------
 
-def _build_er_client(integration: Integration) -> AsyncERClient:
-    """Standard AsyncERClient construction shared by the reference actions
-    (mirrors action_pull_events / action_pull_observations)."""
-    auth_config = get_authentication_config(integration=integration)
-    site_root = er_site_root(integration.base_url)  # raises IntegrationConfigurationError, URL kept out
+def _build_er_client(integration: Integration, auth_config: Optional[AuthenticateConfig] = None) -> AsyncERClient:
+    """The one AsyncERClient construction for every action. `auth_config`
+    defaults to the integration's stored auth configuration; action_auth
+    passes the one it is asked to validate. Raises IntegrationConfigurationError
+    (URL kept out) when the site URL has no hostname."""
+    if auth_config is None:
+        auth_config = get_authentication_config(integration=integration)
+    site_root = er_site_root(integration.base_url)
     return AsyncERClient(
         service_root=f"{site_root}/api/v1.0",
         username=auth_config.username or None,
@@ -1477,14 +1445,20 @@ def _build_er_client(integration: Integration) -> AsyncERClient:
     )
 
 
-def _is_token_endpoint_failure(exc) -> bool:
-    """A failure of the login itself, as opposed to an API call: the token
-    endpoint answers 400 invalid_grant to a wrong username/password. Through
-    erclient's _call it arrives as ERClientBadRequest whose message names the
-    token URL; from a bare login()/auth_headers() it is the raw httpx error."""
+def _is_token_endpoint_url(url) -> bool:
+    return "/oauth2/token" in str(url)
+
+
+def _is_rejected_login(exc) -> bool:
+    """The login itself was rejected, as opposed to an API call failing: the
+    token endpoint answers 400 invalid_grant (or 401/403) to a wrong username
+    or password. Through erclient's _call it arrives as ERClientBadRequest
+    whose message names the token URL; from a bare login()/auth_headers() it
+    is the raw httpx error. A 5xx or 429 from the token endpoint is not a
+    rejection and is classified like any other status."""
     if isinstance(exc, httpx.HTTPStatusError):
-        return "/oauth2/token" in str(exc.request.url)
-    return isinstance(exc, ERClientBadRequest) and "/oauth2/token" in str(exc)
+        return _is_token_endpoint_url(exc.request.url) and exc.response.status_code in (400, 401, 403)
+    return isinstance(exc, ERClientBadRequest) and _is_token_endpoint_url(str(exc))
 
 
 def _as_integration_error(exc: Exception) -> IntegrationError:
@@ -1500,19 +1474,26 @@ def _as_integration_error(exc: Exception) -> IntegrationError:
     str(exc) carries ER's response body, or our request (for the login, the
     password), which must reach neither the activity log nor the portal.
     """
+    # A rejected login is reported as 401 whatever the token endpoint said
+    # (it says 400 invalid_grant): the portal treats 401/403 as a credential
+    # rejection and shows the operator that, which is the point.
+    if _is_rejected_login(exc):
+        return IntegrationAuthError("EarthRanger rejected the credentials", status_code=401)
     if isinstance(exc, httpx.TransportError):
         return IntegrationConnectionError("EarthRanger could not be reached")
     if isinstance(exc, httpx.HTTPStatusError):
         status = exc.response.status_code
-        if _is_token_endpoint_failure(exc) or status in (401, 403):
+        if status in (401, 403):
             return IntegrationAuthError("EarthRanger rejected the credentials", status_code=status)
         if status == 429:
             return IntegrationRateLimitError("EarthRanger rate-limited the request", status_code=status)
+        if status in (502, 503, 504):
+            return IntegrationConnectionError("EarthRanger could not be reached", status_code=status)
         return IntegrationBadResponseError("EarthRanger returned an unexpected response", status_code=status)
     if isinstance(exc, httpx.HTTPError):
         return IntegrationBadResponseError("EarthRanger returned an unexpected response")
     status = exc.status_code if isinstance(getattr(exc, "status_code", None), int) else None
-    if isinstance(exc, ERClientBadCredentials) or _is_token_endpoint_failure(exc):
+    if isinstance(exc, ERClientBadCredentials):
         return IntegrationAuthError("EarthRanger rejected the credentials", status_code=status or 401)
     if isinstance(exc, ERClientPermissionDenied):
         return IntegrationAuthError("EarthRanger denied access with these credentials", status_code=status or 403)
@@ -1531,7 +1512,17 @@ async def _reference_er_client(integration: Integration):
         async with _build_er_client(integration) as er_client:
             yield er_client
     except (ERClientException, httpx.HTTPError) as e:
-        raise _as_integration_error(e) from e
+        translated = _as_integration_error(e)
+        # Local log only, and by type and status: str(e) carries ER's response
+        # body or our request. No chained cause either: on a saved integration
+        # the runner publishes the formatted traceback, whose chained-cause
+        # section would render str(e) into the activity feed.
+        logger.info(
+            f"EarthRanger call failed on the reference path: {type(e).__name__} "
+            f"(status {getattr(e, 'status_code', None) or getattr(getattr(e, 'response', None), 'status_code', None)}) "
+            f"-> {type(translated).__name__}"
+        )
+        raise translated from None
 
 
 async def _fetch_category_display_map(er_client) -> Dict[str, str]:
@@ -1550,8 +1541,7 @@ async def _fetch_category_display_map(er_client) -> Dict[str, str]:
         categories = await er_client.get_event_categories()
     except Exception as e:
         logger.warning(
-            "Could not fetch ER event categories for list_event_types grouping: %s: %s.",
-            type(e).__name__, e,
+            "Could not fetch ER event categories for list_event_types grouping: %s.", _failure_summary(e),
         )
         return {}
     return {
@@ -1605,7 +1595,7 @@ async def _fetch_event_type_fields(er_client, base_url: str, event_type: str):
     try:
         raw_schema = await fetch_prerendered_event_schema(er_client, base_url, event_type)
     except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
+        if e.response.status_code == 404 and not _is_token_endpoint_url(e.request.url):
             logger.info(f"EarthRanger has no v2 schema for event type '{event_type}'.")
             raise IntegrationConfigurationError(
                 "Event type not found in EarthRanger, or it is a classic v1 event type "

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import time
 from collections import defaultdict
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import Dict
 from urllib.parse import urlparse
@@ -11,7 +12,12 @@ import httpx
 import stamina
 from dateutil import parser as dateutil_parser
 from erclient import AsyncERClient, ERClientException, VERSION_1_0, VERSION_2_0
-from erclient.er_errors import ERClientBadCredentials
+from erclient.er_errors import (
+    ERClientBadCredentials,
+    ERClientPermissionDenied,
+    ERClientRateLimitExceeded,
+    ERClientServiceUnreachable,
+)
 from gundi_client_v2.client import GundiClient
 from gundi_core.events import LogLevel
 from gundi_core.schemas.v2 import Integration
@@ -25,6 +31,13 @@ from .configurations import AuthenticateConfig, EventFilterDateField, PullObserv
     ListEventFieldValuesQuery, ListEventCategoriesQuery, ListSubjectTypesQuery
 from .source_profiles import SourceProfileResolver
 from ..services.activity_logger import activity_logger, log_action_activity
+from ..services.errors import (
+    IntegrationAuthError,
+    IntegrationBadResponseError,
+    IntegrationConnectionError,
+    IntegrationError,
+    IntegrationRateLimitError,
+)
 from ..services.gundi import send_events_to_gundi, send_observations_to_gundi, update_event_in_gundi, send_event_attachments_to_gundi
 from ..services.action_scheduler import trigger_action
 
@@ -1164,7 +1177,12 @@ class EventTypeMaps:
     v2_slugs: set = field(default_factory=set)
 
 
-async def _fetch_event_type_maps(er_client) -> EventTypeMaps:
+# erclient failures that mean "these credentials don't work here", as opposed
+# to one endpoint being unavailable.
+_ER_AUTH_ERRORS = (ERClientBadCredentials, ERClientPermissionDenied)
+
+
+async def _fetch_event_type_maps(er_client, *, propagate_auth_errors: bool = False) -> EventTypeMaps:
     """Build slug→display, slug→type_id, and category_slug→category_id maps.
 
     ER's EventType has a ``version`` field — each type is exclusively v1 OR
@@ -1182,13 +1200,18 @@ async def _fetch_event_type_maps(er_client) -> EventTypeMaps:
 
     All three fetches are best-effort and logged independently — a 403 on
     one doesn't break the others. If everything fails, all maps are empty;
-    downstream callers treat that as the "skip the pull" signal.
+    downstream callers treat that as the "skip the pull" signal. The
+    reference path passes propagate_auth_errors=True: there, an empty result
+    on bad credentials would render as an empty dropdown rather than as
+    "Authentication failed", so auth failures escape instead.
     """
     maps = EventTypeMaps()
 
     try:
         v1_types = await er_client.get_event_types(version=VERSION_1_0)
     except Exception as e:
+        if propagate_auth_errors and isinstance(e, _ER_AUTH_ERRORS):
+            raise
         logger.warning(
             "Could not fetch ER v1 event types: %s: %s. "
             "Slug→UUID resolution will fall back to v2-only results.",
@@ -1202,6 +1225,8 @@ async def _fetch_event_type_maps(er_client) -> EventTypeMaps:
     try:
         v2_types = await er_client.get_event_types(version=VERSION_2_0)
     except Exception as e:
+        if propagate_auth_errors and isinstance(e, _ER_AUTH_ERRORS):
+            raise
         logger.warning(
             "Could not fetch ER v2 event types: %s: %s. "
             "Slug→UUID resolution will fall back to v1-only results.",
@@ -1220,6 +1245,8 @@ async def _fetch_event_type_maps(er_client) -> EventTypeMaps:
         try:
             categories = await er_client.get_event_categories()
         except Exception as e:
+            if propagate_auth_errors and isinstance(e, _ER_AUTH_ERRORS):
+                raise
             logger.warning(
                 "Could not fetch ER event categories: %s: %s. "
                 "event_category filter slugs will not resolve.",
@@ -1451,6 +1478,39 @@ def _build_er_client(integration: Integration) -> AsyncERClient:
     )
 
 
+def _as_integration_error(exc: ERClientException) -> IntegrationError:
+    """Translate an erclient failure into the runner's classified errors.
+
+    erclient's exceptions are not IntegrationError subclasses and carry no
+    `.response`, so the runner cannot classify them: on the ephemeral path
+    the portal wizard saw `500 {"error": "ERClientBadCredentials"}` and could
+    not tell bad credentials from a broken site. The message is fixed text on
+    purpose: str(exc) carries ER's response body, which must reach neither
+    the activity log nor the portal.
+    """
+    status = exc.status_code if isinstance(exc.status_code, int) else None
+    if isinstance(exc, ERClientBadCredentials):
+        return IntegrationAuthError("EarthRanger rejected the credentials", status_code=status or 401)
+    if isinstance(exc, ERClientPermissionDenied):
+        return IntegrationAuthError("EarthRanger denied access with these credentials", status_code=status or 403)
+    if isinstance(exc, ERClientRateLimitExceeded):
+        return IntegrationRateLimitError("EarthRanger rate-limited the request", status_code=status or 429)
+    if isinstance(exc, ERClientServiceUnreachable):
+        return IntegrationConnectionError("EarthRanger could not be reached", status_code=status)
+    return IntegrationBadResponseError("EarthRanger returned an unexpected response", status_code=status)
+
+
+@asynccontextmanager
+async def _reference_er_client(integration: Integration):
+    """`_build_er_client` for the reference actions: erclient failures raised
+    in the body come out as IntegrationError subclasses (_as_integration_error)."""
+    try:
+        async with _build_er_client(integration) as er_client:
+            yield er_client
+    except ERClientException as e:
+        raise _as_integration_error(e) from e
+
+
 async def _fetch_category_display_map(er_client) -> Dict[str, str]:
     """Best-effort category slug → display name, unconditionally fetched.
 
@@ -1489,8 +1549,8 @@ async def action_list_event_types(integration: Integration, action_config: ListE
     grouped by ER event category (falling back to no group when the
     category has no known display name), sorted by group then label.
     """
-    async with _build_er_client(integration) as earth_ranger:
-        maps = await _fetch_event_type_maps(earth_ranger)
+    async with _reference_er_client(integration) as earth_ranger:
+        maps = await _fetch_event_type_maps(earth_ranger, propagate_auth_errors=True)
         category_display = await _fetch_category_display_map(earth_ranger)
 
     # The unconditional fetch above is authoritative (covers every category,
@@ -1538,7 +1598,7 @@ async def action_list_event_categories(integration: Integration, action_config: 
     propagate so the portal shows its "couldn't load options" degrade
     instead of silently offering an empty list.
     """
-    async with _build_er_client(integration) as earth_ranger:
+    async with _reference_er_client(integration) as earth_ranger:
         categories = await earth_ranger.get_event_categories()
 
     options = [
@@ -1563,7 +1623,7 @@ async def action_list_subject_types(integration: Integration, action_config: Lis
     propagate so the portal shows its "couldn't load options" degrade
     instead of silently offering an empty list.
     """
-    async with _build_er_client(integration) as earth_ranger:
+    async with _reference_er_client(integration) as earth_ranger:
         groups = await earth_ranger.get_subjectgroups(include_inactive=True, flat=True)
 
     type_by_subtype: Dict[str, str] = {}
@@ -1602,7 +1662,7 @@ async def action_list_subject_types(integration: Integration, action_config: Lis
 
 async def action_list_event_type_fields(integration: Integration, action_config: ListEventTypeFieldsQuery):
     """Reference action: field keys defined on one ER event type's schema."""
-    async with _build_er_client(integration) as earth_ranger:
+    async with _reference_er_client(integration) as earth_ranger:
         fields = await _fetch_event_type_fields(
             earth_ranger, integration.base_url, action_config.event_type
         )
@@ -1624,7 +1684,7 @@ async def action_list_event_field_values(integration: Integration, action_config
     Non-enum fields legitimately return an empty options list — they are
     free-text in ER, so there is nothing to suggest.
     """
-    async with _build_er_client(integration) as earth_ranger:
+    async with _reference_er_client(integration) as earth_ranger:
         fields = await _fetch_event_type_fields(
             earth_ranger, integration.base_url, action_config.event_type
         )

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -34,6 +34,7 @@ from ..services.activity_logger import activity_logger, log_action_activity
 from ..services.errors import (
     IntegrationAuthError,
     IntegrationBadResponseError,
+    IntegrationConfigurationError,
     IntegrationConnectionError,
     IntegrationError,
     IntegrationRateLimitError,
@@ -1139,8 +1140,11 @@ def get_authentication_config(integration):
         action_id='auth'
     )
     if not auth_action_config:
-        raise ValueError(
-            f"Authentication settings for integration {str(integration.id)} are missing. Please fix the integration setup in the portal."
+        # A configuration error, not an EarthRanger verdict: the runner forwards
+        # it on the ephemeral path (422) so the portal wizard can act on it.
+        # No integration id in the message; the runner logs that itself.
+        raise IntegrationConfigurationError(
+            "Authentication settings are missing. Please fix the integration setup in the portal."
         )
     return AuthenticateConfig.parse_obj(auth_action_config.data)
 
@@ -1464,9 +1468,10 @@ def _build_er_client(integration: Integration) -> AsyncERClient:
     url_parse = urlparse(integration.base_url)
     if not url_parse.hostname:
         # Schemeless/empty base_urls occur in Gundi; without this guard the
-        # client would be built against "https://None/...". Same message as
-        # action_auth's validation for consistency.
-        raise ValueError(f"Site URL is empty or invalid: '{integration.base_url}'")
+        # client would be built against "https://None/...". Same wording as
+        # action_auth's validation; the URL itself is a submitted value and
+        # stays out of the message (IntegrationConfigurationError contract).
+        raise IntegrationConfigurationError("Site URL is empty or invalid.")
     return AsyncERClient(
         service_root=f"{url_parse.scheme}://{url_parse.hostname}/api/v1.0",
         username=auth_config.username or None,
@@ -1574,17 +1579,19 @@ async def _fetch_event_type_fields(er_client, base_url: str, event_type: str):
     """Fetch + parse an ER event type's pre-rendered schema into ERFields.
 
     A 404 from ER (unknown event type, or a classic v1 event type — the v2
-    schema endpoint 404s for those too) is translated to a ValueError so it
-    reads naturally as a config-form error; any other upstream failure
-    (e.g. a 5xx) propagates unchanged.
+    schema endpoint 404s for those too) is translated to an
+    IntegrationConfigurationError so it reads as a config-form error and the
+    portal wizard sees it on the ephemeral path; any other upstream failure
+    (e.g. a 5xx) propagates unchanged and is classified by its status.
     """
     try:
         raw_schema = await fetch_prerendered_event_schema(er_client, base_url, event_type)
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 404:
-            raise ValueError(
-                f"Event type '{event_type}' has no v2 schema in EarthRanger "
-                "(classic v1 event types are not supported by reference actions)."
+            logger.info(f"EarthRanger has no v2 schema for event type '{event_type}'.")
+            raise IntegrationConfigurationError(
+                "Event type not found in EarthRanger, or it is a classic v1 event type "
+                "(reference actions support v2 event types only)."
             ) from e
         raise
     return parse_er_event_schema(raw_schema)
@@ -1691,10 +1698,11 @@ async def action_list_event_field_values(integration: Integration, action_config
 
     field_match = next((f for f in fields if f.key == action_config.field_key), None)
     if field_match is None:
-        raise ValueError(
+        logger.info(
             f"Field '{action_config.field_key}' not found on event type "
             f"'{action_config.event_type}' in EarthRanger."
         )
+        raise IntegrationConfigurationError("Field not found on that event type in EarthRanger.")
     if not field_match.is_enum:
         return ReferenceDataResponse(options=[]).dict()
     options = [

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -14,6 +14,7 @@ from dateutil import parser as dateutil_parser
 from erclient import AsyncERClient, ERClientException, VERSION_1_0, VERSION_2_0
 from erclient.er_errors import (
     ERClientBadCredentials,
+    ERClientBadRequest,
     ERClientPermissionDenied,
     ERClientRateLimitExceeded,
     ERClientServiceUnreachable,
@@ -25,7 +26,7 @@ from app import settings
 from app.services.utils import find_config_for_action
 from app.services.state import IntegrationStateManager
 from .core import ReferenceDataResponse, ReferenceOption
-from .er_schema import fetch_prerendered_event_schema, parse_er_event_schema
+from .er_schema import er_site_root, fetch_prerendered_event_schema, parse_er_event_schema
 from .configurations import AuthenticateConfig, EventFilterDateField, PullObservationsConfig, PullEventsConfig, \
     ERAuthenticationType, ShowPermissionsConfig, ListEventTypesQuery, ListEventTypeFieldsQuery, \
     ListEventFieldValuesQuery, ListEventCategoriesQuery, ListSubjectTypesQuery
@@ -66,18 +67,18 @@ ER_EVENT_FILTER_KEY_BY_DATE_FIELD = {
 
 async def action_auth(integration: Integration, action_config: AuthenticateConfig):
     auth_config = action_config
-    url_parse = urlparse(integration.base_url)
-    if not url_parse.hostname:
+    try:
+        site_root = er_site_root(integration.base_url)
+    except IntegrationConfigurationError as e:
         # action_auth reports failures inside a normal result, which nothing in
-        # the runner redacts, so the URL (a submitted value that may carry a
-        # token in its path or query) stays out of the message.
-        return {"valid_credentials": False, "error": "Site URL is empty or invalid."}
+        # the runner redacts; the helper's message keeps the URL out.
+        return {"valid_credentials": False, "error": e.message}
     async with AsyncERClient(
-            service_root=f"{url_parse.scheme}://{url_parse.hostname}/api/v1.0",
+            service_root=f"{site_root}/api/v1.0",
             username=auth_config.username,
             password=auth_config.password.get_secret_value() if auth_config.password else None,
             token=auth_config.token.get_secret_value() if auth_config.token else None,
-            token_url=f"{url_parse.scheme}://{url_parse.hostname}/oauth2/token",
+            token_url=f"{site_root}/oauth2/token",
             client_id="das_web_client",
             connect_timeout=DEFAULT_CONNECT_TIMEOUT_SECONDS,
     ) as er_client:
@@ -94,14 +95,13 @@ async def action_auth(integration: Integration, action_config: AuthenticateConfi
                 valid_credentials = await er_client.login()
             else:
                 return {"valid_credentials": False, "error": "Please select an valid authentication method."}
-        except ERClientException as e:
-            # Same fixed messages the reference actions use: str(e) carries
-            # ER's response body, which must not come back in the result.
+        except (ERClientException, httpx.HTTPError) as e:
+            # Same fixed messages the reference actions use. str(e) carries
+            # ER's response body or our request (for login(), the password),
+            # which must not come back in the result. login() itself raises
+            # raw httpx errors (it runs outside erclient's _call), so the
+            # translation handles both shapes.
             return {"valid_credentials": False, "error": _as_integration_error(e).message}
-        except httpx.HTTPError:
-            # The exception text carries the request; the source status, if
-            # any, is not what the operator needs here.
-            return {"valid_credentials": False, "error": "Could not reach EarthRanger."}
         return {"valid_credentials": valid_credentials}
 
 
@@ -321,17 +321,18 @@ async def action_show_permissions(integration: Integration, action_config: ShowP
       }
     }
     auth_config = get_authentication_config(integration=integration)
-    url_parse = urlparse(integration.base_url)
-    if not url_parse.hostname:
-        response["data"]["User Details"]["error"] = f"Site URL is empty or invalid: '{integration.base_url}'"
+    try:
+        site_root = er_site_root(integration.base_url)
+    except IntegrationConfigurationError as e:
+        response["data"]["User Details"]["error"] = e.message
         return response
 
     async with AsyncERClient(
-            service_root=f"{url_parse.scheme}://{url_parse.hostname}/api/v1.0",
+            service_root=f"{site_root}/api/v1.0",
             username=auth_config.username,
             password=auth_config.password.get_secret_value() if auth_config.password else None,
             token=auth_config.token.get_secret_value() if auth_config.token else None,
-            token_url=f"{url_parse.scheme}://{url_parse.hostname}/oauth2/token",
+            token_url=f"{site_root}/oauth2/token",
             client_id="das_web_client",
             connect_timeout=DEFAULT_CONNECT_TIMEOUT_SECONDS,
     ) as er_client:
@@ -422,12 +423,13 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
         "pull_events: integration.base_url=%r → er_ui_root=%r",
         integration.base_url, er_ui_root,
     )
+    site_root = er_site_root(integration.base_url)
     er_client = AsyncERClient(
-        service_root=f"{url_parse.scheme}://{url_parse.hostname}/api/v1.0",
+        service_root=f"{site_root}/api/v1.0",
         username=auth_config.username or None,
         password=auth_config.password.get_secret_value() if auth_config.password else None,
         token=auth_config.token.get_secret_value() if auth_config.token else None,
-        token_url=f"{url_parse.scheme}://{url_parse.hostname}/oauth2/token",
+        token_url=f"{site_root}/oauth2/token",
         client_id="das_web_client",
         connect_timeout=DEFAULT_CONNECT_TIMEOUT_SECONDS,
     )
@@ -667,13 +669,13 @@ async def action_pull_observations(integration: Integration, action_config: Pull
     execution_timestamp = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
     pull_config = action_config
     auth_config = get_authentication_config(integration=integration)
-    url_parse = urlparse(integration.base_url)
+    site_root = er_site_root(integration.base_url)
     er_client = AsyncERClient(
-        service_root=f"{url_parse.scheme}://{url_parse.hostname}/api/v1.0",
+        service_root=f"{site_root}/api/v1.0",
         username=auth_config.username or None,
         password=auth_config.password.get_secret_value() if auth_config.password else None,
         token=auth_config.token.get_secret_value() if auth_config.token else None,
-        token_url=f"{url_parse.scheme}://{url_parse.hostname}/oauth2/token",
+        token_url=f"{site_root}/oauth2/token",
         client_id="das_web_client",
         connect_timeout=DEFAULT_CONNECT_TIMEOUT_SECONDS,
     )
@@ -1185,12 +1187,7 @@ class EventTypeMaps:
     v2_slugs: set = field(default_factory=set)
 
 
-# erclient failures that mean "these credentials don't work here", as opposed
-# to one endpoint being unavailable.
-_ER_AUTH_ERRORS = (ERClientBadCredentials, ERClientPermissionDenied)
-
-
-async def _fetch_event_type_maps(er_client, *, propagate_auth_errors: bool = False) -> EventTypeMaps:
+async def _fetch_event_type_maps(er_client, *, strict_v2: bool = False) -> EventTypeMaps:
     """Build slug→display, slug→type_id, and category_slug→category_id maps.
 
     ER's EventType has a ``version`` field — each type is exclusively v1 OR
@@ -1209,17 +1206,18 @@ async def _fetch_event_type_maps(er_client, *, propagate_auth_errors: bool = Fal
     All three fetches are best-effort and logged independently — a 403 on
     one doesn't break the others. If everything fails, all maps are empty;
     downstream callers treat that as the "skip the pull" signal. The
-    reference path passes propagate_auth_errors=True: there, an empty result
-    on bad credentials would render as an empty dropdown rather than as
-    "Authentication failed", so auth failures escape instead.
+    reference path (list_event_types) passes strict_v2=True: it offers only
+    v2 slugs, so the v2 fetch is load-bearing there and any failure of it
+    (bad credentials, a 5xx, a rate limit, a network error) propagates, where
+    an empty result would render as an empty dropdown with a 200. The v1 and
+    categories fetches only enrich grouping and stay best-effort, so a role
+    denied on the legacy endpoint still gets its dropdown.
     """
     maps = EventTypeMaps()
 
     try:
         v1_types = await er_client.get_event_types(version=VERSION_1_0)
     except Exception as e:
-        if propagate_auth_errors and isinstance(e, _ER_AUTH_ERRORS):
-            raise
         logger.warning(
             "Could not fetch ER v1 event types: %s: %s. "
             "Slug→UUID resolution will fall back to v2-only results.",
@@ -1233,7 +1231,7 @@ async def _fetch_event_type_maps(er_client, *, propagate_auth_errors: bool = Fal
     try:
         v2_types = await er_client.get_event_types(version=VERSION_2_0)
     except Exception as e:
-        if propagate_auth_errors and isinstance(e, _ER_AUTH_ERRORS):
+        if strict_v2:
             raise
         logger.warning(
             "Could not fetch ER v2 event types: %s: %s. "
@@ -1253,8 +1251,6 @@ async def _fetch_event_type_maps(er_client, *, propagate_auth_errors: bool = Fal
         try:
             categories = await er_client.get_event_categories()
         except Exception as e:
-            if propagate_auth_errors and isinstance(e, _ER_AUTH_ERRORS):
-                raise
             logger.warning(
                 "Could not fetch ER event categories: %s: %s. "
                 "event_category filter slugs will not resolve.",
@@ -1469,42 +1465,60 @@ def _build_er_client(integration: Integration) -> AsyncERClient:
     """Standard AsyncERClient construction shared by the reference actions
     (mirrors action_pull_events / action_pull_observations)."""
     auth_config = get_authentication_config(integration=integration)
-    url_parse = urlparse(integration.base_url)
-    if not url_parse.hostname:
-        # Schemeless/empty base_urls occur in Gundi; without this guard the
-        # client would be built against "https://None/...". Same wording as
-        # action_auth's validation; the URL itself is a submitted value and
-        # stays out of the message (IntegrationConfigurationError contract).
-        raise IntegrationConfigurationError("Site URL is empty or invalid.")
+    site_root = er_site_root(integration.base_url)  # raises IntegrationConfigurationError, URL kept out
     return AsyncERClient(
-        service_root=f"{url_parse.scheme}://{url_parse.hostname}/api/v1.0",
+        service_root=f"{site_root}/api/v1.0",
         username=auth_config.username or None,
         password=auth_config.password.get_secret_value() if auth_config.password else None,
         token=auth_config.token.get_secret_value() if auth_config.token else None,
-        token_url=f"{url_parse.scheme}://{url_parse.hostname}/oauth2/token",
+        token_url=f"{site_root}/oauth2/token",
         client_id="das_web_client",
         connect_timeout=DEFAULT_CONNECT_TIMEOUT_SECONDS,
     )
 
 
-def _as_integration_error(exc: ERClientException) -> IntegrationError:
-    """Translate an erclient failure into the runner's classified errors.
+def _is_token_endpoint_failure(exc) -> bool:
+    """A failure of the login itself, as opposed to an API call: the token
+    endpoint answers 400 invalid_grant to a wrong username/password. Through
+    erclient's _call it arrives as ERClientBadRequest whose message names the
+    token URL; from a bare login()/auth_headers() it is the raw httpx error."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return "/oauth2/token" in str(exc.request.url)
+    return isinstance(exc, ERClientBadRequest) and "/oauth2/token" in str(exc)
+
+
+def _as_integration_error(exc: Exception) -> IntegrationError:
+    """Translate an erclient (or raw httpx) failure into the runner's classified errors.
 
     erclient's exceptions are not IntegrationError subclasses and carry no
     `.response`, so the runner cannot classify them: on the ephemeral path
     the portal wizard saw `500 {"error": "ERClientBadCredentials"}` and could
-    not tell bad credentials from a broken site. The message is fixed text on
-    purpose: str(exc) carries ER's response body, which must reach neither
-    the activity log nor the portal.
+    not tell bad credentials from a broken site. login() and auth_headers()
+    run outside erclient's _call wrapper and raise raw httpx errors, and a
+    network failure inside _call is a plain ERClientException with no status,
+    so those shapes are handled too. The messages are fixed text on purpose:
+    str(exc) carries ER's response body, or our request (for the login, the
+    password), which must reach neither the activity log nor the portal.
     """
-    status = exc.status_code if isinstance(exc.status_code, int) else None
-    if isinstance(exc, ERClientBadCredentials):
+    if isinstance(exc, httpx.TransportError):
+        return IntegrationConnectionError("EarthRanger could not be reached")
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        if _is_token_endpoint_failure(exc) or status in (401, 403):
+            return IntegrationAuthError("EarthRanger rejected the credentials", status_code=status)
+        if status == 429:
+            return IntegrationRateLimitError("EarthRanger rate-limited the request", status_code=status)
+        return IntegrationBadResponseError("EarthRanger returned an unexpected response", status_code=status)
+    if isinstance(exc, httpx.HTTPError):
+        return IntegrationBadResponseError("EarthRanger returned an unexpected response")
+    status = exc.status_code if isinstance(getattr(exc, "status_code", None), int) else None
+    if isinstance(exc, ERClientBadCredentials) or _is_token_endpoint_failure(exc):
         return IntegrationAuthError("EarthRanger rejected the credentials", status_code=status or 401)
     if isinstance(exc, ERClientPermissionDenied):
         return IntegrationAuthError("EarthRanger denied access with these credentials", status_code=status or 403)
     if isinstance(exc, ERClientRateLimitExceeded):
         return IntegrationRateLimitError("EarthRanger rate-limited the request", status_code=status or 429)
-    if isinstance(exc, ERClientServiceUnreachable):
+    if isinstance(exc, ERClientServiceUnreachable) or str(exc).startswith("Request to ER failed"):
         return IntegrationConnectionError("EarthRanger could not be reached", status_code=status)
     return IntegrationBadResponseError("EarthRanger returned an unexpected response", status_code=status)
 
@@ -1516,7 +1530,7 @@ async def _reference_er_client(integration: Integration):
     try:
         async with _build_er_client(integration) as er_client:
             yield er_client
-    except ERClientException as e:
+    except (ERClientException, httpx.HTTPError) as e:
         raise _as_integration_error(e) from e
 
 
@@ -1559,7 +1573,7 @@ async def action_list_event_types(integration: Integration, action_config: ListE
     category has no known display name), sorted by group then label.
     """
     async with _reference_er_client(integration) as earth_ranger:
-        maps = await _fetch_event_type_maps(earth_ranger, propagate_auth_errors=True)
+        maps = await _fetch_event_type_maps(earth_ranger, strict_v2=True)
         category_display = await _fetch_category_display_map(earth_ranger)
 
     # The unconditional fetch above is authoritative (covers every category,

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -12,13 +12,7 @@ import httpx
 import stamina
 from dateutil import parser as dateutil_parser
 from erclient import AsyncERClient, ERClientException, VERSION_1_0, VERSION_2_0
-from erclient.er_errors import (
-    ERClientBadCredentials,
-    ERClientBadRequest,
-    ERClientPermissionDenied,
-    ERClientRateLimitExceeded,
-    ERClientServiceUnreachable,
-)
+from erclient.er_errors import ERClientBadRequest, ERClientServiceUnreachable
 from gundi_client_v2.client import GundiClient
 from gundi_core.events import LogLevel
 from gundi_core.schemas.v2 import Integration
@@ -332,9 +326,11 @@ async def action_show_permissions(integration: Integration, action_config: ShowP
             else:
                 response["data"]["User Details"]["error"] = "Please select an valid authentication method."
                 return response
-        except _ER_CALL_FAILURES as e:
+        except Exception as e:
             # Same fixed texts as action_auth: str(e) carries ER's response
             # body or our login request, neither of which belongs in the card.
+            # A catch-all on purpose: this action's contract is to return the
+            # card with the error in it, whatever the client raised.
             response["data"]["User Details"]["error"] = _as_integration_error(e).message
             return response  # Cannot continue without a valid user/token
         response["data"]["User Details"] = _extract_user_details(er_user_details=er_user_details)
@@ -418,7 +414,7 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
     updates_emitted = 0  # individual update_event calls (notes + field changes)
     events_skipped_unchanged = 0
     attachments_forwarded = 0
-    async with _translating_er_client(integration, auth_config=auth_config) as earth_ranger:
+    async with _translating_er_client(integration, auth_config=auth_config, only_er_requests=True) as earth_ranger:
         # One get_event_types() call powers two things:
         #   1) Operator-configured event_type / event_category slugs must be
         #      resolved to UUIDs before being sent in the ER filter blob —
@@ -638,7 +634,7 @@ async def action_pull_observations(integration: Integration, action_config: Pull
     start_monotonic = time.monotonic()
     soft_budget = settings.MAX_ACTION_EXECUTION_TIME * BUDGET_FRACTION
 
-    async with _translating_er_client(integration, auth_config=auth_config) as earth_ranger:
+    async with _translating_er_client(integration, auth_config=auth_config, only_er_requests=True) as earth_ranger:
         # Mutual exclusion: a long backfill may still be running when the next
         # scheduled tick fires. Without the lease, both would process the same
         # cursor units concurrently (duplicate sends + cursor races).
@@ -1432,7 +1428,7 @@ def _build_er_client(integration: Integration, auth_config: Optional[Authenticat
     if auth_config is None:
         auth_config = get_authentication_config(integration=integration)
     site_root = er_site_root(integration.base_url)
-    return AsyncERClient(
+    client = AsyncERClient(
         service_root=f"{site_root}/api/v1.0",
         username=auth_config.username or None,
         password=auth_config.password.get_secret_value() if auth_config.password else None,
@@ -1441,6 +1437,25 @@ def _build_er_client(integration: Integration, auth_config: Optional[Authenticat
         client_id="das_web_client",
         connect_timeout=DEFAULT_CONNECT_TIMEOUT_SECONDS,
     )
+    # erclient's auth_headers() tries refresh_token() first and falls back to
+    # login() only when the refresh returns False, but _token_request raises
+    # on the token endpoint's 400 instead. A stale refresh token mid-run (a
+    # backfill outlasting the access token) would then surface as a rejected
+    # login with a perfectly good stored password. Turn that one case into
+    # the False erclient expects, so the fallback login runs; a genuinely
+    # wrong password still fails there and is reported as rejected.
+    original_refresh = client.refresh_token
+
+    async def refresh_or_fall_back_to_login(*args, **kwargs):
+        try:
+            return await original_refresh(*args, **kwargs)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 400:
+                return False
+            raise
+
+    client.refresh_token = refresh_or_fall_back_to_login
+    return client
 
 
 def _is_token_endpoint_url(url) -> bool:
@@ -1511,6 +1526,14 @@ def _as_integration_error(exc: Exception) -> IntegrationError:
         return IntegrationAuthError("EarthRanger rejected the credentials", status_code=status)
     if status == 403:
         return IntegrationAuthError("EarthRanger denied access with these credentials", status_code=status)
+    if status == 404:
+        # An ER without the API this action needs (no v2 event-type API, or a
+        # proxy routing only v1). A configuration problem, reported as such:
+        # forwarding the 404 would collide with the runner's own 404 for
+        # "action or configuration not found".
+        return IntegrationConfigurationError(
+            "EarthRanger does not expose the API this action needs; check the site URL and EarthRanger version."
+        )
     if status in (429, 409):  # erclient maps 409 (one observation per second per source) to its rate-limit class too
         return IntegrationRateLimitError("EarthRanger rate-limited the request", status_code=status)
     if status in (502, 503, 504):
@@ -1524,19 +1547,40 @@ def _as_integration_error(exc: Exception) -> IntegrationError:
 
 
 @asynccontextmanager
-async def _translating_er_client(integration: Integration, auth_config: Optional[AuthenticateConfig] = None):
-    """`_build_er_client`, entered, with every EarthRanger call failure raised
-    in the body coming out as an IntegrationError (_as_integration_error).
+async def _translating_er_client(
+        integration: Integration, auth_config: Optional[AuthenticateConfig] = None, *, only_er_requests: bool = False,
+):
+    """`_build_er_client`, entered, with EarthRanger call failures raised in
+    the body coming out as IntegrationErrors (_as_integration_error).
 
-    Used by the reference actions and the pull actions alike. Beyond
-    classification, this is what keeps credentials out of the activity feed on
-    a saved integration: a transport failure on the token POST escapes erclient
-    raw with `.request` intact, and the runner publishes `request.content`,
-    which is the form-encoded username and password."""
+    The client is built outside the translation: parsing the stored auth
+    config can raise a pydantic ValidationError (a ValueError), which the
+    runner renders itself and which is not an EarthRanger verdict.
+
+    The reference actions and show_permissions only talk to EarthRanger in
+    the body, so everything an ER call can raise is translated. The pull
+    actions (only_er_requests=True) also talk to Gundi's Sensors API and run
+    connector code in the body: there, only erclient's own exceptions and
+    httpx errors whose request went to the ER site are translated. Everything
+    else, a Gundi 401 or a connector bug, reaches the runner untouched, with
+    its request details and traceback, so the activity feed keeps saying
+    which side failed. The translated case still matters on that path: a
+    transport failure on the token POST escapes erclient raw with `.request`
+    intact, and the runner publishes `request.content`, which is the
+    form-encoded username and password."""
+    client = _build_er_client(integration, auth_config=auth_config)
+    site_root = er_site_root(integration.base_url)
     try:
-        async with _build_er_client(integration, auth_config=auth_config) as er_client:
+        async with client as er_client:
             yield er_client
-    except _ER_CALL_FAILURES as e:
+    except (ERClientException, httpx.HTTPError) if only_er_requests else _ER_CALL_FAILURES as e:
+        if only_er_requests and isinstance(e, httpx.HTTPError):
+            try:
+                request_url = str(e.request.url)
+            except RuntimeError:  # httpx: no request attached
+                request_url = ""
+            if not request_url.startswith(site_root):
+                raise  # Gundi (or anything else): not ours to relabel
         translated = _as_integration_error(e)
         # Local log only, and by type and status: str(e) carries ER's response
         # body or our request. No chained cause either: on a saved integration

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -87,7 +87,7 @@ async def action_auth(integration: Integration, action_config: AuthenticateConfi
                 valid_credentials = await er_client.login()
             else:
                 return {"valid_credentials": False, "error": "Please select an valid authentication method."}
-        except (ERClientException, httpx.HTTPError) as e:
+        except _ER_CALL_FAILURES as e:
             # Same fixed messages the reference actions use. str(e) carries
             # ER's response body or our request (for login(), the password),
             # which must not come back in the result. login() itself raises
@@ -332,7 +332,7 @@ async def action_show_permissions(integration: Integration, action_config: ShowP
             else:
                 response["data"]["User Details"]["error"] = "Please select an valid authentication method."
                 return response
-        except (ERClientException, httpx.HTTPError) as e:
+        except _ER_CALL_FAILURES as e:
             # Same fixed texts as action_auth: str(e) carries ER's response
             # body or our login request, neither of which belongs in the card.
             response["data"]["User Details"]["error"] = _as_integration_error(e).message
@@ -344,7 +344,7 @@ async def action_show_permissions(integration: Integration, action_config: ShowP
         try:  # Get event categories and types from the activity/events/eventtypes endpoint
             event_types_response = _as_list(await er_client.get_event_types())
         except Exception as e:
-            response["data"]["Event Categories"]["error"] = f"Error retrieving event categories: {type(e).__name__}:{e}"
+            response["data"]["Event Categories"]["error"] = _as_integration_error(e).message
         else:
             event_types_response = [et for et in event_types_response if isinstance(et, dict)]
             response["data"]["Event Categories"] = _merge_event_categories_and_type_perms(
@@ -365,7 +365,7 @@ async def action_show_permissions(integration: Integration, action_config: ShowP
                 flat=not include_subjects_from_subgroups_in_parent
             )
         except Exception as e:
-            response["data"]["Subject Groups"]["error"] = f"Error retrieving subject groups: {type(e).__name__}:{e}"
+            response["data"]["Subject Groups"]["error"] = _as_integration_error(e).message
         else:
             response["data"]["Subject Groups"] = _extract_subject_groups(er_subject_groups=subject_groups_response)
             response["data"]["Subject Group UUIDs"] = sorted(
@@ -398,7 +398,6 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
         "pull_events: integration.base_url=%r → er_ui_root=%r",
         integration.base_url, er_ui_root,
     )
-    er_client = _build_er_client(integration, auth_config=auth_config)
     # Prepare filters to extract Data Since last execution
     state = await state_manager.get_state(
         integration_id=integration_id, action_id="pull_events"
@@ -419,7 +418,7 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
     updates_emitted = 0  # individual update_event calls (notes + field changes)
     events_skipped_unchanged = 0
     attachments_forwarded = 0
-    async with er_client as earth_ranger:
+    async with _translating_er_client(integration, auth_config=auth_config) as earth_ranger:
         # One get_event_types() call powers two things:
         #   1) Operator-configured event_type / event_category slugs must be
         #      resolved to UUIDs before being sent in the ER filter blob —
@@ -635,12 +634,11 @@ async def action_pull_observations(integration: Integration, action_config: Pull
     execution_timestamp = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
     pull_config = action_config
     auth_config = get_authentication_config(integration=integration)
-    er_client = _build_er_client(integration, auth_config=auth_config)
 
     start_monotonic = time.monotonic()
     soft_budget = settings.MAX_ACTION_EXECUTION_TIME * BUDGET_FRACTION
 
-    async with er_client as earth_ranger:
+    async with _translating_er_client(integration, auth_config=auth_config) as earth_ranger:
         # Mutual exclusion: a long backfill may still be running when the next
         # scheduled tick fires. Without the lease, both would process the same
         # cursor units concurrently (duplicate sends + cursor races).
@@ -1147,7 +1145,7 @@ class EventTypeMaps:
 def _failure_summary(exc: Exception) -> str:
     """Type and status only, for log lines about best-effort ER calls: str(exc)
     carries ER's response body (or, for a login failure, our request)."""
-    status = getattr(exc, "status_code", None) or getattr(getattr(exc, "response", None), "status_code", None)
+    status = _status_of(exc)
     return f"{type(exc).__name__} (status {status})" if status else type(exc).__name__
 
 
@@ -1449,79 +1447,102 @@ def _is_token_endpoint_url(url) -> bool:
     return "/oauth2/token" in str(url)
 
 
+def _status_of(exc: Exception):
+    """The HTTP status an exception carries, if any: erclient sets
+    `status_code`; raw httpx status errors carry `response.status_code`."""
+    status = getattr(exc, "status_code", None)
+    if not isinstance(status, int):
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+    return status if isinstance(status, int) and not isinstance(status, bool) else None
+
+
 def _is_rejected_login(exc) -> bool:
     """The login itself was rejected, as opposed to an API call failing: the
     token endpoint answers 400 invalid_grant (or 401/403) to a wrong username
-    or password. Through erclient's _call it arrives as ERClientBadRequest
-    whose message names the token URL; from a bare login()/auth_headers() it
-    is the raw httpx error. A 5xx or 429 from the token endpoint is not a
-    rejection and is classified like any other status."""
+    or password. Through erclient's _call it arrives as ERClientBadRequest whose
+    message (args[0], not str(), which appends ER's response body) names the
+    token URL; from a bare login()/auth_headers() it is the raw httpx error for
+    that URL. A 5xx or 429 from the token endpoint is not a rejection."""
     if isinstance(exc, httpx.HTTPStatusError):
         return _is_token_endpoint_url(exc.request.url) and exc.response.status_code in (400, 401, 403)
-    return isinstance(exc, ERClientBadRequest) and _is_token_endpoint_url(str(exc))
+    return (
+        isinstance(exc, ERClientBadRequest)
+        and bool(exc.args) and _is_token_endpoint_url(exc.args[0])
+    )
+
+
+# Exceptions an EarthRanger call can raise. erclient's own hierarchy; raw
+# httpx errors from login()/auth_headers(), which run outside its _call
+# wrapper; and the ValueError/KeyError erclient itself raises on realistic
+# failures (HTTPStatus(...).phrase on a CDN's 520, response.json() on a 200
+# HTML page, auth["expires_in"] missing from a token body).
+_ER_CALL_FAILURES = (ERClientException, httpx.HTTPError, ValueError, KeyError)
 
 
 def _as_integration_error(exc: Exception) -> IntegrationError:
-    """Translate an erclient (or raw httpx) failure into the runner's classified errors.
+    """Translate an EarthRanger call failure into the runner's classified errors.
 
     erclient's exceptions are not IntegrationError subclasses and carry no
     `.response`, so the runner cannot classify them: on the ephemeral path
     the portal wizard saw `500 {"error": "ERClientBadCredentials"}` and could
-    not tell bad credentials from a broken site. login() and auth_headers()
-    run outside erclient's _call wrapper and raise raw httpx errors, and a
-    network failure inside _call is a plain ERClientException with no status,
-    so those shapes are handled too. The messages are fixed text on purpose:
-    str(exc) carries ER's response body, or our request (for the login, the
-    password), which must reach neither the activity log nor the portal.
+    not tell bad credentials from a broken site. One table keyed by the HTTP
+    status serves every shape (erclient, raw httpx, erclient's own
+    ValueError/KeyError), so the same ER verdict reads the same whichever
+    path it took. The messages are fixed text on purpose: str(exc) carries
+    ER's response body, or our request (for the login, the password), which
+    must reach neither the activity log nor the portal.
     """
-    # A rejected login is reported as 401 whatever the token endpoint said
-    # (it says 400 invalid_grant): the portal treats 401/403 as a credential
+    # A rejected login is reported as 401 whatever the token endpoint said (it
+    # says 400 invalid_grant): the portal treats 401/403 as a credential
     # rejection and shows the operator that, which is the point.
     if _is_rejected_login(exc):
         return IntegrationAuthError("EarthRanger rejected the credentials", status_code=401)
-    if isinstance(exc, httpx.TransportError):
-        return IntegrationConnectionError("EarthRanger could not be reached")
-    if isinstance(exc, httpx.HTTPStatusError):
-        status = exc.response.status_code
-        if status in (401, 403):
-            return IntegrationAuthError("EarthRanger rejected the credentials", status_code=status)
-        if status == 429:
-            return IntegrationRateLimitError("EarthRanger rate-limited the request", status_code=status)
-        if status in (502, 503, 504):
-            return IntegrationConnectionError("EarthRanger could not be reached", status_code=status)
-        return IntegrationBadResponseError("EarthRanger returned an unexpected response", status_code=status)
-    if isinstance(exc, httpx.HTTPError):
-        return IntegrationBadResponseError("EarthRanger returned an unexpected response")
-    status = exc.status_code if isinstance(getattr(exc, "status_code", None), int) else None
-    if isinstance(exc, ERClientBadCredentials):
-        return IntegrationAuthError("EarthRanger rejected the credentials", status_code=status or 401)
-    if isinstance(exc, ERClientPermissionDenied):
-        return IntegrationAuthError("EarthRanger denied access with these credentials", status_code=status or 403)
-    if isinstance(exc, ERClientRateLimitExceeded):
-        return IntegrationRateLimitError("EarthRanger rate-limited the request", status_code=status or 429)
-    if isinstance(exc, ERClientServiceUnreachable) or str(exc).startswith("Request to ER failed"):
+    status = _status_of(exc)
+    if isinstance(exc, ERClientServiceUnreachable):
         return IntegrationConnectionError("EarthRanger could not be reached", status_code=status)
+    if isinstance(exc, httpx.TransportError) or (type(exc) is ERClientException and status is None):
+        # httpx never escapes _call, so post-login network failures arrive as
+        # erclient's status-less plain ERClientException (its network branch is
+        # the only status-less raise a reference action can reach).
+        return IntegrationConnectionError("EarthRanger could not be reached")
+    if status is None:
+        return IntegrationBadResponseError("EarthRanger returned an unexpected response")
+    if status == 401:
+        return IntegrationAuthError("EarthRanger rejected the credentials", status_code=status)
+    if status == 403:
+        return IntegrationAuthError("EarthRanger denied access with these credentials", status_code=status)
+    if status in (429, 409):  # erclient maps 409 (one observation per second per source) to its rate-limit class too
+        return IntegrationRateLimitError("EarthRanger rate-limited the request", status_code=status)
+    if status in (502, 503, 504):
+        return IntegrationConnectionError("EarthRanger could not be reached", status_code=status)
+    if 300 <= status < 400:
+        # erclient's httpx client does not follow redirects, so an http:// site
+        # URL surfaces as the 3xx to https. A configuration problem, not a
+        # provider verdict; the wizard cannot classify a 3xx status either.
+        return IntegrationConfigurationError("Site URL redirects elsewhere; use the site's https URL.")
     return IntegrationBadResponseError("EarthRanger returned an unexpected response", status_code=status)
 
 
 @asynccontextmanager
-async def _reference_er_client(integration: Integration):
-    """`_build_er_client` for the reference actions: erclient failures raised
-    in the body come out as IntegrationError subclasses (_as_integration_error)."""
+async def _translating_er_client(integration: Integration, auth_config: Optional[AuthenticateConfig] = None):
+    """`_build_er_client`, entered, with every EarthRanger call failure raised
+    in the body coming out as an IntegrationError (_as_integration_error).
+
+    Used by the reference actions and the pull actions alike. Beyond
+    classification, this is what keeps credentials out of the activity feed on
+    a saved integration: a transport failure on the token POST escapes erclient
+    raw with `.request` intact, and the runner publishes `request.content`,
+    which is the form-encoded username and password."""
     try:
-        async with _build_er_client(integration) as er_client:
+        async with _build_er_client(integration, auth_config=auth_config) as er_client:
             yield er_client
-    except (ERClientException, httpx.HTTPError) as e:
+    except _ER_CALL_FAILURES as e:
         translated = _as_integration_error(e)
         # Local log only, and by type and status: str(e) carries ER's response
         # body or our request. No chained cause either: on a saved integration
         # the runner publishes the formatted traceback, whose chained-cause
         # section would render str(e) into the activity feed.
-        logger.info(
-            f"EarthRanger call failed on the reference path: {type(e).__name__} "
-            f"(status {getattr(e, 'status_code', None) or getattr(getattr(e, 'response', None), 'status_code', None)}) "
-            f"-> {type(translated).__name__}"
-        )
+        logger.info(f"EarthRanger call failed: {_failure_summary(e)} -> {type(translated).__name__}")
         raise translated from None
 
 
@@ -1562,7 +1583,7 @@ async def action_list_event_types(integration: Integration, action_config: ListE
     grouped by ER event category (falling back to no group when the
     category has no known display name), sorted by group then label.
     """
-    async with _reference_er_client(integration) as earth_ranger:
+    async with _translating_er_client(integration) as earth_ranger:
         maps = await _fetch_event_type_maps(earth_ranger, strict_v2=True)
         category_display = await _fetch_category_display_map(earth_ranger)
 
@@ -1597,10 +1618,12 @@ async def _fetch_event_type_fields(er_client, base_url: str, event_type: str):
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 404 and not _is_token_endpoint_url(e.request.url):
             logger.info(f"EarthRanger has no v2 schema for event type '{event_type}'.")
+            # from None: the published traceback would otherwise render the
+            # chained 404 with the ER host and the slug the message omits.
             raise IntegrationConfigurationError(
                 "Event type not found in EarthRanger, or it is a classic v1 event type "
                 "(reference actions support v2 event types only)."
-            ) from e
+            ) from None
         raise
     return parse_er_event_schema(raw_schema)
 
@@ -1613,7 +1636,7 @@ async def action_list_event_categories(integration: Integration, action_config: 
     propagate so the portal shows its "couldn't load options" degrade
     instead of silently offering an empty list.
     """
-    async with _reference_er_client(integration) as earth_ranger:
+    async with _translating_er_client(integration) as earth_ranger:
         categories = await earth_ranger.get_event_categories()
 
     options = [
@@ -1638,7 +1661,7 @@ async def action_list_subject_types(integration: Integration, action_config: Lis
     propagate so the portal shows its "couldn't load options" degrade
     instead of silently offering an empty list.
     """
-    async with _reference_er_client(integration) as earth_ranger:
+    async with _translating_er_client(integration) as earth_ranger:
         groups = await earth_ranger.get_subjectgroups(include_inactive=True, flat=True)
 
     type_by_subtype: Dict[str, str] = {}
@@ -1677,7 +1700,7 @@ async def action_list_subject_types(integration: Integration, action_config: Lis
 
 async def action_list_event_type_fields(integration: Integration, action_config: ListEventTypeFieldsQuery):
     """Reference action: field keys defined on one ER event type's schema."""
-    async with _reference_er_client(integration) as earth_ranger:
+    async with _translating_er_client(integration) as earth_ranger:
         fields = await _fetch_event_type_fields(
             earth_ranger, integration.base_url, action_config.event_type
         )
@@ -1699,7 +1722,7 @@ async def action_list_event_field_values(integration: Integration, action_config
     Non-enum fields legitimately return an empty options list — they are
     free-text in ER, so there is nothing to suggest.
     """
-    async with _reference_er_client(integration) as earth_ranger:
+    async with _translating_er_client(integration) as earth_ranger:
         fields = await _fetch_event_type_fields(
             earth_ranger, integration.base_url, action_config.event_type
         )

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -12,7 +12,7 @@ import httpx
 import stamina
 from dateutil import parser as dateutil_parser
 from erclient import AsyncERClient, ERClientException, VERSION_1_0, VERSION_2_0
-from erclient.er_errors import ERClientBadRequest, ERClientServiceUnreachable
+from erclient.er_errors import ERClientBadRequest
 from gundi_client_v2.client import GundiClient
 from gundi_core.events import LogLevel
 from gundi_core.schemas.v2 import Integration
@@ -1479,7 +1479,9 @@ def _is_rejected_login(exc) -> bool:
     token URL; from a bare login()/auth_headers() it is the raw httpx error for
     that URL. A 5xx or 429 from the token endpoint is not a rejection."""
     if isinstance(exc, httpx.HTTPStatusError):
-        return _is_token_endpoint_url(exc.request.url) and exc.response.status_code in (400, 401, 403)
+        # Not 403: the token endpoint never answers 403 for a credential
+        # rejection, so a 403 there is a proxy or WAF verdict ("denied access").
+        return _is_token_endpoint_url(exc.request.url) and exc.response.status_code in (400, 401)
     return (
         isinstance(exc, ERClientBadRequest)
         and bool(exc.args) and _is_token_endpoint_url(exc.args[0])
@@ -1494,7 +1496,7 @@ def _is_rejected_login(exc) -> bool:
 _ER_CALL_FAILURES = (ERClientException, httpx.HTTPError, ValueError, KeyError)
 
 
-def _as_integration_error(exc: Exception) -> IntegrationError:
+def _as_integration_error(exc: Exception, *, not_found_is_configuration: bool = True) -> IntegrationError:
     """Translate an EarthRanger call failure into the runner's classified errors.
 
     erclient's exceptions are not IntegrationError subclasses and carry no
@@ -1506,6 +1508,11 @@ def _as_integration_error(exc: Exception) -> IntegrationError:
     path it took. The messages are fixed text on purpose: str(exc) carries
     ER's response body, or our request (for the login, the password), which
     must reach neither the activity log nor the portal.
+
+    A 404 reads as a configuration error by default (the reference actions'
+    case: a site without the v2 event-type API); the pull actions pass
+    not_found_is_configuration=False, where a 404 means a stale resource such
+    as a deleted subject group and the operator needs the status.
     """
     # A rejected login is reported as 401 whatever the token endpoint said (it
     # says 400 invalid_grant): the portal treats 401/403 as a credential
@@ -1513,8 +1520,6 @@ def _as_integration_error(exc: Exception) -> IntegrationError:
     if _is_rejected_login(exc):
         return IntegrationAuthError("EarthRanger rejected the credentials", status_code=401)
     status = _status_of(exc)
-    if isinstance(exc, ERClientServiceUnreachable):
-        return IntegrationConnectionError("EarthRanger could not be reached", status_code=status)
     if isinstance(exc, httpx.TransportError) or (type(exc) is ERClientException and status is None):
         # httpx never escapes _call, so post-login network failures arrive as
         # erclient's status-less plain ERClientException (its network branch is
@@ -1526,7 +1531,7 @@ def _as_integration_error(exc: Exception) -> IntegrationError:
         return IntegrationAuthError("EarthRanger rejected the credentials", status_code=status)
     if status == 403:
         return IntegrationAuthError("EarthRanger denied access with these credentials", status_code=status)
-    if status == 404:
+    if status == 404 and not_found_is_configuration:
         # An ER without the API this action needs (no v2 event-type API, or a
         # proxy routing only v1). A configuration problem, reported as such:
         # forwarding the 404 would collide with the runner's own 404 for
@@ -1569,25 +1574,48 @@ async def _translating_er_client(
     intact, and the runner publishes `request.content`, which is the
     form-encoded username and password."""
     client = _build_er_client(integration, auth_config=auth_config)
-    site_root = er_site_root(integration.base_url)
+    site = httpx.URL(er_site_root(integration.base_url))  # normalises the host the way request URLs are
     try:
         async with client as er_client:
             yield er_client
-    except (ERClientException, httpx.HTTPError) if only_er_requests else _ER_CALL_FAILURES as e:
-        if only_er_requests and isinstance(e, httpx.HTTPError):
-            try:
-                request_url = str(e.request.url)
-            except RuntimeError:  # httpx: no request attached
-                request_url = ""
-            if not request_url.startswith(site_root):
-                raise  # Gundi (or anything else): not ours to relabel
-        translated = _as_integration_error(e)
-        # Local log only, and by type and status: str(e) carries ER's response
-        # body or our request. No chained cause either: on a saved integration
-        # the runner publishes the formatted traceback, whose chained-cause
-        # section would render str(e) into the activity feed.
-        logger.info(f"EarthRanger call failed: {_failure_summary(e)} -> {type(translated).__name__}")
+    except _ER_CALL_FAILURES as e:
+        if only_er_requests and not _is_earthranger_failure(e, site):
+            raise  # Gundi, or a connector bug: not ours to relabel, and it keeps its traceback
+        translated = _as_integration_error(e, not_found_is_configuration=not only_er_requests)
+        # No chained cause: on a saved integration the runner publishes the
+        # formatted traceback, whose chained-cause section would render str(e)
+        # (ER's response body, or our login request) into the activity feed.
+        # The local log keeps the full original instead, since for a
+        # status-less failure nothing else records which call failed or why.
+        logger.warning(
+            f"EarthRanger call failed: {_failure_summary(e)} -> {type(translated).__name__}", exc_info=e,
+        )
         raise translated from None
+
+
+def _is_earthranger_failure(exc: Exception, site: httpx.URL) -> bool:
+    """Whether an exception raised inside a pull action's body came from the
+    EarthRanger call rather than from Gundi or from connector code: erclient's
+    own exceptions always did; an httpx error did if its request went to the
+    ER site (compared by origin, host normalised as httpx does, so an IDN site
+    URL matches its punycode request URL and a look-alike host does not); a
+    ValueError/KeyError did if erclient raised it (HTTPStatus(...).phrase on a
+    CDN's 520, response.json() on an HTML page, a token body without
+    expires_in)."""
+    if isinstance(exc, ERClientException):
+        return True
+    if isinstance(exc, httpx.HTTPError):
+        try:
+            url = exc.request.url
+        except RuntimeError:  # httpx: no request attached
+            return False
+        return (url.scheme, url.host) == (site.scheme, site.host)
+    tb = exc.__traceback__
+    while tb is not None:
+        if "/erclient/" in tb.tb_frame.f_code.co_filename.replace("\\", "/"):
+            return True
+        tb = tb.tb_next
+    return False
 
 
 async def _fetch_category_display_map(er_client) -> Dict[str, str]:

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -68,7 +68,10 @@ async def action_auth(integration: Integration, action_config: AuthenticateConfi
     auth_config = action_config
     url_parse = urlparse(integration.base_url)
     if not url_parse.hostname:
-        return {"valid_credentials": False, "error": f"Site URL is empty or invalid: '{integration.base_url}'"}
+        # action_auth reports failures inside a normal result, which nothing in
+        # the runner redacts, so the URL (a submitted value that may carry a
+        # token in its path or query) stays out of the message.
+        return {"valid_credentials": False, "error": "Site URL is empty or invalid."}
     async with AsyncERClient(
             service_root=f"{url_parse.scheme}://{url_parse.hostname}/api/v1.0",
             username=auth_config.username,
@@ -91,13 +94,14 @@ async def action_auth(integration: Integration, action_config: AuthenticateConfi
                 valid_credentials = await er_client.login()
             else:
                 return {"valid_credentials": False, "error": "Please select an valid authentication method."}
-        except ERClientBadCredentials:
-            return {"valid_credentials": False, "error": "Invalid credentials"}
         except ERClientException as e:
-            # ToDo. Differentiate ER errors from invalid credentials in the ER client
-            return {"valid_credentials": False, "error": str(e)}
-        except httpx.HTTPError as e:
-            return {"valid_credentials": False, "error": f"HTTP error: {e}"}
+            # Same fixed messages the reference actions use: str(e) carries
+            # ER's response body, which must not come back in the result.
+            return {"valid_credentials": False, "error": _as_integration_error(e).message}
+        except httpx.HTTPError:
+            # The exception text carries the request; the source status, if
+            # any, is not what the operator needs here.
+            return {"valid_credentials": False, "error": "Could not reach EarthRanger."}
         return {"valid_credentials": valid_credentials}
 
 

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -1,7 +1,9 @@
 import json
 
 import pytest
-from erclient import ERClientPermissionDenied
+import httpx
+from erclient import ERClientException, ERClientPermissionDenied
+from erclient.er_errors import ERClientBadCredentials
 from gundi_core.events import LogLevel
 
 from app.conftest import async_return
@@ -91,6 +93,59 @@ async def test_execute_auth_action_with_invalid_credentials(
     assert mock_erclient_class_with_error.return_value.get_me.called
     assert response.get("valid_credentials") == False
     assert "error" in response
+
+
+def _auth_client_raising(mocker, exc):
+    """Patch AsyncERClient in handlers with a client whose get_me raises exc."""
+    from unittest.mock import AsyncMock, MagicMock
+    from app.actions import handlers as handlers_module
+
+    instance = MagicMock()
+    instance.get_me = AsyncMock(side_effect=exc)
+    client_cls = MagicMock()
+    client_cls.return_value.__aenter__ = AsyncMock(return_value=instance)
+    client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch.object(handlers_module, "AsyncERClient", client_cls)
+
+
+@pytest.mark.asyncio
+async def test_auth_action_error_text_does_not_echo_the_site_url(er_integration_v2_provider):
+    """action_auth reports failures inside a normal result, so nothing in the
+    runner redacts them; on the ephemeral path the draft URL (which may carry
+    a token in its path or query) came straight back to the caller."""
+    from app.actions.handlers import action_auth
+    from app.actions.configurations import AuthenticateConfig
+
+    integration = er_integration_v2_provider.copy(update={"base_url": "gundi-er.pamdas.org/?token=SECRET"})
+    response = await action_auth(integration, AuthenticateConfig(token="abc123"))
+
+    assert response["valid_credentials"] is False
+    assert response["error"] == "Site URL is empty or invalid."
+    assert "SECRET" not in response["error"]
+
+
+@pytest.mark.parametrize(
+    "exc,expected",
+    [
+        (ERClientBadCredentials("nope", status_code=401, response_body="secret-body"), "EarthRanger rejected the credentials"),
+        (ERClientException("Failed to GET ... 500 from ER. Message: secret-body"), "EarthRanger returned an unexpected response"),
+        (httpx.ConnectError("[Errno -3] Temporary failure in name resolution"), "Could not reach EarthRanger"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_auth_action_reports_er_failures_with_fixed_text(mocker, er_integration_v2_provider, exc, expected):
+    """str(ERClientException) carries ER's response body and httpx errors carry
+    the request; both used to be returned verbatim. The same fixed messages the
+    reference actions use keep the result actionable without echoing either."""
+    from app.actions.handlers import action_auth
+    from app.actions.configurations import AuthenticateConfig
+
+    _auth_client_raising(mocker, exc)
+    response = await action_auth(er_integration_v2_provider, AuthenticateConfig(token="abc123"))
+
+    assert response["valid_credentials"] is False
+    assert response["error"].startswith(expected)
+    assert "secret-body" not in response["error"] and "name resolution" not in response["error"]
 
 
 @pytest.mark.asyncio

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -2820,3 +2820,61 @@ async def test_show_permissions_secondary_fetch_errors_do_not_carry_the_er_respo
 
     assert response["data"][card]["error"].startswith("EarthRanger denied access")
     assert "secret-body" not in str(response)
+
+
+@pytest.mark.asyncio
+async def test_pull_events_does_not_relabel_a_gundi_failure_as_an_earthranger_verdict(
+        mocker, mock_gundi_client_v2, mock_state_manager, mock_erclient_class, mock_get_gundi_api_key,
+        mock_gundi_sensors_client_class, er_integration_v2_provider, mock_publish_event,
+        mock_gundi_client_v2_class, mock_config_manager_er_provider,
+):
+    """The pull body also talks to Gundi's Sensors API and runs connector code.
+    Translating everything raised inside it turned a revoked Gundi API key
+    into "EarthRanger rejected the credentials" and dropped the request URL
+    that showed which side failed. Only EarthRanger's own failures are
+    translated; everything else reaches the runner untouched."""
+    import json
+
+    gundi_401 = httpx.HTTPStatusError(
+        "Unauthorized", request=httpx.Request("POST", "https://sensors.api.gundiservice.org/v2/events/"),
+        response=httpx.Response(401, text='{"detail": "Invalid API key"}'),
+    )
+    mocker.patch("app.services.gundi.send_events_to_gundi", side_effect=gundi_401)
+    mocker.patch("app.actions.handlers.send_events_to_gundi", side_effect=gundi_401)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager_er_provider)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.actions.handlers.state_manager", mock_state_manager)
+    mocker.patch("app.actions.handlers.AsyncERClient", mock_erclient_class)
+    mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class)
+    mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
+
+    response = await execute_action(integration_id=str(er_integration_v2_provider.id), action_id="pull_events")
+
+    detail = json.loads(response.body.decode())["detail"]
+    assert "EarthRanger" not in detail["error"]
+    assert "sensors.api.gundiservice.org" in detail.get("request_url", ""), "the runner keeps saying which side failed"
+
+
+@pytest.mark.asyncio
+async def test_show_permissions_still_returns_the_card_on_an_unexpected_client_error(mocker, er_integration_v2_provider):
+    """A proxy answering the token endpoint with 200 and a bogus body makes
+    erclient raise TypeError from int(auth['expires_in']); the card must still
+    come back with a fixed text rather than the action failing with a 500."""
+    from unittest.mock import AsyncMock, MagicMock
+    from app.actions import handlers as handlers_module
+    from app.actions.handlers import action_show_permissions
+    from app.actions.configurations import ShowPermissionsConfig
+
+    instance = MagicMock()
+    instance.get_me = AsyncMock(side_effect=TypeError("int() argument must be a string, ... not 'NoneType'"))
+    client_cls = MagicMock()
+    client_cls.return_value.__aenter__ = AsyncMock(return_value=instance)
+    client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch.object(handlers_module, "AsyncERClient", client_cls)
+
+    response = await action_show_permissions(er_integration_v2_provider, ShowPermissionsConfig())
+
+    assert response["data"]["User Details"]["error"] == "EarthRanger returned an unexpected response"

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -428,7 +428,7 @@ async def test_execute_show_permissions_action_with_bad_token(
     assert mock_erclient.get_me.called
     response_data = response.get("data")
     user_details = response_data.get("User Details", {})
-    assert user_details.get("error") == "Invalid credentials. Please provide a valid credentials in the authentication config."
+    assert user_details.get("error") == "EarthRanger rejected the credentials"
 
 
 @pytest.mark.asyncio
@@ -453,7 +453,9 @@ async def test_execute_show_permissions_action_with_bad_password(
     assert mock_erclient.get_me.called
     response_data = response.get("data")
     user_details = response_data.get("User Details", {})
-    assert user_details.get("error") == "ER status 400: Invalid credentials given."
+    # The token endpoint's 400 invalid_grant is a rejected login; the raw
+    # error_description no longer reaches the card.
+    assert user_details.get("error") == "EarthRanger rejected the credentials"
 
 
 @pytest.mark.asyncio
@@ -2670,3 +2672,80 @@ async def test_show_permissions_error_text_does_not_echo_the_site_url(er_integra
 
     assert response["data"]["User Details"]["error"] == "Site URL is empty or invalid."
     assert "SECRET" not in str(response)
+
+
+@pytest.mark.asyncio
+async def test_auth_action_reports_a_token_endpoint_outage_as_unreachable(mocker, er_integration_v2_provider):
+    """A 503 from /oauth2/token during an outage is not a credential problem."""
+    from unittest.mock import AsyncMock, MagicMock
+    from app.actions import handlers as handlers_module
+    from app.actions.handlers import action_auth
+    from app.actions.configurations import AuthenticateConfig, ERAuthenticationType
+
+    outage = httpx.HTTPStatusError(
+        "Server error '503'", request=httpx.Request("POST", "https://gundi-er.pamdas.org/oauth2/token"),
+        response=httpx.Response(503, text="upstream unavailable"),
+    )
+    instance = MagicMock()
+    instance.login = AsyncMock(side_effect=outage)
+    client_cls = MagicMock()
+    client_cls.return_value.__aenter__ = AsyncMock(return_value=instance)
+    client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch.object(handlers_module, "AsyncERClient", client_cls)
+
+    response = await action_auth(
+        er_integration_v2_provider,
+        AuthenticateConfig(authentication_type=ERAuthenticationType.USERNAME_PASSWORD, username="u", password="p"),
+    )
+
+    assert response["error"] == "EarthRanger could not be reached"
+
+
+@pytest.mark.parametrize(
+    "auth_type,method,exc,expected",
+    [
+        ("USERNAME_PASSWORD", "login", "token-400", "EarthRanger rejected the credentials"),
+        ("USERNAME_PASSWORD", "login", "token-503-html", "EarthRanger could not be reached"),
+        ("TOKEN", "get_me", "internal-500", "EarthRanger returned an unexpected response"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_show_permissions_reports_er_failures_with_the_same_fixed_text(
+        mocker, er_integration_v2_provider, er_400_invalid_credentials_exception, auth_type, method, exc, expected,
+):
+    """show_permissions had its own error handling: a token-endpoint error
+    without error_description evaluated `response.text` on the result dict
+    (AttributeError, so the action 500ed), and the catch-all wrote str(e),
+    with ER's response body, into the card. Same translation as action_auth."""
+    from unittest.mock import AsyncMock, MagicMock
+    from erclient.er_errors import ERClientInternalError
+    from app.actions import handlers as handlers_module
+    from app.actions.handlers import action_show_permissions
+    from app.actions.configurations import ShowPermissionsConfig, ERAuthenticationType
+
+    errors = {
+        "token-400": er_400_invalid_credentials_exception,
+        "token-503-html": httpx.HTTPStatusError(
+            "Server error '503'", request=httpx.Request("POST", "https://gundi-er.pamdas.org/oauth2/token"),
+            response=httpx.Response(503, text="<html>bad gateway</html>"),
+        ),
+        "internal-500": ERClientInternalError("ER Internal Server Error ON GET .../user/me.", status_code=500, response_body="secret-body"),
+    }
+    instance = MagicMock()
+    setattr(instance, method, AsyncMock(side_effect=errors[exc]))
+    client_cls = MagicMock()
+    client_cls.return_value.__aenter__ = AsyncMock(return_value=instance)
+    client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch.object(handlers_module, "AsyncERClient", client_cls)
+    auth_cfg = next(c for c in er_integration_v2_provider.configurations if c.action.value == "auth")
+    data = {**auth_cfg.data, "authentication_type": getattr(ERAuthenticationType, auth_type).value}
+    if auth_type == "USERNAME_PASSWORD":
+        data.update(username="u", password="p")
+    integration = er_integration_v2_provider.copy(update={
+        "configurations": [c.copy(update={"data": data}) if c.action.value == "auth" else c for c in er_integration_v2_provider.configurations],
+    })
+
+    response = await action_show_permissions(integration, ShowPermissionsConfig())
+
+    assert response["data"]["User Details"]["error"] == expected
+    assert "secret-body" not in str(response) and "bad gateway" not in str(response)

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -128,7 +128,9 @@ async def test_auth_action_error_text_does_not_echo_the_site_url(er_integration_
     "exc,expected",
     [
         (ERClientBadCredentials("nope", status_code=401, response_body="secret-body"), "EarthRanger rejected the credentials"),
-        (ERClientException("Failed to GET ... 500 from ER. Message: secret-body"), "EarthRanger returned an unexpected response"),
+        # A status-less plain ERClientException is erclient's network branch
+        # (the only status-less raise a handler can reach), whatever the text.
+        (ERClientException("Failed to GET ... 500 from ER. Message: secret-body"), "EarthRanger could not be reached"),
         (httpx.ConnectError("[Errno -3] Temporary failure in name resolution"), "EarthRanger could not be reached"),
         # erclient raises plain ERClientException for network failures inside _call.
         (ERClientException("Request to ER failed: [Errno 61] Connection refused"), "EarthRanger could not be reached"),
@@ -481,7 +483,7 @@ async def test_execute_show_permissions_action_with_403_on_subjectgroups(
     response_data = response.get("data")
     user_details = response_data.get("Subject Groups", {})
     exc = mock_er_403_on_subjectgroups_exception
-    assert user_details.get("error") == f"Error retrieving subject groups: {type(exc).__name__}:{exc}"
+    assert user_details.get("error") == "EarthRanger denied access with these credentials"
 
 
 # ---------------------------------------------------------------------------
@@ -2749,3 +2751,72 @@ async def test_show_permissions_reports_er_failures_with_the_same_fixed_text(
 
     assert response["data"]["User Details"]["error"] == expected
     assert "secret-body" not in str(response) and "bad gateway" not in str(response)
+
+
+@pytest.mark.asyncio
+async def test_pull_events_never_publishes_the_login_request_when_the_token_call_fails(
+        mocker, mock_gundi_client_v2, mock_state_manager, mock_erclient_class, mock_get_gundi_api_key,
+        mock_gundi_sensors_client_class, er_integration_v2_provider, mock_publish_event,
+        mock_gundi_client_v2_class, mock_config_manager_er_provider,
+):
+    """erclient's _call only maps HTTP status errors around auth_headers(); a
+    transport failure on the token POST (host unreachable, TCP timeout) escapes
+    raw with .request intact, and on a saved integration the runner publishes
+    request.content, which is the form-encoded username and password. The
+    pull actions now run inside the same translating client as the reference
+    actions, so what reaches the runner is a classified error with no request."""
+    import json
+    from gundi_core.events import IntegrationActionFailed
+
+    token_post = httpx.Request(
+        "POST", "https://gundi-er.pamdas.org/oauth2/token",
+        content=b"grant_type=password&username=u&password=SECRETPASS&client_id=das_web_client",
+    )
+    mock_erclient_class.return_value.get_events.side_effect = httpx.ConnectError("boom", request=token_post)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager_er_provider)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.actions.handlers.state_manager", mock_state_manager)
+    mocker.patch("app.actions.handlers.AsyncERClient", mock_erclient_class)
+    mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class)
+    mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
+
+    response = await execute_action(integration_id=str(er_integration_v2_provider.id), action_id="pull_events")
+
+    body = response.body.decode()
+    assert "SECRETPASS" not in body
+    assert json.loads(body)["detail"]["error_type"] == "connectivity"
+    published = [c.kwargs.get("event") or c.args[0] for c in mock_publish_event.call_args_list]
+    failed = [e for e in published if isinstance(e, IntegrationActionFailed)]
+    assert failed and all("SECRETPASS" not in e.json() for e in failed)
+
+
+@pytest.mark.parametrize("method,card", [("get_event_types", "Event Categories"), ("get_subjectgroups", "Subject Groups")])
+@pytest.mark.asyncio
+async def test_show_permissions_secondary_fetch_errors_do_not_carry_the_er_response_body(
+        mocker, er_integration_v2_provider, get_me_response, method, card,
+):
+    from unittest.mock import AsyncMock, MagicMock
+    from erclient.er_errors import ERClientPermissionDenied
+    from app.actions import handlers as handlers_module
+    from app.actions.handlers import action_show_permissions
+    from app.actions.configurations import ShowPermissionsConfig
+
+    instance = MagicMock()
+    instance.get_me = AsyncMock(return_value=get_me_response)
+    instance.get_event_types = AsyncMock(return_value=[])
+    instance.get_subjectgroups = AsyncMock(return_value=[])
+    setattr(instance, method, AsyncMock(side_effect=ERClientPermissionDenied(
+        "ER Forbidden ON GET https://gundi-er.pamdas.org/api/v1.0/x.", status_code=403, response_body="secret-body",
+    )))
+    client_cls = MagicMock()
+    client_cls.return_value.__aenter__ = AsyncMock(return_value=instance)
+    client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch.object(handlers_module, "AsyncERClient", client_cls)
+
+    response = await action_show_permissions(er_integration_v2_provider, ShowPermissionsConfig())
+
+    assert response["data"][card]["error"].startswith("EarthRanger denied access")
+    assert "secret-body" not in str(response)

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -2878,3 +2878,29 @@ async def test_show_permissions_still_returns_the_card_on_an_unexpected_client_e
     response = await action_show_permissions(er_integration_v2_provider, ShowPermissionsConfig())
 
     assert response["data"]["User Details"]["error"] == "EarthRanger returned an unexpected response"
+
+
+@pytest.mark.asyncio
+async def test_translated_er_failures_keep_their_traceback_in_the_local_log(mocker, er_integration_v2_provider, caplog):
+    """The published traceback drops the cause on purpose, so the local log
+    must hold it, or a status-less failure (a CDN 520 read as ValueError, a
+    JSONDecodeError on a maintenance page) leaves nothing to diagnose."""
+    import logging
+    from unittest.mock import AsyncMock, MagicMock
+    from app.actions import handlers as handlers_module
+    from app.actions.handlers import _translating_er_client
+    from app.services.errors import IntegrationBadResponseError
+
+    instance = MagicMock()
+    client_cls = MagicMock()
+    client_cls.return_value.__aenter__ = AsyncMock(return_value=instance)
+    client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch.object(handlers_module, "AsyncERClient", client_cls)
+
+    with caplog.at_level(logging.WARNING, logger="app.actions.handlers"):
+        with pytest.raises(IntegrationBadResponseError):
+            async with _translating_er_client(er_integration_v2_provider):
+                raise ValueError("520 is not a valid HTTPStatus")
+
+    records = [r for r in caplog.records if r.name == "app.actions.handlers" and "EarthRanger call failed" in r.getMessage()]
+    assert records and records[-1].exc_info and records[-1].exc_info[0] is ValueError

--- a/app/actions/tests/test_actions.py
+++ b/app/actions/tests/test_actions.py
@@ -129,7 +129,9 @@ async def test_auth_action_error_text_does_not_echo_the_site_url(er_integration_
     [
         (ERClientBadCredentials("nope", status_code=401, response_body="secret-body"), "EarthRanger rejected the credentials"),
         (ERClientException("Failed to GET ... 500 from ER. Message: secret-body"), "EarthRanger returned an unexpected response"),
-        (httpx.ConnectError("[Errno -3] Temporary failure in name resolution"), "Could not reach EarthRanger"),
+        (httpx.ConnectError("[Errno -3] Temporary failure in name resolution"), "EarthRanger could not be reached"),
+        # erclient raises plain ERClientException for network failures inside _call.
+        (ERClientException("Request to ER failed: [Errno 61] Connection refused"), "EarthRanger could not be reached"),
     ],
 )
 @pytest.mark.asyncio
@@ -2623,3 +2625,48 @@ def test_authenticate_config_schema_has_auth_type_display_labels():
     assert set(options) == {member.value for member in ERAuthenticationType}
     assert options["token"] == "Token"
     assert options["username_password"] == "Username & Password"
+
+
+@pytest.mark.asyncio
+async def test_auth_action_with_username_password_reports_a_rejected_password_as_rejected_credentials(
+        mocker, er_integration_v2_provider, er_400_invalid_credentials_exception,
+):
+    """AsyncERClient.login() does not go through _call: a wrong password surfaces
+    as a raw httpx.HTTPStatusError (400 invalid_grant from /oauth2/token), not
+    as ERClientBadCredentials. Catching it as a generic HTTP error made the
+    result say EarthRanger could not be reached, while the token method said
+    the credentials were rejected for the same mistake."""
+    from unittest.mock import AsyncMock, MagicMock
+    from app.actions import handlers as handlers_module
+    from app.actions.handlers import action_auth
+    from app.actions.configurations import AuthenticateConfig, ERAuthenticationType
+
+    instance = MagicMock()
+    instance.login = AsyncMock(side_effect=er_400_invalid_credentials_exception)
+    client_cls = MagicMock()
+    client_cls.return_value.__aenter__ = AsyncMock(return_value=instance)
+    client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch.object(handlers_module, "AsyncERClient", client_cls)
+
+    response = await action_auth(
+        er_integration_v2_provider,
+        AuthenticateConfig(authentication_type=ERAuthenticationType.USERNAME_PASSWORD, username="u", password="wrong"),
+    )
+
+    assert response["valid_credentials"] is False
+    assert response["error"] == "EarthRanger rejected the credentials"
+
+
+@pytest.mark.asyncio
+async def test_show_permissions_error_text_does_not_echo_the_site_url(er_integration_v2_provider):
+    """The same guard as action_auth and _build_er_client, from one helper:
+    a submitted URL may carry a token in its path or query and must not come
+    back in the result or the activity log."""
+    from app.actions.handlers import action_show_permissions
+    from app.actions.configurations import ShowPermissionsConfig
+
+    integration = er_integration_v2_provider.copy(update={"base_url": "gundi-er.pamdas.org/?token=SECRET"})
+    response = await action_show_permissions(integration, ShowPermissionsConfig())
+
+    assert response["data"]["User Details"]["error"] == "Site URL is empty or invalid."
+    assert "SECRET" not in str(response)

--- a/app/actions/tests/test_er_schema.py
+++ b/app/actions/tests/test_er_schema.py
@@ -143,14 +143,19 @@ async def test_fetch_prerendered_event_schema_raises_on_404():
 async def test_fetch_prerendered_event_schema_rejects_schemeless_base_url():
     # Schemeless base_urls occur in Gundi; urlparse leaves hostname None for
     # them, which would otherwise build a "https://None/..." URL.
+    from app.services.errors import IntegrationConfigurationError
+
     er_client = AsyncMock()
-    with pytest.raises(ValueError, match="Site URL is empty or invalid: 'gundi-er.pamdas.org'"):
+    with pytest.raises(IntegrationConfigurationError, match="Site URL is empty or invalid") as info:
         await fetch_prerendered_event_schema(er_client, "gundi-er.pamdas.org", "rhino_carcass")
+    assert "gundi-er.pamdas.org" not in str(info.value)  # a submitted value stays out of the message
     er_client.auth_headers.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_fetch_prerendered_event_schema_rejects_empty_base_url():
+    from app.services.errors import IntegrationConfigurationError
+
     er_client = AsyncMock()
-    with pytest.raises(ValueError, match="Site URL is empty or invalid"):
+    with pytest.raises(IntegrationConfigurationError, match="Site URL is empty or invalid"):
         await fetch_prerendered_event_schema(er_client, "", "rhino_carcass")

--- a/app/actions/tests/test_er_schema.py
+++ b/app/actions/tests/test_er_schema.py
@@ -159,3 +159,28 @@ async def test_fetch_prerendered_event_schema_rejects_empty_base_url():
     er_client = AsyncMock()
     with pytest.raises(IntegrationConfigurationError, match="Site URL is empty or invalid"):
         await fetch_prerendered_event_schema(er_client, "", "rhino_carcass")
+
+
+@pytest.mark.asyncio
+async def test_fetch_prerendered_event_schema_maps_a_login_failure_like_the_client_does(er_400_invalid_credentials_exception):
+    """fetch_prerendered_event_schema calls er_client.auth_headers() outside
+    erclient's _call wrapper, so a username/password login failure escaped as a
+    raw httpx.HTTPStatusError for the token URL. Nothing downstream translated
+    it, and on a saved integration the runner would publish the request body,
+    which for the token POST is the plaintext password. Route it through the
+    client's own status-error mapping so it comes out as an ERClientException
+    like every other failure."""
+    from unittest.mock import AsyncMock
+    from erclient import AsyncERClient
+    from erclient.er_errors import ERClientBadRequest
+
+    er_client = AsyncERClient(
+        service_root="https://gundi-er.pamdas.org/api/v1.0", username="u", password="wrong",
+        token_url="https://gundi-er.pamdas.org/oauth2/token", client_id="das_web_client",
+    )
+    er_client.auth_headers = AsyncMock(side_effect=er_400_invalid_credentials_exception)
+
+    with pytest.raises(ERClientBadRequest) as info:
+        await fetch_prerendered_event_schema(er_client, "https://gundi-er.pamdas.org", "rhino_carcass")
+    assert info.value.status_code == 400
+    assert "oauth2/token" in str(info.value)

--- a/app/actions/tests/test_er_schema.py
+++ b/app/actions/tests/test_er_schema.py
@@ -178,3 +178,16 @@ async def test_fetch_prerendered_event_schema_lets_a_login_failure_out_untouched
         await fetch_prerendered_event_schema(er_client, "https://gundi-er.pamdas.org", "rhino_carcass")
     assert info.value is er_400_invalid_credentials_exception
     assert not any(m[0] == "_handle_http_status_error" for m in er_client.method_calls)
+
+
+def test_er_site_root_requires_a_scheme():
+    """A scheme-relative URL ("//host") has a hostname but no scheme and would
+    yield "://host", which fails later as a connectivity error instead of the
+    configuration error this guard exists to raise."""
+    from app.services.errors import IntegrationConfigurationError
+    from app.actions.er_schema import er_site_root
+
+    assert er_site_root("https://gundi-er.pamdas.org:443/anything?x=1") == "https://gundi-er.pamdas.org"
+    for bad in ("//gundi-er.pamdas.org", "gundi-er.pamdas.org", "", None):
+        with pytest.raises(IntegrationConfigurationError):
+            er_site_root(bad)

--- a/app/actions/tests/test_er_schema.py
+++ b/app/actions/tests/test_er_schema.py
@@ -162,25 +162,19 @@ async def test_fetch_prerendered_event_schema_rejects_empty_base_url():
 
 
 @pytest.mark.asyncio
-async def test_fetch_prerendered_event_schema_maps_a_login_failure_like_the_client_does(er_400_invalid_credentials_exception):
+async def test_fetch_prerendered_event_schema_lets_a_login_failure_out_untouched(er_400_invalid_credentials_exception):
     """fetch_prerendered_event_schema calls er_client.auth_headers() outside
-    erclient's _call wrapper, so a username/password login failure escaped as a
-    raw httpx.HTTPStatusError for the token URL. Nothing downstream translated
-    it, and on a saved integration the runner would publish the request body,
-    which for the token POST is the plaintext password. Route it through the
-    client's own status-error mapping so it comes out as an ERClientException
-    like every other failure."""
+    erclient's _call, so a login failure is the raw httpx error for the token
+    URL. It is not mapped here: every caller runs inside the reference path's
+    translation, which recognises token-URL failures, and erclient's own mapper
+    is a private method that raises ValueError on non-standard status codes
+    (a 520 from a CDN) that nothing downstream would then translate."""
     from unittest.mock import AsyncMock
-    from erclient import AsyncERClient
-    from erclient.er_errors import ERClientBadRequest
 
-    er_client = AsyncERClient(
-        service_root="https://gundi-er.pamdas.org/api/v1.0", username="u", password="wrong",
-        token_url="https://gundi-er.pamdas.org/oauth2/token", client_id="das_web_client",
-    )
+    er_client = AsyncMock()
     er_client.auth_headers = AsyncMock(side_effect=er_400_invalid_credentials_exception)
 
-    with pytest.raises(ERClientBadRequest) as info:
+    with pytest.raises(httpx.HTTPStatusError) as info:
         await fetch_prerendered_event_schema(er_client, "https://gundi-er.pamdas.org", "rhino_carcass")
-    assert info.value.status_code == 400
-    assert "oauth2/token" in str(info.value)
+    assert info.value is er_400_invalid_credentials_exception
+    assert not any(m[0] == "_handle_http_status_error" for m in er_client.method_calls)

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -37,6 +37,7 @@ def _er(class_name, status_code):
 
 from erclient import ERClientException
 from app.services.errors import IntegrationBadResponseError
+from app.actions.handlers import _status_of
 from erclient.er_errors import ERClientBadRequest, ERClientPermissionDenied, ERClientServiceUnreachable
 
 
@@ -589,7 +590,11 @@ async def test_list_subject_types_propagates_upstream_errors(
         (_er("ERClientPermissionDenied", 403), "IntegrationAuthError", 403),
         (_er("ERClientRateLimitExceeded", 429), "IntegrationRateLimitError", 429),
         (_er("ERClientInternalError", 500), "IntegrationBadResponseError", 500),
-        (_er("ERClientNotFound", 404), "IntegrationBadResponseError", 404),
+        # A 404 from ER means the site does not expose the API this action needs
+        # (an ER without the v2 event-type API, or a proxy routing only v1). A
+        # configuration problem, reported as such; forwarding the 404 would
+        # collide with the runner's own 404 for "action or config not found".
+        (_er("ERClientNotFound", 404), "IntegrationConfigurationError", None),
         (_er("ERClientServiceUnreachable", None), "IntegrationConnectionError", None),
         # A wrong username/password never reaches ER's API: erclient's _call turns
         # the token endpoint's 400 invalid_grant into ERClientBadRequest naming
@@ -659,7 +664,7 @@ async def test_reference_actions_translate_er_client_errors(
     # formatted traceback, whose chained-cause section would render str(cause)
     # with ER's response body. The local log gets the original separately.
     assert info.value.__cause__ is None and info.value.__suppress_context__
-    if expected_type == "IntegrationConfigurationError":
+    if _status_of(er_error) == 308:
         assert "https" in str(info.value)
     # The ER response body rides on str(ERClientException); it must not
     # reach the activity log or the portal through the translated message.
@@ -775,20 +780,22 @@ async def test_list_event_type_fields_reports_a_login_failure_from_the_schema_fe
     login failure surfaces as the raw httpx error for the token URL; the
     reference-path translation must recognise it (and must not mistake a 404
     from the token URL for an unknown event type)."""
-    from app.services.errors import IntegrationAuthError, IntegrationBadResponseError
+    from app.services.errors import IntegrationAuthError, IntegrationConfigurationError
 
     mock_fetch_schema.side_effect = er_400_invalid_credentials_exception
     with pytest.raises(IntegrationAuthError) as info:
         await action_list_event_type_fields(er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="rhino_carcass"))
     assert info.value.status_code == 401
 
+    # A 404 from the token URL is not "unknown event type": it is a site that
+    # does not expose the API at all, which reads as a configuration error.
     mock_fetch_schema.side_effect = httpx.HTTPStatusError(
         "Not Found", request=httpx.Request("POST", "https://not-an-er-site.example/oauth2/token"),
         response=httpx.Response(404, text=""),
     )
-    with pytest.raises(IntegrationBadResponseError) as info:
+    with pytest.raises(IntegrationConfigurationError) as info:
         await action_list_event_type_fields(er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="rhino_carcass"))
-    assert info.value.status_code == 404
+    assert "event type" not in str(info.value).lower() or "does not expose" in str(info.value)
 
 
 @pytest.mark.asyncio
@@ -829,3 +836,58 @@ async def test_unknown_event_type_error_carries_no_chained_cause(er_integration_
     with pytest.raises(IntegrationConfigurationError) as info:
         await action_list_event_type_fields(er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="typo"))
     assert info.value.__cause__ is None and info.value.__suppress_context__
+
+
+@pytest.mark.asyncio
+async def test_a_broken_auth_config_is_a_validation_error_not_an_earthranger_verdict(mock_er_client, er_integration_v2_provider):
+    """Building the client parses the stored auth config; a pydantic
+    ValidationError there is a ValueError and must not be swallowed into
+    "EarthRanger returned an unexpected response" when no request was made.
+    The runner renders validation errors itself."""
+    import pydantic
+
+    auth_cfg = next(c for c in er_integration_v2_provider.configurations if c.action.value == "auth")
+    integration = er_integration_v2_provider.copy(update={
+        "configurations": [c.copy(update={"data": {**c.data, "authentication_type": "bogus"}}) if c is auth_cfg else c
+                           for c in er_integration_v2_provider.configurations],
+    })
+    with pytest.raises(pydantic.ValidationError):
+        await action_list_event_types(integration, ListEventTypesQuery())
+
+
+@pytest.mark.asyncio
+async def test_a_stale_refresh_token_falls_back_to_a_fresh_login(er_integration_v2_provider):
+    """erclient's auth_headers() tries refresh_token() first and falls back to
+    login() only when the refresh returns False, but _token_request raises on
+    the token endpoint's 400 instead, so a stale refresh token mid-run (a
+    backfill outlasting the access token) surfaced as a rejected login while
+    the stored password was fine. The client we build turns that 400 into a
+    False so the fallback runs; a genuinely wrong password still fails there."""
+    from unittest.mock import AsyncMock
+    import datetime, pytz
+    from app.actions.handlers import _build_er_client
+
+    client = _build_er_client(er_integration_v2_provider)
+    client.auth = {"access_token": "old", "refresh_token": "stale", "token_type": "Bearer"}
+    client.auth_expires = pytz.utc.localize(datetime.datetime.min)  # expired: refresh first
+    stale = httpx.HTTPStatusError(
+        "400", request=httpx.Request("POST", "https://gundi-er.pamdas.org/oauth2/token"),
+        response=httpx.Response(400, text='{"error": "invalid_grant"}'),
+    )
+    grants = []
+
+    async def token_request(payload):
+        grants.append(payload["grant_type"])
+        if payload["grant_type"] == "refresh_token":
+            client.auth = None
+            raise stale
+        client.auth = {"access_token": "new", "refresh_token": "r2", "token_type": "Bearer"}
+        client.auth_expires = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(hours=1)
+        return True
+
+    client._token_request = AsyncMock(side_effect=token_request)
+
+    headers = await client.auth_headers()
+
+    assert grants == ["refresh_token", "password"]
+    assert headers["Authorization"] == "Bearer new"

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -570,9 +570,10 @@ async def test_list_subject_types_propagates_upstream_errors(
     mock_er_client.get_subjectgroups.side_effect = httpx.HTTPStatusError(
         "boom", request=MagicMock(), response=MagicMock(status_code=502)
     )
-    # Raw httpx errors from the ER client are translated on the reference path
-    # (a 5xx reads as an unexpected response, with its status), never re-raised as is.
-    with pytest.raises(IntegrationBadResponseError):
+    # Raw httpx errors from the ER client are translated on the reference path,
+    # never re-raised as is; a 502 reads as EarthRanger being unreachable.
+    from app.services.errors import IntegrationConnectionError
+    with pytest.raises(IntegrationConnectionError):
         await action_list_subject_types(
             er_integration_v2_provider, ListSubjectTypesQuery()
         )
@@ -593,9 +594,11 @@ async def test_list_subject_types_propagates_upstream_errors(
         # A wrong username/password never reaches ER's API: erclient's _call turns
         # the token endpoint's 400 invalid_grant into ERClientBadRequest naming
         # /oauth2/token. That is an auth failure, not a bad request.
+        # Reported as 401: the source said 400, but the portal treats only 401/403
+        # as a credential rejection, and a wizard toast that says so is the point.
         (ERClientBadRequest("ER Bad Request ON GET https://gundi-er.pamdas.org/oauth2/token.", status_code=400,
                             response_body='{"error": "invalid_grant", "error_description": "Invalid credentials given."}'),
-         "IntegrationAuthError", 400),
+         "IntegrationAuthError", 401),
         # A genuine 400 from the API stays a bad response.
         (ERClientBadRequest("ER Bad Request ON GET https://gundi-er.pamdas.org/api/v1.0/activity/events/categories.",
                             status_code=400, response_body="secret-body"), "IntegrationBadResponseError", 400),
@@ -605,7 +608,16 @@ async def test_list_subject_types_propagates_upstream_errors(
         (httpx.HTTPStatusError("Client error '400 Bad Request' for url 'https://gundi-er.pamdas.org/oauth2/token'",
                                request=httpx.Request("POST", "https://gundi-er.pamdas.org/oauth2/token"),
                                response=httpx.Response(400, text='{"error": "invalid_grant"}')),
-         "IntegrationAuthError", 400),
+         "IntegrationAuthError", 401),
+        # The token endpoint being down is not a credential problem.
+        (httpx.HTTPStatusError("Server error '503' for url 'https://gundi-er.pamdas.org/oauth2/token'",
+                               request=httpx.Request("POST", "https://gundi-er.pamdas.org/oauth2/token"),
+                               response=httpx.Response(503, text="upstream unavailable")),
+         "IntegrationConnectionError", 503),
+        (httpx.HTTPStatusError("Server error '500' for url 'https://gundi-er.pamdas.org/api/v1.0/x'",
+                               request=httpx.Request("GET", "https://gundi-er.pamdas.org/api/v1.0/x"),
+                               response=httpx.Response(500, text="secret-body")),
+         "IntegrationBadResponseError", 500),
         (httpx.ConnectError("[Errno -3] Temporary failure in name resolution"), "IntegrationConnectionError", None),
     ],
 )
@@ -627,7 +639,10 @@ async def test_reference_actions_translate_er_client_errors(
         await action_list_event_categories(er_integration_v2_provider, ListEventCategoriesQuery())
 
     assert info.value.status_code == expected_status
-    assert info.value.__cause__ is er_error
+    # No chained cause: on a saved integration the runner publishes the
+    # formatted traceback, whose chained-cause section would render str(cause)
+    # with ER's response body. The local log gets the original separately.
+    assert info.value.__cause__ is None and info.value.__suppress_context__
     # The ER response body rides on str(ERClientException); it must not
     # reach the activity log or the portal through the translated message.
     assert "response_body" not in str(info.value) and "secret-body" not in str(info.value)
@@ -691,3 +706,68 @@ async def test_list_event_types_surfaces_a_failing_v2_fetch_whatever_the_failure
     with pytest.raises(IntegrationConnectionError) as info:
         await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
     assert info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_list_event_types_fetches_v2_first_so_a_failure_costs_one_round_trip(mock_er_client, er_integration_v2_provider):
+    """The v2 fetch is the load-bearing one; running it after the best-effort
+    v1 fetch meant a wrong password (or a down site) paid the identical
+    failure twice, once as a warning and once as the error."""
+    from erclient import VERSION_2_0
+    from app.services.errors import IntegrationAuthError
+
+    calls = []
+
+    async def get_event_types(version=None, **kwargs):
+        calls.append(version)
+        raise ERClientBadRequest("ER Bad Request ON GET https://gundi-er.pamdas.org/oauth2/token.",
+                                 status_code=400, response_body='{"error": "invalid_grant"}')
+
+    mock_er_client.get_event_types = AsyncMock(side_effect=get_event_types)
+
+    with pytest.raises(IntegrationAuthError):
+        await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
+    assert calls == [VERSION_2_0]
+
+
+@pytest.mark.asyncio
+async def test_best_effort_fetch_warnings_do_not_carry_the_er_response_body(mock_er_client, er_integration_v2_provider, caplog):
+    from erclient import VERSION_1_0, VERSION_2_0
+
+    async def get_event_types(version=None, **kwargs):
+        if version == VERSION_1_0:
+            raise ERClientPermissionDenied("ER Forbidden ON GET .../eventtypes.", status_code=403, response_body="secret-body")
+        return [{"value": "rhino_carcass", "display": "Rhino Carcass", "category": "security", "version": VERSION_2_0}]
+
+    mock_er_client.get_event_types = AsyncMock(side_effect=get_event_types)
+    mock_er_client.get_event_categories = AsyncMock(return_value=[])
+
+    result = await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
+
+    assert [o["value"] for o in result["options"]] == ["rhino_carcass"]
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert warnings and all("secret-body" not in w for w in warnings)
+
+
+@pytest.mark.asyncio
+async def test_list_event_type_fields_reports_a_login_failure_from_the_schema_fetch_as_rejected_credentials(
+        er_integration_v2_provider, mock_er_client, mock_fetch_schema, er_400_invalid_credentials_exception,
+):
+    """The schema fetch calls auth_headers() outside erclient's _call, so a
+    login failure surfaces as the raw httpx error for the token URL; the
+    reference-path translation must recognise it (and must not mistake a 404
+    from the token URL for an unknown event type)."""
+    from app.services.errors import IntegrationAuthError, IntegrationBadResponseError
+
+    mock_fetch_schema.side_effect = er_400_invalid_credentials_exception
+    with pytest.raises(IntegrationAuthError) as info:
+        await action_list_event_type_fields(er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="rhino_carcass"))
+    assert info.value.status_code == 401
+
+    mock_fetch_schema.side_effect = httpx.HTTPStatusError(
+        "Not Found", request=httpx.Request("POST", "https://not-an-er-site.example/oauth2/token"),
+        response=httpx.Response(404, text=""),
+    )
+    with pytest.raises(IntegrationBadResponseError) as info:
+        await action_list_event_type_fields(er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="rhino_carcass"))
+    assert info.value.status_code == 404

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -28,6 +28,13 @@ _FIXTURE_PATH = os.path.join(
 )
 
 
+def _er(class_name, status_code):
+    """Build an erclient exception the way the client does, response body included."""
+    from erclient import er_errors
+
+    return getattr(er_errors, class_name)("ER said no", status_code=status_code, response_body="secret-body")
+
+
 def _load_fixture():
     with open(_FIXTURE_PATH) as fh:
         return json.load(fh)
@@ -525,3 +532,57 @@ async def test_list_subject_types_propagates_upstream_errors(
         await action_list_subject_types(
             er_integration_v2_provider, ListSubjectTypesQuery()
         )
+
+
+# --- ER client errors on the reference path ------------------------------------
+
+
+@pytest.mark.parametrize(
+    "er_error,expected_type,expected_status",
+    [
+        (_er("ERClientBadCredentials", 401), "IntegrationAuthError", 401),
+        (_er("ERClientPermissionDenied", 403), "IntegrationAuthError", 403),
+        (_er("ERClientRateLimitExceeded", 429), "IntegrationRateLimitError", 429),
+        (_er("ERClientInternalError", 500), "IntegrationBadResponseError", 500),
+        (_er("ERClientNotFound", 404), "IntegrationBadResponseError", 404),
+        (_er("ERClientServiceUnreachable", None), "IntegrationConnectionError", None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_reference_actions_translate_er_client_errors(
+        mock_er_client, er_integration_v2_provider, er_error, expected_type, expected_status,
+):
+    """erclient's exceptions are not IntegrationError subclasses and carry no
+    .response, so the runner cannot classify them: on the ephemeral path the
+    portal wizard got `500 {"error": "ERClientBadCredentials"}` and could not
+    tell bad credentials from a broken site. Translated, it gets the runner's
+    curated text and the source status (401/403/429/5xx)."""
+    from app.services import errors
+    from app.actions.handlers import action_list_event_categories
+    from app.actions.configurations import ListEventCategoriesQuery
+
+    mock_er_client.get_event_categories = AsyncMock(side_effect=er_error)
+    with pytest.raises(getattr(errors, expected_type)) as info:
+        await action_list_event_categories(er_integration_v2_provider, ListEventCategoriesQuery())
+
+    assert info.value.status_code == expected_status
+    assert info.value.__cause__ is er_error
+    # The ER response body rides on str(ERClientException); it must not
+    # reach the activity log or the portal through the translated message.
+    assert "response_body" not in str(info.value) and "secret-body" not in str(info.value)
+
+
+@pytest.mark.asyncio
+async def test_list_event_types_surfaces_bad_credentials_instead_of_an_empty_list(
+        mock_er_client, er_integration_v2_provider,
+):
+    """_fetch_event_type_maps is best-effort for pull_events (a 403 on one
+    endpoint must not break the others), but on the reference path swallowing
+    an auth failure returns 200 with no options: the wizard shows an empty
+    dropdown instead of "Authentication failed"."""
+    from app.services.errors import IntegrationAuthError
+
+    mock_er_client.get_event_types = AsyncMock(side_effect=_er("ERClientBadCredentials", 401))
+    with pytest.raises(IntegrationAuthError) as info:
+        await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
+    assert info.value.status_code == 401

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -595,7 +595,7 @@ async def test_list_subject_types_propagates_upstream_errors(
         # configuration problem, reported as such; forwarding the 404 would
         # collide with the runner's own 404 for "action or config not found".
         (_er("ERClientNotFound", 404), "IntegrationConfigurationError", None),
-        (_er("ERClientServiceUnreachable", None), "IntegrationConnectionError", None),
+        (_er("ERClientServiceUnreachable", 503), "IntegrationConnectionError", 503),
         # A wrong username/password never reaches ER's API: erclient's _call turns
         # the token endpoint's 400 invalid_grant into ERClientBadRequest naming
         # /oauth2/token. That is an auth failure, not a bad request.
@@ -891,3 +891,97 @@ async def test_a_stale_refresh_token_falls_back_to_a_fresh_login(er_integration_
 
     assert grants == ["refresh_token", "password"]
     assert headers["Authorization"] == "Bearer new"
+
+
+def test_a_403_from_the_token_endpoint_is_denied_access_on_both_paths():
+    """django-oauth-toolkit never answers 403 for a credential rejection (it
+    uses 400 invalid_grant / 401 invalid_client); a 403 on /oauth2/token is a
+    proxy or WAF verdict. Through erclient it already read as "denied access";
+    the raw-httpx branch called it a rejected login."""
+    from app.actions.handlers import _as_integration_error
+
+    raw = httpx.HTTPStatusError(
+        "Forbidden", request=httpx.Request("POST", "https://gundi-er.pamdas.org/oauth2/token"),
+        response=httpx.Response(403, text=""),
+    )
+    via_call = ERClientPermissionDenied("ER Forbidden ON GET https://gundi-er.pamdas.org/oauth2/token.", status_code=403, response_body="")
+
+    assert str(_as_integration_error(raw)) == str(_as_integration_error(via_call)) == "EarthRanger denied access with these credentials"
+    assert _as_integration_error(raw).status_code == 403
+
+
+def test_a_404_is_a_not_found_verdict_on_the_pull_path_and_a_configuration_error_on_the_reference_path():
+    """On the reference path a 404 means the site lacks the API (no v2
+    event-type API); on the pull path it means a stale resource, e.g. a
+    deleted subject group, and the operator needs the status and not a hint
+    about the site URL."""
+    from erclient.er_errors import ERClientNotFound
+    from app.actions.handlers import _as_integration_error
+    from app.services.errors import IntegrationBadResponseError, IntegrationConfigurationError
+
+    not_found = ERClientNotFound("ER Not Found ON GET https://gundi-er.pamdas.org/api/v1.0/subjectgroups/x.", status_code=404, response_body="")
+    assert isinstance(_as_integration_error(not_found), IntegrationConfigurationError)
+    pull = _as_integration_error(not_found, not_found_is_configuration=False)
+    assert isinstance(pull, IntegrationBadResponseError) and pull.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_pull_path_translation_recognises_erclient_by_host_not_by_string_prefix(mocker, er_integration_v2_provider):
+    """`startswith(site_root)` matched any host that merely begins with the ER
+    hostname, and an IDN site URL never matched its punycode request URL, so a
+    token-POST transport error there would have escaped untranslated with the
+    login body attached. Compare origins."""
+    from unittest.mock import AsyncMock, MagicMock
+    from app.actions import handlers as handlers_module
+    from app.actions.handlers import _translating_er_client
+    from app.services.errors import IntegrationConnectionError
+
+    instance = MagicMock()
+    client_cls = MagicMock()
+    client_cls.return_value.__aenter__ = AsyncMock(return_value=instance)
+    client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch.object(handlers_module, "AsyncERClient", client_cls)
+
+    idn = er_integration_v2_provider.copy(update={"base_url": "https://ér-site.example"})
+    token_post = httpx.Request("POST", "https://ér-site.example/oauth2/token", content=b"password=SECRET")  # punycode, as httpx sends it
+    with pytest.raises(IntegrationConnectionError):
+        async with _translating_er_client(idn, only_er_requests=True):
+            raise httpx.ConnectError("boom", request=token_post)
+
+    lookalike = httpx.Request("POST", "https://gundi-er.pamdas.org.evil.example/v2/events/")
+    with pytest.raises(httpx.HTTPStatusError):  # not ours: untouched
+        async with _translating_er_client(er_integration_v2_provider, only_er_requests=True):
+            raise httpx.HTTPStatusError("401", request=lookalike, response=httpx.Response(401, text=""))
+
+
+@pytest.mark.asyncio
+async def test_pull_path_translation_covers_erclient_raised_value_errors_but_not_connector_ones(mocker, er_integration_v2_provider):
+    """erclient raises ValueError/KeyError itself on realistic failures (a
+    CDN's 520 through HTTPStatus(...).phrase, a 200 HTML body through
+    response.json()); those are EarthRanger failures and classify like on the
+    reference path. A ValueError from connector code is a bug and must keep
+    its traceback."""
+    from unittest.mock import AsyncMock, MagicMock
+    from app.actions import handlers as handlers_module
+    from app.actions.handlers import _translating_er_client
+    from app.services.errors import IntegrationBadResponseError
+    from erclient import client as erclient_module
+
+    instance = MagicMock()
+    client_cls = MagicMock()
+    client_cls.return_value.__aenter__ = AsyncMock(return_value=instance)
+    client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch.object(handlers_module, "AsyncERClient", client_cls)
+
+    def raised_inside_erclient():
+        # Execute a raise from a code object whose filename is erclient's.
+        code = compile("raise ValueError('520 is not a valid HTTPStatus')", erclient_module.__file__, "exec")
+        exec(code, {})
+
+    with pytest.raises(IntegrationBadResponseError):
+        async with _translating_er_client(er_integration_v2_provider, only_er_requests=True):
+            raised_inside_erclient()
+
+    with pytest.raises(ValueError):  # a connector bug: untouched
+        async with _translating_er_client(er_integration_v2_provider, only_er_requests=True):
+            raise ValueError("connector bug")

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -619,6 +619,22 @@ async def test_list_subject_types_propagates_upstream_errors(
                                response=httpx.Response(500, text="secret-body")),
          "IntegrationBadResponseError", 500),
         (httpx.ConnectError("[Errno -3] Temporary failure in name resolution"), "IntegrationConnectionError", None),
+        # erclient itself raises these on realistic failures: ValueError from
+        # HTTPStatus(520).phrase behind a CDN, JSONDecodeError/KeyError on a 200
+        # non-JSON body or a token body without expires_in. Neither erclient nor
+        # httpx types, so they escaped as a bare 500 "ValueError".
+        (ValueError("520 is not a valid HTTPStatus"), "IntegrationBadResponseError", None),
+        (KeyError("expires_in"), "IntegrationBadResponseError", None),
+        # Any status-less plain ERClientException from the client is its network
+        # branch (structural, not a match on the log wording).
+        (ERClientException("ER request failed: connection refused"), "IntegrationConnectionError", None),
+        # A body that merely mentions the token URL is not a rejected login.
+        (ERClientBadRequest("ER Bad Request ON GET https://gundi-er.pamdas.org/api/v1.0/activity/events.",
+                            status_code=400, response_body='{"detail": "see /oauth2/token"}'), "IntegrationBadResponseError", 400),
+        # An http:// site URL gets a redirect to https; that is a configuration
+        # problem, not a provider verdict (and the wizard cannot classify a 3xx).
+        (ERClientException("ER Permanent Redirect ON GET http://gundi-er.pamdas.org/api/v1.0/x.", status_code=308,
+                           response_body=""), "IntegrationConfigurationError", None),
     ],
 )
 @pytest.mark.asyncio
@@ -643,6 +659,8 @@ async def test_reference_actions_translate_er_client_errors(
     # formatted traceback, whose chained-cause section would render str(cause)
     # with ER's response body. The local log gets the original separately.
     assert info.value.__cause__ is None and info.value.__suppress_context__
+    if expected_type == "IntegrationConfigurationError":
+        assert "https" in str(info.value)
     # The ER response body rides on str(ERClientException); it must not
     # reach the activity log or the portal through the translated message.
     assert "response_body" not in str(info.value) and "secret-body" not in str(info.value)
@@ -771,3 +789,43 @@ async def test_list_event_type_fields_reports_a_login_failure_from_the_schema_fe
     with pytest.raises(IntegrationBadResponseError) as info:
         await action_list_event_type_fields(er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="rhino_carcass"))
     assert info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_a_403_reads_the_same_whichever_path_it_took(mock_er_client, er_integration_v2_provider, mock_fetch_schema):
+    """One status table: a 403 through erclient's _call and a raw httpx 403
+    from the schema fetch describe the same ER verdict with the same words."""
+    from app.services.errors import IntegrationAuthError
+    from app.actions.configurations import ListEventCategoriesQuery
+    from app.actions.handlers import action_list_event_categories
+
+    mock_er_client.get_event_categories = AsyncMock(side_effect=ERClientPermissionDenied(
+        "ER Forbidden ON GET .../categories.", status_code=403, response_body="",
+    ))
+    with pytest.raises(IntegrationAuthError) as via_call:
+        await action_list_event_categories(er_integration_v2_provider, ListEventCategoriesQuery())
+
+    mock_fetch_schema.side_effect = httpx.HTTPStatusError(
+        "Forbidden", request=httpx.Request("GET", "https://gundi-er.pamdas.org/api/v2.0/activity/eventtypes/x/schema"),
+        response=httpx.Response(403, text=""),
+    )
+    with pytest.raises(IntegrationAuthError) as raw:
+        await action_list_event_type_fields(er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="x"))
+
+    assert str(via_call.value) == str(raw.value) == "EarthRanger denied access with these credentials"
+    assert via_call.value.status_code == raw.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_unknown_event_type_error_carries_no_chained_cause(er_integration_v2_provider, mock_er_client, mock_fetch_schema):
+    """The published traceback would otherwise render the chained httpx 404
+    with the ER host and the submitted slug that the message itself omits."""
+    from app.services.errors import IntegrationConfigurationError
+
+    mock_fetch_schema.side_effect = httpx.HTTPStatusError(
+        "Not Found", request=httpx.Request("GET", "https://gundi-er.pamdas.org/api/v2.0/activity/eventtypes/typo/schema"),
+        response=httpx.Response(404, text=""),
+    )
+    with pytest.raises(IntegrationConfigurationError) as info:
+        await action_list_event_type_fields(er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="typo"))
+    assert info.value.__cause__ is None and info.value.__suppress_context__

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -246,13 +246,18 @@ async def test_list_event_type_fields_unknown_event_type_raises(
         "Not Found", request=MagicMock(), response=MagicMock(status_code=404)
     )
 
-    with pytest.raises(
-        ValueError,
-        match="rhino_carcass.*has no v2 schema in EarthRanger.*classic v1 event types are not supported",
-    ):
+    # A connector guard the portal wizard must be able to act on: the runner
+    # forwards IntegrationConfigurationError on the ephemeral path (422),
+    # where every other connector message is redacted to the type name. By
+    # contract the message names the shape of the problem and never echoes
+    # the submitted value.
+    from app.services.errors import IntegrationConfigurationError
+
+    with pytest.raises(IntegrationConfigurationError, match="v1 event type") as info:
         await action_list_event_type_fields(
             er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="rhino_carcass")
         )
+    assert "rhino_carcass" not in str(info.value)
 
 
 @pytest.mark.asyncio
@@ -315,11 +320,14 @@ async def test_list_event_field_values_unknown_field_raises(
 ):
     mock_fetch_schema.return_value = _load_fixture()
 
-    with pytest.raises(ValueError, match="no_such_field"):
+    from app.services.errors import IntegrationConfigurationError
+
+    with pytest.raises(IntegrationConfigurationError, match="Field not found") as info:
         await action_list_event_field_values(
             er_integration_v2_provider,
             ListEventFieldValuesQuery(event_type="rhino_carcass", field_key="no_such_field"),
         )
+    assert "no_such_field" not in str(info.value)
 
 
 @pytest.mark.asyncio
@@ -330,11 +338,14 @@ async def test_list_event_field_values_unknown_event_type_raises(
         "Not Found", request=MagicMock(), response=MagicMock(status_code=404)
     )
 
-    with pytest.raises(ValueError, match="has no v2 schema in EarthRanger"):
+    from app.services.errors import IntegrationConfigurationError
+
+    with pytest.raises(IntegrationConfigurationError, match="v1 event type") as info:
         await action_list_event_field_values(
             er_integration_v2_provider,
             ListEventFieldValuesQuery(event_type="no_such_type", field_key="animal_sex"),
         )
+    assert "no_such_type" not in str(info.value)
 
 
 # --- base_url validation in _build_er_client ----------------------------------
@@ -345,14 +356,36 @@ async def test_reference_action_with_schemeless_base_url_raises_clean_error(
     mocker, er_integration_v2_provider
 ):
     """A schemeless/empty integration.base_url must fail with the same clean
-    'Site URL is empty or invalid' message action_auth uses, not a confusing
-    downstream error against https://None/..."""
+    'Site URL is empty or invalid' wording action_auth uses, not a confusing
+    downstream error against https://None/... As a configuration error it
+    reaches the portal wizard on the ephemeral path; the draft URL itself is
+    a submitted value and stays out of the message."""
     from app.actions.handlers import action_list_event_types
     from app.actions.configurations import ListEventTypesQuery
+    from app.services.errors import IntegrationConfigurationError
 
     mocker.patch.object(er_integration_v2_provider, "base_url", "gundi-er.pamdas.org")
-    with pytest.raises(ValueError, match="Site URL is empty or invalid: 'gundi-er.pamdas.org'"):
+    with pytest.raises(IntegrationConfigurationError, match="Site URL is empty or invalid") as info:
         await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
+    assert "gundi-er.pamdas.org" not in str(info.value)
+
+
+@pytest.mark.asyncio
+async def test_reference_action_without_auth_settings_raises_a_configuration_error(er_integration_v2_provider):
+    """The wizard can open a dropdown before the auth step is saved. Missing
+    auth settings are a configuration problem, not an EarthRanger verdict, and
+    the message must not carry the integration id (an identifier the draft
+    path synthesizes per run)."""
+    from app.actions.handlers import action_list_event_types
+    from app.actions.configurations import ListEventTypesQuery
+    from app.services.errors import IntegrationConfigurationError
+
+    integration = er_integration_v2_provider.copy(update={
+        "configurations": [c for c in er_integration_v2_provider.configurations if c.action.value != "auth"],
+    })
+    with pytest.raises(IntegrationConfigurationError, match="Authentication settings are missing") as info:
+        await action_list_event_types(integration, ListEventTypesQuery())
+    assert str(integration.id) not in str(info.value)
 
 
 # --- action_list_event_categories ---------------------------------------------

--- a/app/actions/tests/test_reference_actions.py
+++ b/app/actions/tests/test_reference_actions.py
@@ -35,6 +35,11 @@ def _er(class_name, status_code):
     return getattr(er_errors, class_name)("ER said no", status_code=status_code, response_body="secret-body")
 
 
+from erclient import ERClientException
+from app.services.errors import IntegrationBadResponseError
+from erclient.er_errors import ERClientBadRequest, ERClientPermissionDenied, ERClientServiceUnreachable
+
+
 def _load_fixture():
     with open(_FIXTURE_PATH) as fh:
         return json.load(fh)
@@ -270,7 +275,9 @@ async def test_list_event_type_fields_upstream_500_propagates(
         "Server Error", request=MagicMock(), response=MagicMock(status_code=500)
     )
 
-    with pytest.raises(httpx.HTTPStatusError):
+    # Raw httpx errors from the ER client are translated on the reference path
+    # (a 5xx reads as an unexpected response, with its status), never re-raised as is.
+    with pytest.raises(IntegrationBadResponseError):
         await action_list_event_type_fields(
             er_integration_v2_provider, ListEventTypeFieldsQuery(event_type="rhino_carcass")
         )
@@ -440,7 +447,9 @@ async def test_list_event_categories_upstream_error_propagates(mock_er_client, e
     mock_er_client.get_event_categories = AsyncMock(side_effect=httpx.HTTPStatusError(
         "boom", request=MagicMock(), response=MagicMock(status_code=500)
     ))
-    with pytest.raises(httpx.HTTPStatusError):
+    # Raw httpx errors from the ER client are translated on the reference path
+    # (a 5xx reads as an unexpected response, with its status), never re-raised as is.
+    with pytest.raises(IntegrationBadResponseError):
         await action_list_event_categories(er_integration_v2_provider, ListEventCategoriesQuery())
 
 
@@ -561,7 +570,9 @@ async def test_list_subject_types_propagates_upstream_errors(
     mock_er_client.get_subjectgroups.side_effect = httpx.HTTPStatusError(
         "boom", request=MagicMock(), response=MagicMock(status_code=502)
     )
-    with pytest.raises(httpx.HTTPStatusError):
+    # Raw httpx errors from the ER client are translated on the reference path
+    # (a 5xx reads as an unexpected response, with its status), never re-raised as is.
+    with pytest.raises(IntegrationBadResponseError):
         await action_list_subject_types(
             er_integration_v2_provider, ListSubjectTypesQuery()
         )
@@ -579,6 +590,23 @@ async def test_list_subject_types_propagates_upstream_errors(
         (_er("ERClientInternalError", 500), "IntegrationBadResponseError", 500),
         (_er("ERClientNotFound", 404), "IntegrationBadResponseError", 404),
         (_er("ERClientServiceUnreachable", None), "IntegrationConnectionError", None),
+        # A wrong username/password never reaches ER's API: erclient's _call turns
+        # the token endpoint's 400 invalid_grant into ERClientBadRequest naming
+        # /oauth2/token. That is an auth failure, not a bad request.
+        (ERClientBadRequest("ER Bad Request ON GET https://gundi-er.pamdas.org/oauth2/token.", status_code=400,
+                            response_body='{"error": "invalid_grant", "error_description": "Invalid credentials given."}'),
+         "IntegrationAuthError", 400),
+        # A genuine 400 from the API stays a bad response.
+        (ERClientBadRequest("ER Bad Request ON GET https://gundi-er.pamdas.org/api/v1.0/activity/events/categories.",
+                            status_code=400, response_body="secret-body"), "IntegrationBadResponseError", 400),
+        # Network failures inside _call are a plain ERClientException with no status.
+        (ERClientException("Request to ER failed: [Errno 61] Connection refused"), "IntegrationConnectionError", None),
+        # The bare auth_headers() call in er_schema lets the token endpoint's error out raw.
+        (httpx.HTTPStatusError("Client error '400 Bad Request' for url 'https://gundi-er.pamdas.org/oauth2/token'",
+                               request=httpx.Request("POST", "https://gundi-er.pamdas.org/oauth2/token"),
+                               response=httpx.Response(400, text='{"error": "invalid_grant"}')),
+         "IntegrationAuthError", 400),
+        (httpx.ConnectError("[Errno -3] Temporary failure in name resolution"), "IntegrationConnectionError", None),
     ],
 )
 @pytest.mark.asyncio
@@ -603,6 +631,7 @@ async def test_reference_actions_translate_er_client_errors(
     # The ER response body rides on str(ERClientException); it must not
     # reach the activity log or the portal through the translated message.
     assert "response_body" not in str(info.value) and "secret-body" not in str(info.value)
+    assert "invalid_grant" not in str(info.value) and "name resolution" not in str(info.value)
 
 
 @pytest.mark.asyncio
@@ -619,3 +648,46 @@ async def test_list_event_types_surfaces_bad_credentials_instead_of_an_empty_lis
     with pytest.raises(IntegrationAuthError) as info:
         await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
     assert info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_event_types_tolerates_a_403_on_the_v1_endpoint(mock_er_client, er_integration_v2_provider):
+    """Only the v2 event types are offered, so the v2 fetch is load-bearing;
+    the v1 fetch and the categories fetch only enrich grouping. An ER role
+    denied on the legacy v1 endpoint but allowed on v2 must still get its
+    dropdown, as it did before the reference path started surfacing auth
+    failures. (A wrong password fails the v2 fetch too, so it still surfaces.)"""
+    from erclient import VERSION_1_0, VERSION_2_0
+
+    async def get_event_types(version=None, **kwargs):
+        if version == VERSION_1_0:
+            raise ERClientPermissionDenied("ER Forbidden ON GET .../eventtypes.", status_code=403, response_body="")
+        return [{"value": "rhino_carcass", "display": "Rhino Carcass", "category": "security", "version": VERSION_2_0}]
+
+    mock_er_client.get_event_types = AsyncMock(side_effect=get_event_types)
+    mock_er_client.get_event_categories = AsyncMock(return_value=[{"value": "security", "display": "Security", "id": "c1"}])
+
+    result = await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
+
+    assert [o["value"] for o in result["options"]] == ["rhino_carcass"]
+
+
+@pytest.mark.asyncio
+async def test_list_event_types_surfaces_a_failing_v2_fetch_whatever_the_failure(mock_er_client, er_integration_v2_provider):
+    """A 503, a rate limit or a network failure on the load-bearing fetch used
+    to be swallowed into an empty dropdown with a 200, after up to four
+    round trips to a failing server; the other reference actions let the
+    same failures propagate. Everything from the v2 fetch propagates now."""
+    from erclient import VERSION_2_0
+    from app.services.errors import IntegrationConnectionError
+
+    async def get_event_types(version=None, **kwargs):
+        if version == VERSION_2_0:
+            raise ERClientServiceUnreachable("ER Service Unavailable ON GET .../eventtypes.", status_code=503, response_body="")
+        return []
+
+    mock_er_client.get_event_types = AsyncMock(side_effect=get_event_types)
+
+    with pytest.raises(IntegrationConnectionError) as info:
+        await action_list_event_types(er_integration_v2_provider, ListEventTypesQuery())
+    assert info.value.status_code == 503

--- a/docs/actions/auth.md
+++ b/docs/actions/auth.md
@@ -18,7 +18,7 @@ It returns a small result the portal interprets as valid / invalid:
 ```
 
 ```json
-{ "valid_credentials": false, "error": "Invalid credentials" }
+{ "valid_credentials": false, "error": "EarthRanger rejected the credentials" }
 ```
 
 ## Error cases

--- a/docs/actions/auth.md
+++ b/docs/actions/auth.md
@@ -27,13 +27,18 @@ The action returns `valid_credentials: false` with a descriptive `error` for eac
 
 | Condition | `error` |
 |-----------|---------|
-| Missing/invalid ER site URL | `Site URL is empty or invalid: '<url>'` |
+| Missing/invalid ER site URL | `Site URL is empty or invalid.` (the URL itself is never echoed: it may carry a token) |
 | Token method, no token | `Please provide a token.` |
 | Username/password method, missing either | `Please provide both a username and a password.` |
 | Unknown `authentication_type` | `Please select an valid authentication method.` |
-| ER rejects the credentials | `Invalid credentials` |
-| Other ER client error | the ER client's message |
-| Transport/HTTP error | `HTTP error: <detail>` |
+| ER rejects the credentials (401, 403, or the token endpoint's 400 `invalid_grant`) | `EarthRanger rejected the credentials` or `EarthRanger denied access with these credentials` |
+| ER rate-limits the request | `EarthRanger rate-limited the request` |
+| ER unreachable (DNS, connection, timeout, 502/503/504) | `EarthRanger could not be reached` |
+| Any other ER failure | `EarthRanger returned an unexpected response` |
+
+These are fixed texts: the ER client's own messages carry ER's response body, or the login request (which
+includes the password), and neither may reach the result or the activity log. The same translation serves the
+[reference actions](reference-actions.md).
 
 ## Configuration — `AuthenticateConfig`
 

--- a/docs/actions/reference-actions.md
+++ b/docs/actions/reference-actions.md
@@ -87,11 +87,16 @@ come from whichever site(s) define that type.
 
 ## Error semantics
 
-- Unknown `event_type` or `field_key` → the handler raises `ValueError`, which the runner turns into an
-  error response (never a leaked config, per the reference-action error carve-out). A classic v1 `event_type`
-  passed to `list_event_type_fields` / `list_event_field_values` surfaces the same way (ER's 404), with
-  wording that calls out the v1/v2 distinction rather than implying the slug is simply unknown.
-- Any other upstream ER failure (e.g. a 5xx) propagates unchanged.
+- Unknown `event_type` or `field_key`, an empty Site URL, or missing auth settings → the handler raises
+  `IntegrationConfigurationError`. The runner reports it as `Invalid configuration — <message>`; on the
+  ephemeral (draft-integration) path it is forwarded to the portal wizard with a 422, where every other
+  connector message is redacted. The messages describe the problem without echoing the submitted value. A
+  classic v1 `event_type` passed to `list_event_type_fields` / `list_event_field_values` surfaces the same way
+  (ER's 404), with wording that calls out the v1/v2 distinction rather than implying the slug is simply unknown.
+- EarthRanger client failures (bad credentials, permission denied, rate limit, 5xx, unreachable) are translated
+  into the runner's classified errors with the source status, so the wizard sees e.g.
+  `Authentication failed (HTTP 401)` and a 401 rather than a bare 500.
+- Any other upstream ER failure propagates unchanged and is classified by its status.
 
 ## Registration
 


### PR DESCRIPTION
On the new ephemeral path the portal wizard could not act on any EarthRanger-side failure: every error came back as a bare 500 with a class name. Two changes fix that.

**EarthRanger client failures are classified.** erclient's exceptions are not `IntegrationError` subclasses and carry no `.response`, so bad credentials rendered as `500 {"error": "ERClientBadCredentials"}`. The reference actions now build their client through `_reference_er_client`, which translates erclient failures into the runner's classified errors with a fixed message and the source status, so the wizard sees `Authentication failed (HTTP 401)` with a 401. The message is fixed text on purpose: `str(exc)` carries ER's response body. `list_event_types` also stops swallowing auth failures; `_fetch_event_type_maps` stays best-effort for `pull_events`, but on the reference path an empty result on bad credentials rendered as an empty dropdown rather than an error.

**ER's own guards are configuration errors.** An empty or schemeless site URL, missing auth settings, an unknown or classic-v1 event type, and an unknown field were `ValueError`s whose text echoed the submitted value, so the ephemeral path redacted them to the word `ValueError`. They now raise `IntegrationConfigurationError` (from the template, synced in #45): the runner reports `Invalid configuration — <message>` and forwards it to the wizard as a 422. The messages name the shape of the problem and never the submitted value; the slug still goes to the local log. This also changes the activity-log text for saved integrations with missing auth settings from the verbose `ValueError` format to the classified one.

**`action_auth`'s result text is fixed too.** It reports failures inside a normal result, which nothing in the runner redacts, so the draft URL (which may carry a token in its path or query) and `str(ERClientException)`, which includes ER's response body, came straight back. Its messages are now the same fixed texts, and the URL guard drops the URL.

**Username/password logins take a different path, now covered too.** A wrong password never reaches ER's API: the token endpoint answers 400 `invalid_grant`, and that comes out of the client three ways (an `ERClientBadRequest` naming `/oauth2/token` through `_call`, or a raw `httpx.HTTPStatusError` from `login()` in `action_auth` and from the bare `auth_headers()` in the schema fetch). One translation now handles erclient exceptions, the token-endpoint 400, raw httpx status and transport errors, and the client's status-less network failure. `list_event_types` treats the v2 fetch as load-bearing (any failure propagates) and the v1 and categories fetches as best-effort enrichment, so a role denied on the legacy endpoint keeps its dropdown while a 5xx or network failure no longer reads as an empty list. The site-URL guard lives once in `er_site_root` and every client construction site uses it, including `show_permissions` (which echoed the URL) and the two pull actions (which built `https://None/...`). `docs/actions/auth.md` describes the current result texts.

Reviewed locally (Copilot reviews are no longer available to us), five passes, thirty-nine findings; thirty-six fixed and three declined with reasons (routing the schema fetch through erclient's private `_get`, a client subclass in place of the per-instance refresh override, both deferred as follow-ups; and pull-path parity for erclient-raised ValueErrors, which the fifth pass then fixed after all). The first pass found a credential exposure on the saved-integration path (the raw login error would have had the runner publish the request body) and the username/password gap above. The second tightened it: a rejected login is reported as 401 (the portal treats only 401/403 as a credential rejection); a 5xx or 429 from the token endpoint is not a rejection; translated errors are raised `from None` so the published traceback cannot carry ER's response body through a chained cause; `list_event_types` fetches v2 first so a failure costs one round trip; every `AsyncERClient` is built by `_build_er_client`; and `show_permissions` drops its own error branch, which evaluated `.text` on the result dict and wrote `str(e)` into the card. The third pass closed the last credential path: the pull actions ran their client bare, so a transport failure on the token POST reached the runner with the login request attached and, on a saved integration, the runner published the form-encoded password. Every action now runs inside `_translating_er_client`. It also unified the two status tables into one (a raw httpx 403 and an erclient 403 read the same), made the translator catch the `ValueError`/`KeyError` erclient itself raises behind a CDN or on a non-JSON body, and mapped a redirect to a configuration error about the site URL's scheme. The fourth pass caught a regression the third had introduced: wrapping the whole pull bodies relabelled a Gundi Sensors API 401 as an EarthRanger verdict and dropped the request URL that said which side failed. The pull actions now translate only EarthRanger's own failures (erclient exceptions, and httpx errors whose request went to the ER site); a Gundi failure or a connector bug reaches the runner untouched. It also builds the client outside the translation so a broken stored auth config is rendered as a validation error, maps ER's 404 to a configuration error rather than a forwarded 404 that collides with the runner's own, and makes a stale refresh token mid-backfill fall back to a fresh login instead of reporting the stored password rejected. The fifth pass settled the pull path's edges: a 404 there keeps its status (a deleted subject group is not a site-URL problem), "is this EarthRanger's failure" is decided by request origin rather than string prefix, erclient's own `ValueError`s are recognised by their frames, and the local log keeps the traceback the published one drops on purpose.

Now targets `main` (rebased by GitHub when #45 was squash-merged).

Validation: `pytest app`, 490 passed (438 on `main`), each change written test-first; `mkdocs build --strict` passes with the updated reference-actions page.

Related: #45, PADAS/gundi-integration-action-runner#103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiRFpnqiEX9VeEJk5DD8ck