### PR TITLE
Sync template: gundi-client-v2 3.7.0 and the shared OAuth token cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,13 @@
 GUNDI_API_BASE_URL=https://api.stage.gundiservice.org
-KEYCLOAK_AUDIENCE=cdip-admin-portal
-KEYCLOAK_CLIENT_ID=cdip-integrations
-KEYCLOAK_CLIENT_SECRET=REPLACE_FOR_SECRET
-KEYCLOAK_ISSUER=https://cdip-auth.pamdas.org/auth/realms/cdip-dev
+GUNDI_OAUTH_AUDIENCE=cdip-admin-portal
+GUNDI_OAUTH_CLIENT_ID=cdip-integrations
+GUNDI_OAUTH_CLIENT_SECRET=REPLACE_FOR_SECRET
+GUNDI_OAUTH_ISSUER=https://cdip-auth.pamdas.org/auth/realms/cdip-dev
 LOG_LEVEL=INFO
 SENSORS_API_BASE_URL=https://sensors.api.stage.gundiservice.org
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_STATE_DB=0
+# Redis databases: state 0, config cache 1, shared Gundi OAuth token cache 2.
+REDIS_TOKEN_CACHE_DB=2
+# GUNDI_TOKEN_CACHE_URL overrides the derived redis:// URL (e.g. file:///dir); empty = in-process only.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+# Load the runner's settings before anything else in the package. app.actions
+# executes the connector's handlers module at import, and app.settings installs
+# the shared token cache URL into gundi-client-v2's settings, so a GundiClient()
+# built at module scope in connector code only picks it up if this runs first.
+from app import settings  # noqa: F401

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,0 @@
-# Load the runner's settings before anything else in the package. app.actions
-# executes the connector's handlers module at import, and app.settings installs
-# the shared token cache URL into gundi-client-v2's settings, so a GundiClient()
-# built at module scope in connector code only picks it up if this runs first.
-from app import settings  # noqa: F401

--- a/app/actions/__init__.py
+++ b/app/actions/__init__.py
@@ -1,3 +1,9 @@
+# Settings first: discover_actions() below executes the connector's handlers
+# module at import, and app.settings installs the shared token cache URL into
+# gundi-client-v2's settings, so a GundiClient() built at module scope there
+# only picks it up if this runs first. Done here rather than in app/__init__
+# so lightweight imports (app.services.utils, app.actions.core) stay light.
+from app import settings  # noqa: F401
 from .core import *
 
 

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import json
+import sys
 
 import httpx
 import pydantic
@@ -2160,12 +2161,22 @@ def _clear_gundi_client_caches():
     Since gundi-client-v2 3.7 every GundiClient in a process shares one OAuth
     token per set of credentials; without this, a token minted in one test would
     be served to the clients built in the next. The OIDC discovery cache is
-    cleared for the same reason.
+    cleared for the same reason. The module-level portal client in
+    action_runner is a singleton that also keeps the token on the instance, and
+    get_access_token consults that before the shared cache, so it is reset too.
     """
     from gundi_client_v2 import auth, token_cache
 
-    token_cache.clear_token_cache()
-    auth.clear_discovery_cache()
+    def _clear():
+        token_cache.clear_token_cache()
+        auth.clear_discovery_cache()
+        action_runner = sys.modules.get("app.services.action_runner")
+        if action_runner is not None:
+            never = datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+            action_runner._portal.cached_token = None
+            action_runner._portal.cached_token_expires_at = never
+            action_runner._portal.cached_token_refresh_expires_at = never
+
+    _clear()
     yield
-    token_cache.clear_token_cache()
-    auth.clear_discovery_cache()
+    _clear()

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -7,6 +7,8 @@ import httpx
 import pydantic
 import pytest
 from unittest.mock import MagicMock
+# GUNDI_TOKEN_CACHE_URL is defaulted to "" for tests in the root conftest.py,
+# which runs before the `app` package (and with it app.settings) is imported.
 from app import settings
 from gcloud.aio import pubsub
 from gundi_core.schemas.v2 import Integration, IntegrationSummary
@@ -2172,10 +2174,8 @@ def _clear_gundi_client_caches():
         auth.clear_discovery_cache()
         action_runner = sys.modules.get("app.services.action_runner")
         if action_runner is not None:
-            never = datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+            # The expiry stamps are only read when a token is present.
             action_runner._portal.cached_token = None
-            action_runner._portal.cached_token_expires_at = never
-            action_runner._portal.cached_token_refresh_expires_at = never
 
     _clear()
     yield

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -2151,3 +2151,21 @@ def mock_webhook_request_payload_for_fixed_schema():
         "lat": -2.3828796,
         "lon": 35.3380609,
     }
+
+
+@pytest.fixture(autouse=True)
+def _clear_gundi_client_caches():
+    """Keep gundi-client-v2's process-wide caches test-isolated.
+
+    Since gundi-client-v2 3.7 every GundiClient in a process shares one OAuth
+    token per set of credentials; without this, a token minted in one test would
+    be served to the clients built in the next. The OIDC discovery cache is
+    cleared for the same reason.
+    """
+    from gundi_client_v2 import auth, token_cache
+
+    token_cache.clear_token_cache()
+    auth.clear_discovery_cache()
+    yield
+    token_cache.clear_token_cache()
+    auth.clear_discovery_cache()

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -8,7 +8,7 @@ import pydantic
 import pytest
 from unittest.mock import MagicMock
 # GUNDI_TOKEN_CACHE_URL is defaulted to "" for tests in the root conftest.py,
-# which runs before the `app` package (and with it app.settings) is imported.
+# which runs before anything under app/ (and with it app.settings) is imported.
 from app import settings
 from gcloud.aio import pubsub
 from gundi_core.schemas.v2 import Integration, IntegrationSummary

--- a/app/main.py
+++ b/app/main.py
@@ -7,8 +7,10 @@ from fastapi import FastAPI, Request, status, BackgroundTasks
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-from app.routers import actions, webhooks, config_events
+# app.settings first: the routers pull in gundi_client_v2, which loads a .env of
+# its own, and the first loader wins per key (see app/settings/base.py).
 import app.settings as settings
+from app.routers import actions, webhooks, config_events
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.services.action_runner import execute_action, _portal

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -28,7 +28,7 @@ from .errors import classify_error, format_classified_error, source_status_code,
 from .url_policy import validate_outbound_url
 from .gundi import EphemeralWriteBlocked
 
-_portal = GundiClient()
+_portal = GundiClient(token_cache_url=settings.GUNDI_TOKEN_CACHE_URL)
 config_manager = IntegrationConfigurationManager()
 state_manager = IntegrationStateManager()
 logger = logging.getLogger(__name__)

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -28,7 +28,7 @@ from .errors import classify_error, format_classified_error, source_status_code,
 from .url_policy import validate_outbound_url
 from .gundi import EphemeralWriteBlocked
 
-_portal = GundiClient(token_cache_url=settings.GUNDI_TOKEN_CACHE_URL)
+_portal = GundiClient()
 config_manager = IntegrationConfigurationManager()
 state_manager = IntegrationStateManager()
 logger = logging.getLogger(__name__)

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -8,12 +8,15 @@ from typing import Optional
 
 import pydantic
 import stamina
-from gundi_client_v2 import GundiClient
-from gundi_client_v2.errors import GundiAPIError
 from gundi_core.schemas.v2 import Integration
 
-from app.actions import action_handlers, get_action_handler_by_data_type
+# app.settings before gundi_client_v2: both load a .env, and the first loader
+# wins per key (see app/settings/base.py).
 from app import settings
+from gundi_client_v2 import GundiClient
+from gundi_client_v2.errors import GundiAPIError
+
+from app.actions import action_handlers, get_action_handler_by_data_type
 from fastapi import status
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
@@ -280,9 +283,13 @@ async def _handle_error(
 
     request = _request_of(exc)
     response = getattr(exc, "response", None)  # bool(response) on status errors returns False
-    if request is None and response is None and exc.__cause__ is not None:
-        # gundi-client-v2 3.x wraps a non-2xx as GundiAPIError, which carries
-        # neither, and chains httpx's error as the cause: read it from there.
+    if isinstance(exc, GundiAPIError) and request is None and response is None and exc.__cause__ is not None:
+        # gundi-client-v2 3.x wraps a non-2xx Gundi response as GundiAPIError,
+        # which carries neither, and chains httpx's error as the cause: read it
+        # from there. Only for that type. An AuthenticationError's cause is the
+        # token POST, whose body holds the client secret or password, and a
+        # connector's `raise IntegrationAuthError(...) from e` may chain a
+        # provider login; neither request may reach the activity log.
         request = _request_of(exc.__cause__)
         response = getattr(exc.__cause__, "response", None)
     if request is not None:
@@ -295,11 +302,6 @@ async def _handle_error(
         error_details.update({
             "server_response_status": getattr(response, "status_code", None),
             "server_response_body": str(getattr(response, "text", getattr(response, "content", None)) or "")
-        })
-    elif isinstance(exc, GundiAPIError):
-        error_details.update({
-            "server_response_status": exc.status_code,
-            "server_response_body": exc.detail or "",
         })
 
     await publish_event(

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -9,6 +9,7 @@ from typing import Optional
 import pydantic
 import stamina
 from gundi_client_v2 import GundiClient
+from gundi_client_v2.errors import GundiAPIError
 from gundi_core.schemas.v2 import Integration
 
 from app.actions import action_handlers, get_action_handler_by_data_type
@@ -271,20 +272,34 @@ async def _handle_error(
     # Extract additional request/response details if available.
     # httpx exceptions expose .request as a property that raises RuntimeError
     # when the error was constructed without one — treat that as "no request".
-    try:
-        request = getattr(exc, "request", None)
-    except RuntimeError:
-        request = None
+    def _request_of(e):
+        try:
+            return getattr(e, "request", None)
+        except RuntimeError:
+            return None
+
+    request = _request_of(exc)
+    response = getattr(exc, "response", None)  # bool(response) on status errors returns False
+    if request is None and response is None and exc.__cause__ is not None:
+        # gundi-client-v2 3.x wraps a non-2xx as GundiAPIError, which carries
+        # neither, and chains httpx's error as the cause: read it from there.
+        request = _request_of(exc.__cause__)
+        response = getattr(exc.__cause__, "response", None)
     if request is not None:
         error_details.update({
             "request_verb": str(request.method),
             "request_url": str(request.url),
             "request_data": str(getattr(request, "content", getattr(request, "body", None)) or "")
         })
-    if (response := getattr(exc, "response", None)) is not None:  # bool(response) on status errors returns False
+    if response is not None:
         error_details.update({
             "server_response_status": getattr(response, "status_code", None),
             "server_response_body": str(getattr(response, "text", getattr(response, "content", None)) or "")
+        })
+    elif isinstance(exc, GundiAPIError):
+        error_details.update({
+            "server_response_status": exc.status_code,
+            "server_response_body": exc.detail or "",
         })
 
     await publish_event(

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -11,8 +11,8 @@ import redis.asyncio as redis
 # raise TypeError instead of catching.
 from redis.exceptions import RedisError
 from gundi_core.schemas.v2 import Integration, IntegrationSummary, IntegrationActionConfiguration, WebhookConfiguration
+from app import settings  # before gundi_client_v2: .env loader precedence, see app/settings/base.py
 from gundi_client_v2 import GundiClient
-from app import settings
 from .gundi import GUNDI_API_RETRY, _block_if_ephemeral
 from .retry_policies import REDIS_RETRY
 

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -232,7 +232,7 @@ class IntegrationConfigurationManager:
         # and spin GUNDI_API_RETRY for up to two minutes on the request (the
         # same guard, for the same reason, as gundi._get_gundi_api_key).
         _block_if_ephemeral("IntegrationConfigurationManager reload")
-        async with GundiClient(token_cache_url=settings.GUNDI_TOKEN_CACHE_URL) as gundi:
+        async with GundiClient() as gundi:
             async for attempt in stamina.retry_context(**GUNDI_API_RETRY):
                 with attempt:
                     integration_details = await gundi.get_integration_details(integration_id)

--- a/app/services/config_manager.py
+++ b/app/services/config_manager.py
@@ -232,7 +232,7 @@ class IntegrationConfigurationManager:
         # and spin GUNDI_API_RETRY for up to two minutes on the request (the
         # same guard, for the same reason, as gundi._get_gundi_api_key).
         _block_if_ephemeral("IntegrationConfigurationManager reload")
-        async with GundiClient() as gundi:
+        async with GundiClient(token_cache_url=settings.GUNDI_TOKEN_CACHE_URL) as gundi:
             async for attempt in stamina.retry_context(**GUNDI_API_RETRY):
                 with attempt:
                     integration_details = await gundi.get_integration_details(integration_id)

--- a/app/services/errors.py
+++ b/app/services/errors.py
@@ -79,6 +79,13 @@ class IntegrationConfigurationError(IntegrationError):
     default_title = "Invalid configuration"
 
 
+# Titles for failures of the runner's own requests to Gundi (raised by
+# gundi-client-v2). Kept apart from the provider titles above: a Gundi 401 is
+# the runner's OAuth configuration, not the source's credentials.
+GUNDI_API_ERROR_TITLE = "Gundi API request failed"
+GUNDI_AUTH_ERROR_TITLE = "Could not authenticate with Gundi"
+
+
 class ClassifiedError(NamedTuple):
     error_type: str
     title: str
@@ -132,10 +139,12 @@ def source_status_code(exc: Exception) -> Optional[int]:
 def classify_error(exc: Exception) -> Optional[ClassifiedError]:
     """Classify a third-party failure for consistent activity-log reporting.
 
-    Explicitly raised `IntegrationError` subclasses always win. Otherwise fall
-    back to heuristics based on signals the action runner already reads
-    (`exc.response.status_code`, exception type). Returns None when the error
-    can't be classified — callers keep the generic format.
+    Explicitly raised `IntegrationError` subclasses always win. A failure of
+    the runner's own call to Gundi (gundi-client-v2's errors) is reported as
+    such, never with a provider title. Otherwise fall back to heuristics based
+    on signals the action runner already reads (`exc.response.status_code`,
+    exception type). Returns None when the error can't be classified — callers
+    keep the generic format.
     """
     status_code = source_status_code(exc)
     if isinstance(exc, IntegrationError):
@@ -150,6 +159,13 @@ def classify_error(exc: Exception) -> Optional[ClassifiedError]:
     # text (URL plus a "For more information check: ..." line) — only the
     # first line is useful as a short, human-first message.
     first_line = (str(exc).splitlines() or [""])[0]
+    if isinstance(exc, (GundiAPIError, AuthenticationError)):
+        # Raised by gundi-client-v2: the runner's own request to Gundi, or to
+        # Gundi's identity provider, failed. Not a verdict from the provider,
+        # so none of the provider titles below, which would send an operator
+        # to the source's credentials when the fault is on the Gundi side.
+        title = GUNDI_AUTH_ERROR_TITLE if isinstance(exc, AuthenticationError) else GUNDI_API_ERROR_TITLE
+        return ClassifiedError("gundi", title, first_line, status_code)
     if status_code in (401, 403):
         return ClassifiedError("auth", IntegrationAuthError.default_title, first_line, status_code)
     if status_code == 429:

--- a/app/services/errors.py
+++ b/app/services/errors.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import NamedTuple, Optional
 
 import aiohttp
+from gundi_client_v2.errors import AuthenticationError, GundiAPIError
 import httpx
 
 
@@ -98,7 +99,8 @@ CONNECTIVITY_EXCEPTIONS = (
 def source_status_code(exc: Exception) -> Optional[int]:
     """The HTTP status the third party answered with, if the exception carries one.
 
-    Three shapes carry it: `IntegrationError.status_code`, aiohttp's
+    Four shapes carry it: `IntegrationError.status_code`, gundi-client-v2's
+    `GundiAPIError` / `AuthenticationError` `.status_code`, aiohttp's
     `ClientResponseError.status`, and the duck-typed `.response.status_code`
     (httpx.HTTPStatusError, requests.HTTPError, and anything else that keeps
     the response on the exception). This is the single reader shared by the
@@ -114,6 +116,11 @@ def source_status_code(exc: Exception) -> Optional[int]:
         code = getattr(exc, "status_code", None)
     elif isinstance(exc, aiohttp.ClientResponseError):
         code = exc.status
+    elif isinstance(exc, (GundiAPIError, AuthenticationError)):
+        # gundi-client-v2 3.x wraps the Gundi API's non-2xx responses (and the
+        # token endpoint's) instead of letting httpx's error escape: the status
+        # is on the wrapper, and there is no `.response`.
+        code = exc.status_code
     else:
         # getattr chain: non-HTTP exceptions have no .response attribute.
         code = getattr(getattr(exc, "response", None), "status_code", None)

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -13,6 +13,8 @@ import httpx
 import stamina
 from gundi_client_v2.client import GundiClient, GundiDataSenderClient
 
+from app import settings
+
 from .activity_logger import ephemeral_run
 
 
@@ -71,7 +73,7 @@ async def _get_gundi_api_key(integration_id):
     # letting this reach the portal would 404 and then stamina would retry
     # for up to 5 minutes with the portal-facing request thread held.
     _block_if_ephemeral("_get_gundi_api_key")
-    async with GundiClient() as gundi_client:
+    async with GundiClient(token_cache_url=settings.GUNDI_TOKEN_CACHE_URL) as gundi_client:
         return await gundi_client.get_integration_api_key(
             integration_id=integration_id
         )

--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -9,13 +9,11 @@ directly are out of scope.
 """
 import datetime
 from typing import List
-import httpx
 import stamina
 from gundi_client_v2.client import GundiClient, GundiDataSenderClient
 
-from app import settings
-
 from .activity_logger import ephemeral_run
+from .retry_policies import is_transient_gundi_error
 
 
 class EphemeralWriteBlocked(RuntimeError):
@@ -55,7 +53,7 @@ def _block_if_ephemeral(op: str) -> None:
 # hangs should turn background processing on or shorten this policy; the
 # tests in test_gundi_api.py pin the loop-overhead bound.
 GUNDI_API_RETRY = dict(
-    on=httpx.HTTPError,
+    on=is_transient_gundi_error,
     attempts=6,
     timeout=120.0,
     wait_initial=2.0,
@@ -73,7 +71,7 @@ async def _get_gundi_api_key(integration_id):
     # letting this reach the portal would 404 and then stamina would retry
     # for up to 5 minutes with the portal-facing request thread held.
     _block_if_ephemeral("_get_gundi_api_key")
-    async with GundiClient(token_cache_url=settings.GUNDI_TOKEN_CACHE_URL) as gundi_client:
+    async with GundiClient() as gundi_client:
         return await gundi_client.get_integration_api_key(
             integration_id=integration_id
         )

--- a/app/services/retry_policies.py
+++ b/app/services/retry_policies.py
@@ -37,15 +37,12 @@ def is_transient_gundi_error(exc: BaseException) -> bool:
     if isinstance(exc, AuthenticationError) and exc.status_code is None:
         # No status from the token endpoint. ``transport``: it never answered.
         # OIDC discovery failures are wrapped without the flag, with httpx's
-        # error as the cause: judge that by its status, or retry a transport
-        # failure. Anything else (no token URL or credentials configured, a
-        # malformed token response) is permanent.
+        # error as the cause: judge the cause by the same rules. Anything else
+        # (no token URL or credentials configured, a malformed token response)
+        # has no httpx cause and is permanent.
         if exc.transport:
             return True
-        cause = exc.__cause__
-        if isinstance(cause, httpx.HTTPStatusError):
-            return _retryable_status(cause.response.status_code)
-        return isinstance(cause, httpx.HTTPError)
+        return exc.__cause__ is not None and is_transient_gundi_error(exc.__cause__)
     if isinstance(exc, (httpx.HTTPError, GundiAPIError, AuthenticationError)):
         status_code = source_status_code(exc)
         # An httpx error without a status is a transport failure.

--- a/app/services/retry_policies.py
+++ b/app/services/retry_policies.py
@@ -8,6 +8,34 @@ Iterate stamina with `async for`: its synchronous iterator sleeps with
 time.sleep, which inside a coroutine stalls the whole event loop for the
 length of the back-off.
 """
+import httpx
+from gundi_client_v2.errors import AuthenticationError, GundiAPIError
 from redis.exceptions import RedisError
 
 REDIS_RETRY = dict(on=RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0)
+
+
+def _retryable_status(status_code) -> bool:
+    # No status: the request never got an answer (transport failure, malformed
+    # body). 429 and 5xx are the server's problem for now. Any other 4xx is a
+    # definite answer that will not change on the next attempt.
+    return status_code is None or status_code == 429 or status_code >= 500
+
+
+def is_transient_gundi_error(exc: BaseException) -> bool:
+    """Retry predicate for Gundi API calls (``on=`` for stamina).
+
+    gundi-client-v2 3.x reports a non-2xx Gundi response as ``GundiAPIError``
+    and a token-endpoint failure as ``AuthenticationError``; neither subclasses
+    ``httpx.HTTPError``, which is all these policies used to retry on, so a
+    transient 503 or a Keycloak outage would otherwise fail on the first
+    attempt. Transport failures, 429 and 5xx get another try; a 4xx (a missing
+    integration, rejected credentials) fails at once instead of six times.
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        return _retryable_status(exc.response.status_code)
+    if isinstance(exc, httpx.HTTPError):
+        return True
+    if isinstance(exc, (GundiAPIError, AuthenticationError)):
+        return _retryable_status(exc.status_code)
+    return False

--- a/app/services/retry_policies.py
+++ b/app/services/retry_policies.py
@@ -1,7 +1,7 @@
 """Retry policies shared across the service layer.
 
-Kept in a leaf module (no app imports) so config_manager and state can both
-use REDIS_RETRY without importing each other. GUNDI_API_RETRY lives in
+Kept in a leaf module (imports only .errors, itself a leaf) so config_manager
+and state can both use REDIS_RETRY without importing each other. GUNDI_API_RETRY lives in
 gundi.py next to the helpers it decorates.
 
 Iterate stamina with `async for`: its synchronous iterator sleeps with
@@ -12,14 +12,15 @@ import httpx
 from gundi_client_v2.errors import AuthenticationError, GundiAPIError
 from redis.exceptions import RedisError
 
+from .errors import source_status_code
+
 REDIS_RETRY = dict(on=RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0)
 
 
-def _retryable_status(status_code) -> bool:
-    # No status: the request never got an answer (transport failure, malformed
-    # body). 429 and 5xx are the server's problem for now. Any other 4xx is a
+def _retryable_status(status_code: int) -> bool:
+    # 429 and 5xx are the server's problem for now. Any other status is a
     # definite answer that will not change on the next attempt.
-    return status_code is None or status_code == 429 or status_code >= 500
+    return status_code == 429 or status_code >= 500
 
 
 def is_transient_gundi_error(exc: BaseException) -> bool:
@@ -33,22 +34,20 @@ def is_transient_gundi_error(exc: BaseException) -> bool:
     integration, rejected credentials) and a permanent OAuth misconfiguration
     fail at once instead of six times.
     """
-    if isinstance(exc, httpx.HTTPStatusError):
-        return _retryable_status(exc.response.status_code)
-    if isinstance(exc, httpx.HTTPError):
-        return True
-    if isinstance(exc, GundiAPIError):
-        return _retryable_status(exc.status_code)
-    if isinstance(exc, AuthenticationError):
-        # A status-less AuthenticationError is usually permanent: no token URL or
-        # credentials configured, a malformed token response. Only a token
-        # endpoint that never answered (``transport``), or OIDC discovery that
-        # failed on the network (wrapped without the flag; the cause is httpx's
-        # transport error), is worth another attempt.
+    if isinstance(exc, AuthenticationError) and exc.status_code is None:
+        # No status from the token endpoint. ``transport``: it never answered.
+        # OIDC discovery failures are wrapped without the flag, with httpx's
+        # error as the cause: judge that by its status, or retry a transport
+        # failure. Anything else (no token URL or credentials configured, a
+        # malformed token response) is permanent.
         if exc.transport:
             return True
-        if exc.status_code is None:
-            cause = exc.__cause__
-            return isinstance(cause, httpx.HTTPError) and not isinstance(cause, httpx.HTTPStatusError)
-        return exc.status_code == 429 or exc.status_code >= 500
+        cause = exc.__cause__
+        if isinstance(cause, httpx.HTTPStatusError):
+            return _retryable_status(cause.response.status_code)
+        return isinstance(cause, httpx.HTTPError)
+    if isinstance(exc, (httpx.HTTPError, GundiAPIError, AuthenticationError)):
+        status_code = source_status_code(exc)
+        # An httpx error without a status is a transport failure.
+        return True if status_code is None else _retryable_status(status_code)
     return False

--- a/app/services/retry_policies.py
+++ b/app/services/retry_policies.py
@@ -30,12 +30,25 @@ def is_transient_gundi_error(exc: BaseException) -> bool:
     ``httpx.HTTPError``, which is all these policies used to retry on, so a
     transient 503 or a Keycloak outage would otherwise fail on the first
     attempt. Transport failures, 429 and 5xx get another try; a 4xx (a missing
-    integration, rejected credentials) fails at once instead of six times.
+    integration, rejected credentials) and a permanent OAuth misconfiguration
+    fail at once instead of six times.
     """
     if isinstance(exc, httpx.HTTPStatusError):
         return _retryable_status(exc.response.status_code)
     if isinstance(exc, httpx.HTTPError):
         return True
-    if isinstance(exc, (GundiAPIError, AuthenticationError)):
+    if isinstance(exc, GundiAPIError):
         return _retryable_status(exc.status_code)
+    if isinstance(exc, AuthenticationError):
+        # A status-less AuthenticationError is usually permanent: no token URL or
+        # credentials configured, a malformed token response. Only a token
+        # endpoint that never answered (``transport``), or OIDC discovery that
+        # failed on the network (wrapped without the flag; the cause is httpx's
+        # transport error), is worth another attempt.
+        if exc.transport:
+            return True
+        if exc.status_code is None:
+            cause = exc.__cause__
+            return isinstance(cause, httpx.HTTPError) and not isinstance(cause, httpx.HTTPStatusError)
+        return exc.status_code == 429 or exc.status_code >= 500
     return False

--- a/app/services/self_registration.py
+++ b/app/services/self_registration.py
@@ -3,7 +3,6 @@ import datetime
 import logging
 
 import stamina
-import httpx
 
 from app.actions import (
     action_handlers,
@@ -21,6 +20,7 @@ from app.settings import (
 )
 from .core import ActionTypeEnum
 from app.webhooks.core import get_webhook_handler, GenericJsonTransformConfig
+from .retry_policies import is_transient_gundi_error
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +117,7 @@ async def register_integration_in_gundi(gundi_client, type_slug=None, type_name=
     logger.info(f"Registering '{integration_type_slug}' with actions: '{actions}'")
     # Register the integration type and actions in Gundi
     async for attempt in stamina.retry_context(
-        on=httpx.HTTPError, wait_initial=datetime.timedelta(seconds=1), attempts=3
+        on=is_transient_gundi_error, wait_initial=datetime.timedelta(seconds=1), attempts=3
     ):
         with attempt:
             response = await gundi_client.register_integration_type(data)

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -697,6 +697,89 @@ async def test_execute_action_with_handler_error(
     assert event.payload.server_response_body == str(expected_error.response.text)
 
 
+def _gundi_api_error_from_httpx(status_code: int, body: str) -> Exception:
+    """How gundi-client-v2 3.x raises a non-2xx: GundiAPIError(status, body)
+    with httpx's status error, which holds the request and response, as the
+    cause (errors.raise_for_status)."""
+    import httpx
+    from gundi_client_v2.errors import GundiAPIError
+
+    request = httpx.Request("POST", "https://sensors.api.test.gundiservice.org/v2/observations/", content=b'[{"source": "x"}]')
+    response = httpx.Response(status_code, text=body, request=request)
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        try:
+            raise GundiAPIError(status_code=status_code, detail=body) from e
+        except GundiAPIError as wrapped:
+            return wrapped
+
+
+@pytest.mark.asyncio
+async def test_execute_action_reports_gundi_api_error_with_response_details(
+        mocker, mock_gundi_client_v2, integration_v2, mock_config_manager, mock_publish_event,
+):
+    """A handler's send_*_to_gundi fails with a Sensors API 400. The activity
+    log must still carry the request URL and the response status and body,
+    now that the client wraps httpx's error, and the text must name Gundi,
+    not the provider."""
+    exc = _gundi_api_error_from_httpx(400, '{"observations": ["recorded_at is required"]}')
+    handler = AsyncMock(side_effect=exc)
+    del handler.action_title
+    mocker.patch("app.services.action_runner.action_handlers", {"pull_observations": (handler, MockPullActionConfiguration, None)})
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post(
+        "/v1/actions/execute/",
+        json={"integration_id": str(integration_v2.id), "action_id": "pull_observations"},
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    details = response.json()["detail"]
+    assert details["error_type"] == "gundi"
+    assert details["error"].startswith("Gundi API request failed")
+    assert "Authentication failed" not in details["error"]
+    assert details["request_url"] == "https://sensors.api.test.gundiservice.org/v2/observations/"
+    assert details["server_response_status"] == 400
+    assert details["server_response_body"] == '{"observations": ["recorded_at is required"]}'
+    event = mock_publish_event.mock_calls[0].kwargs["event"]
+    assert event.payload.server_response_status == 400
+    assert event.payload.server_response_body == '{"observations": ["recorded_at is required"]}'
+    assert event.payload.request_url == "https://sensors.api.test.gundiservice.org/v2/observations/"
+
+
+@pytest.mark.asyncio
+async def test_execute_action_reports_gundi_auth_failure_as_gundi_side(
+        mocker, mock_gundi_client_v2, integration_v2, mock_config_manager, mock_publish_event,
+):
+    """A wrong GUNDI_OAUTH_CLIENT_SECRET surfaces from the handler's portal
+    call as AuthenticationError(401). It must not read as the provider
+    rejecting the integration's credentials."""
+    from gundi_client_v2.errors import AuthenticationError
+
+    handler = AsyncMock(side_effect=AuthenticationError("Token request failed: HTTP 401", status_code=401, error="invalid_client"))
+    del handler.action_title
+    mocker.patch("app.services.action_runner.action_handlers", {"pull_observations": (handler, MockPullActionConfiguration, None)})
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post(
+        "/v1/actions/execute/",
+        json={"integration_id": str(integration_v2.id), "action_id": "pull_observations"},
+    )
+
+    details = response.json()["detail"]
+    assert details["error_type"] == "gundi"
+    assert details["error"].startswith("Could not authenticate with Gundi")
+    assert "(HTTP 401)" in details["error"]
+    assert details.get("server_response_status") is None  # no Gundi response to report; the status is in the text
+
+
 _EPHEMERAL_SECRET = "ephemeral-token-abc123"
 
 

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1145,6 +1145,32 @@ async def test_ephemeral_run_error_does_not_leak_request_or_response_bodies(
 
 
 @pytest.mark.asyncio
+async def test_ephemeral_run_forwards_gundi_client_status(
+        mocker, mock_gundi_client_v2, mock_config_manager,
+        mock_publish_event, mock_ephemeral_action_handlers, mock_reference_action_handler,
+):
+    """gundi-client-v2 3.x reports a non-2xx Gundi response as GundiAPIError
+    (status on the wrapper, no .response), so the runner has to read it there
+    for cdip's upstream_status to match what Gundi answered."""
+    from gundi_client_v2.errors import GundiAPIError
+
+    mock_reference_action_handler.side_effect = GundiAPIError(
+        status_code=401, detail=f'{{"error": "bad api key {_EPHEMERAL_SECRET}"}}',
+    )
+    mocker.patch("app.services.action_runner.action_handlers", mock_ephemeral_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    resp = api_client.post("/v1/actions/execute/", json=_ephemeral_body())
+
+    assert resp.status_code == 401
+    assert _EPHEMERAL_SECRET not in resp.text
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
 async def test_ephemeral_run_rejects_background_execution(
         mocker, mock_gundi_client_v2, mock_config_manager,
         mock_publish_event, mock_ephemeral_action_handlers, mock_reference_action_handler,

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -697,22 +697,41 @@ async def test_execute_action_with_handler_error(
     assert event.payload.server_response_body == str(expected_error.response.text)
 
 
-def _gundi_api_error_from_httpx(status_code: int, body: str) -> Exception:
-    """How gundi-client-v2 3.x raises a non-2xx: GundiAPIError(status, body)
-    with httpx's status error, which holds the request and response, as the
-    cause (errors.raise_for_status)."""
+def _gundi_api_error_from_httpx(status_code: int, body: str, url: str = "https://sensors.api.test.gundiservice.org/v2/observations/") -> Exception:
+    """A non-2xx exactly as gundi-client-v2 3.x raises it: through the library's
+    own raise_for_status, so the shape (status, detail, httpx's error as the
+    cause) cannot drift from what the client produces."""
     import httpx
-    from gundi_client_v2.errors import GundiAPIError
+    from gundi_client_v2.errors import GundiAPIError, raise_for_status
 
-    request = httpx.Request("POST", "https://sensors.api.test.gundiservice.org/v2/observations/", content=b'[{"source": "x"}]')
-    response = httpx.Response(status_code, text=body, request=request)
+    request = httpx.Request("POST", url, content=b'[{"source": "x"}]')
+    try:
+        raise_for_status(httpx.Response(status_code, text=body, request=request))
+    except GundiAPIError as e:
+        return e
+    raise AssertionError("raise_for_status did not raise")
+
+
+def _auth_error_from_token_post(secret: str) -> Exception:
+    """An AuthenticationError as gundi_client_v2.auth raises it for a rejected
+    token request: chained from httpx's status error, whose request body is the
+    token POST carrying the client secret."""
+    import httpx
+    from gundi_client_v2.errors import AuthenticationError
+
+    request = httpx.Request(
+        "POST", "https://auth.example.org/realms/x/protocol/openid-connect/token",
+        content=f"client_id=cdip-integrations&client_secret={secret}&grant_type=client_credentials".encode(),
+    )
+    response = httpx.Response(401, text='{"error": "invalid_client"}', request=request)
     try:
         response.raise_for_status()
     except httpx.HTTPStatusError as e:
         try:
-            raise GundiAPIError(status_code=status_code, detail=body) from e
-        except GundiAPIError as wrapped:
+            raise AuthenticationError("Token request failed: HTTP 401", status_code=401, error="invalid_client") from e
+        except AuthenticationError as wrapped:
             return wrapped
+    raise AssertionError("unreachable")
 
 
 @pytest.mark.asyncio
@@ -757,10 +776,10 @@ async def test_execute_action_reports_gundi_auth_failure_as_gundi_side(
 ):
     """A wrong GUNDI_OAUTH_CLIENT_SECRET surfaces from the handler's portal
     call as AuthenticationError(401). It must not read as the provider
-    rejecting the integration's credentials."""
-    from gundi_client_v2.errors import AuthenticationError
+    rejecting the integration's credentials, and the token request chained
+    under it must not be published."""
 
-    handler = AsyncMock(side_effect=AuthenticationError("Token request failed: HTTP 401", status_code=401, error="invalid_client"))
+    handler = AsyncMock(side_effect=_auth_error_from_token_post("SUPERSECRET-client-secret"))
     del handler.action_title
     mocker.patch("app.services.action_runner.action_handlers", {"pull_observations": (handler, MockPullActionConfiguration, None)})
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
@@ -777,7 +796,55 @@ async def test_execute_action_reports_gundi_auth_failure_as_gundi_side(
     assert details["error_type"] == "gundi"
     assert details["error"].startswith("Could not authenticate with Gundi")
     assert "(HTTP 401)" in details["error"]
-    assert details.get("server_response_status") is None  # no Gundi response to report; the status is in the text
+    # The chained token POST carries the client secret: it must reach neither
+    # the response nor the published event, so no request/response fields at
+    # all for an AuthenticationError (the status is in the text).
+    assert "SUPERSECRET" not in response.text
+    assert "request_data" not in details and "request_url" not in details
+    assert details.get("server_response_status") is None
+    event = mock_publish_event.mock_calls[0].kwargs["event"]
+    assert "SUPERSECRET" not in event.json()
+    assert not event.payload.request_data  # gundi_core defaults the field to ""
+
+
+@pytest.mark.asyncio
+async def test_execute_action_does_not_publish_a_chained_provider_login(
+        mocker, mock_gundi_client_v2, integration_v2, mock_config_manager, mock_publish_event,
+):
+    """A connector that does `raise IntegrationAuthError(...) from e` after a
+    failed provider login chains the login POST, whose body holds the
+    provider password. IntegrationError carries no request of its own, and the
+    runner must not go looking for one on the cause."""
+    import httpx
+    from app.services.errors import IntegrationAuthError
+
+    request = httpx.Request("POST", "https://provider.example.org/login", content=b"user=ranger&password=PROVIDER-PASSWORD")
+    response = httpx.Response(401, text="bad login", request=request)
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        try:
+            raise IntegrationAuthError("Provider rejected the credentials") from e
+        except IntegrationAuthError as wrapped:
+            exc = wrapped
+    handler = AsyncMock(side_effect=exc)
+    del handler.action_title
+    mocker.patch("app.services.action_runner.action_handlers", {"pull_observations": (handler, MockPullActionConfiguration, None)})
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    response = api_client.post(
+        "/v1/actions/execute/",
+        json={"integration_id": str(integration_v2.id), "action_id": "pull_observations"},
+    )
+
+    assert "PROVIDER-PASSWORD" not in response.text
+    assert "request_data" not in response.json()["detail"]
+    event = mock_publish_event.mock_calls[0].kwargs["event"]
+    assert "PROVIDER-PASSWORD" not in event.json()
+    assert event.payload.error_traceback  # the traceback still names the chain, without bodies
 
 
 _EPHEMERAL_SECRET = "ephemeral-token-abc123"

--- a/app/services/tests/test_errors.py
+++ b/app/services/tests/test_errors.py
@@ -3,6 +3,7 @@ import asyncio
 import aiohttp
 import httpx
 import pytest
+from gundi_client_v2.errors import AuthenticationError, GundiAPIError
 
 from app.services.errors import (
     IntegrationError,
@@ -197,11 +198,32 @@ def test_classify_builtin_timeout_as_connectivity():
         (_http_status_error(404), 404),
         (IntegrationAuthError("nope", status_code=401), 401),
         (IntegrationAuthError("nope"), None),
+        # gundi-client-v2 3.x wraps the Gundi API's non-2xx (no .response on it)
+        (GundiAPIError(status_code=429, detail="slow down"), 429),
+        (AuthenticationError("invalid_client", status_code=401, error="invalid_client"), 401),
+        (AuthenticationError("keycloak unreachable", transport=True), None),
         (ValueError("no response here"), None),
     ],
 )
 def test_source_status_code_reads_every_carrier(exc, expected):
     assert source_status_code(exc) == expected
+
+
+@pytest.mark.parametrize(
+    "exc,expected_type",
+    [
+        (GundiAPIError(status_code=401, detail="bad api key"), "auth"),
+        (GundiAPIError(status_code=429), "rate_limit"),
+        (GundiAPIError(status_code=503), "bad_response"),
+    ],
+)
+def test_classify_error_reads_gundi_client_status(exc, expected_type):
+    """A Sensors API 429 after the retries are exhausted must still read as a
+    rate limit, not a generic GundiAPIError, now that the client wraps it."""
+    classified = classify_error(exc)
+    assert classified is not None
+    assert classified.error_type == expected_type
+    assert classified.status_code == exc.status_code
 
 
 @pytest.mark.parametrize("junk", ["401", True, 4.01, None])

--- a/app/services/tests/test_errors.py
+++ b/app/services/tests/test_errors.py
@@ -16,6 +16,8 @@ from app.services.errors import (
     format_classified_error,
     format_error_message,
     source_status_code,
+    GUNDI_API_ERROR_TITLE,
+    GUNDI_AUTH_ERROR_TITLE,
 )
 
 
@@ -210,20 +212,26 @@ def test_source_status_code_reads_every_carrier(exc, expected):
 
 
 @pytest.mark.parametrize(
-    "exc,expected_type",
+    "exc,expected_title",
     [
-        (GundiAPIError(status_code=401, detail="bad api key"), "auth"),
-        (GundiAPIError(status_code=429), "rate_limit"),
-        (GundiAPIError(status_code=503), "bad_response"),
+        (GundiAPIError(status_code=401, detail="bad api key"), GUNDI_API_ERROR_TITLE),
+        (GundiAPIError(status_code=429), GUNDI_API_ERROR_TITLE),
+        (GundiAPIError(status_code=503), GUNDI_API_ERROR_TITLE),
+        (AuthenticationError("Token request failed: HTTP 401", status_code=401, error="invalid_client"), GUNDI_AUTH_ERROR_TITLE),
+        (AuthenticationError("keycloak unreachable", transport=True), GUNDI_AUTH_ERROR_TITLE),
     ],
 )
-def test_classify_error_reads_gundi_client_status(exc, expected_type):
-    """A Sensors API 429 after the retries are exhausted must still read as a
-    rate limit, not a generic GundiAPIError, now that the client wraps it."""
+def test_classify_error_reports_gundi_client_failures_as_gundi_side(exc, expected_title):
+    """A 401 from Gundi or its identity provider is the runner's OAuth
+    configuration, not the provider's credentials: never the provider's
+    "Authentication failed" title, but the status is still carried so the
+    ephemeral path can forward it."""
     classified = classify_error(exc)
     assert classified is not None
-    assert classified.error_type == expected_type
+    assert classified.error_type == "gundi"
+    assert classified.title == expected_title
     assert classified.status_code == exc.status_code
+    assert "provider" not in format_classified_error(classified).lower()
 
 
 @pytest.mark.parametrize("junk", ["401", True, 4.01, None])

--- a/app/services/tests/test_gundi_api.py
+++ b/app/services/tests/test_gundi_api.py
@@ -241,8 +241,10 @@ async def test_config_manager_reload_uses_the_shared_gundi_retry_policy(
 
     await IntegrationConfigurationManager().get_integration(str(integration_v2.id))
 
-    http_policies = [c.kwargs for c in spy.call_args_list if c.kwargs.get("on") is httpx.HTTPError]
-    assert http_policies, "expected the reload to retry on httpx.HTTPError"
+    from app.services.retry_policies import is_transient_gundi_error
+
+    http_policies = [c.kwargs for c in spy.call_args_list if c.kwargs.get("on") is is_transient_gundi_error]
+    assert http_policies, "expected the reload to retry on transient Gundi errors"
     assert all(kw == GUNDI_API_RETRY for kw in http_policies), http_policies
 
 

--- a/app/services/tests/test_retry_policies.py
+++ b/app/services/tests/test_retry_policies.py
@@ -1,0 +1,125 @@
+"""The Gundi API retry policies must recognise gundi-client-v2 3.x's errors.
+
+The client reports a non-2xx Gundi response as GundiAPIError and a token
+endpoint failure as AuthenticationError. Neither subclasses httpx.HTTPError,
+which is all the policies retried on before the 3.7 upgrade, so a transient
+503 or a Keycloak outage failed on the first attempt while the suite, which
+simulated failures with httpx errors, stayed green.
+"""
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import stamina
+from gundi_client_v2.errors import AuthenticationError, GundiAPIError
+
+from app.services.retry_policies import is_transient_gundi_error
+
+
+@pytest.fixture
+def no_backoff():
+    """stamina's testing mode: no sleeps between attempts, attempts capped."""
+    stamina.set_testing(True, attempts=3)
+    yield
+    stamina.set_testing(False)
+
+
+def _status_error(status_code):
+    request = httpx.Request("POST", "https://sensors.example.org/v2/observations/")
+    return httpx.HTTPStatusError(
+        f"HTTP {status_code}", request=request, response=httpx.Response(status_code, request=request)
+    )
+
+
+@pytest.mark.parametrize("exc", [
+    GundiAPIError(status_code=503, detail="upstream unavailable"),
+    GundiAPIError(status_code=502),
+    GundiAPIError(status_code=429, detail="slow down"),
+    AuthenticationError("keycloak unreachable", transport=True),
+    AuthenticationError("keycloak 503", status_code=503),
+    AuthenticationError("malformed token response"),  # no status: never answered properly
+    httpx.ConnectError("portal unreachable"),
+    httpx.ReadTimeout("timed out"),
+    _status_error(503),
+])
+def test_transient_failures_are_retried(exc):
+    assert is_transient_gundi_error(exc) is True
+
+
+@pytest.mark.parametrize("exc", [
+    GundiAPIError(status_code=404, detail="integration not found"),
+    GundiAPIError(status_code=400, detail="bad payload"),
+    GundiAPIError(status_code=403),
+    AuthenticationError("invalid_client", status_code=401, error="invalid_client"),
+    AuthenticationError("invalid_grant", status_code=400, error="invalid_grant", refresh_token_rejected=True),
+    _status_error(404),
+    ValueError("not an HTTP problem at all"),
+])
+def test_definite_failures_are_not_retried(exc):
+    assert is_transient_gundi_error(exc) is False
+
+
+@pytest.mark.asyncio
+async def test_send_observations_retries_a_transient_gundi_api_error(
+        no_backoff, mocker, mock_gundi_sensors_client_class, mock_get_gundi_api_key,
+):
+    """End to end through the real GUNDI_API_RETRY: one 503 from the Sensors
+    API, then success."""
+    from app.services.gundi import send_observations_to_gundi
+
+    mocker.patch("app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class)
+    mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
+    sensors = mock_gundi_sensors_client_class.return_value
+    sensors.post_observations = AsyncMock(side_effect=[GundiAPIError(status_code=503), {"status": "ok"}])
+
+    result = await send_observations_to_gundi(observations=[{"source": "x"}], integration_id="abc-123")
+
+    assert result == {"status": "ok"}
+    assert sensors.post_observations.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_send_observations_does_not_retry_a_client_error(
+        no_backoff, mocker, mock_gundi_sensors_client_class, mock_get_gundi_api_key,
+):
+    from app.services.gundi import send_observations_to_gundi
+
+    mocker.patch("app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class)
+    mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
+    sensors = mock_gundi_sensors_client_class.return_value
+    sensors.post_observations = AsyncMock(side_effect=GundiAPIError(status_code=400, detail="bad payload"))
+
+    with pytest.raises(GundiAPIError):
+        await send_observations_to_gundi(observations=[{"source": "x"}], integration_id="abc-123")
+
+    assert sensors.post_observations.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_registration_retries_a_portal_outage(no_backoff, mocker):
+    """Self-registration keeps its own three-attempt policy; it must use the
+    same predicate, or REGISTER_ON_START fails the boot on one portal 502."""
+    from app.services import self_registration
+
+    mocker.patch.object(self_registration, "action_handlers", {})
+    client = mocker.MagicMock()
+    client.register_integration_type = AsyncMock(side_effect=[GundiAPIError(status_code=502), {"id": "1"}])
+
+    response = await self_registration.register_integration_in_gundi(gundi_client=client, type_slug="acme_tracker")
+
+    assert response == {"id": "1"}
+    assert client.register_integration_type.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_registration_does_not_retry_a_rejected_registration(no_backoff, mocker):
+    from app.services import self_registration
+
+    mocker.patch.object(self_registration, "action_handlers", {})
+    client = mocker.MagicMock()
+    client.register_integration_type = AsyncMock(side_effect=GundiAPIError(status_code=403, detail="forbidden"))
+
+    with pytest.raises(GundiAPIError):
+        await self_registration.register_integration_in_gundi(gundi_client=client, type_slug="acme_tracker")
+
+    assert client.register_integration_type.await_count == 1

--- a/app/services/tests/test_retry_policies.py
+++ b/app/services/tests/test_retry_policies.py
@@ -31,13 +31,22 @@ def _status_error(status_code):
     )
 
 
+def _discovery_failure(cause):
+    """How gundi_client_v2.auth wraps an OIDC discovery failure: no status, no
+    transport flag, the httpx error as the cause."""
+    exc = AuthenticationError(f"OIDC discovery failed: {cause}")
+    exc.__cause__ = cause
+    return exc
+
+
 @pytest.mark.parametrize("exc", [
     GundiAPIError(status_code=503, detail="upstream unavailable"),
     GundiAPIError(status_code=502),
     GundiAPIError(status_code=429, detail="slow down"),
     AuthenticationError("keycloak unreachable", transport=True),
     AuthenticationError("keycloak 503", status_code=503),
-    AuthenticationError("malformed token response"),  # no status: never answered properly
+    AuthenticationError("keycloak rate limit", status_code=429),
+    _discovery_failure(httpx.ConnectError("keycloak unreachable")),  # OIDC discovery, network
     httpx.ConnectError("portal unreachable"),
     httpx.ReadTimeout("timed out"),
     _status_error(503),
@@ -52,6 +61,11 @@ def test_transient_failures_are_retried(exc):
     GundiAPIError(status_code=403),
     AuthenticationError("invalid_client", status_code=401, error="invalid_client"),
     AuthenticationError("invalid_grant", status_code=400, error="invalid_grant", refresh_token_rejected=True),
+    # Status-less and not a transport failure: permanent misconfiguration.
+    AuthenticationError("No token URL configured"),
+    AuthenticationError("No credentials configured"),
+    AuthenticationError("malformed token response"),
+    _discovery_failure(_status_error(404)),  # OIDC discovery document missing
     _status_error(404),
     ValueError("not an HTTP problem at all"),
 ])

--- a/app/services/tests/test_retry_policies.py
+++ b/app/services/tests/test_retry_policies.py
@@ -47,6 +47,8 @@ def _discovery_failure(cause):
     AuthenticationError("keycloak 503", status_code=503),
     AuthenticationError("keycloak rate limit", status_code=429),
     _discovery_failure(httpx.ConnectError("keycloak unreachable")),  # OIDC discovery, network
+    _discovery_failure(_status_error(503)),  # OIDC discovery endpoint down during a Keycloak restart
+    _discovery_failure(_status_error(429)),
     httpx.ConnectError("portal unreachable"),
     httpx.ReadTimeout("timed out"),
     _status_error(503),

--- a/app/services/tests/test_token_cache.py
+++ b/app/services/tests/test_token_cache.py
@@ -1,105 +1,139 @@
 """Contract tests for the shared OAuth token cache.
 
 gundi-client-v2 3.7 keeps one token per set of credentials in process memory
-and, when a client is given a ``token_cache_url``, in Redis, so runner replicas
-stop minting a fresh Keycloak token for nearly every portal call. These tests
-pin that the runner derives that URL from its Redis settings and hands it to
-every GundiClient it builds.
+and, when configured with a token cache URL, in Redis, so runner replicas stop
+minting a fresh Keycloak token for nearly every portal call. These tests pin
+that the runner derives that URL from its Redis settings, installs it as the
+client library's default so every GundiClient() in the process uses it, and
+never lets an unusable URL take the service down.
+
+The tests read the loaded settings rather than reloading the settings module
+against a patched environment: a reload re-runs env.read_env(), so a
+developer's repo .env would leak into the assertions.
 """
-import importlib
+import logging
+import os
 
 import pytest
 from gundi_client_v2 import GundiClient
-from gundi_client_v2.token_cache import RedisTokenCache
+from gundi_client_v2 import settings as client_settings
+from gundi_client_v2.token_cache import RedisTokenCache, token_cache_from_url
 
 from app import settings
+from app.settings.base import default_token_cache_url, validated_token_cache_url
 
 
-def _reload_settings():
-    # app.settings re-exports app.settings.base, so the base module has to be
-    # re-evaluated first and the package reloaded to pick up the new values.
-    import app.settings.base
-
-    importlib.reload(app.settings.base)
-    importlib.reload(settings)
+def test_default_token_cache_url_derives_from_redis_settings():
+    assert default_token_cache_url("cache.internal", 6380, 7) == "redis://cache.internal:6380/7"
 
 
-@pytest.fixture
-def reload_settings():
-    """Re-evaluate app.settings against the patched environment and restore it
-    afterwards. Request it BEFORE ``monkeypatch`` so that the environment is
-    restored before the final reload."""
-    yield _reload_settings
-    _reload_settings()
+def test_default_token_cache_url_brackets_ipv6_hosts():
+    # redis.Redis(host="::1") is fine, but a URL needs the brackets or redis-py
+    # reads ":1:6379" as the port.
+    assert default_token_cache_url("::1", 6379, 2) == "redis://[::1]:6379/2"
+    assert default_token_cache_url("[::1]", 6379, 2) == "redis://[::1]:6379/2"
+    assert validated_token_cache_url(default_token_cache_url("::1", 6379, 2)) == "redis://[::1]:6379/2"
 
 
-def test_token_cache_url_is_derived_from_redis_settings(reload_settings, monkeypatch):
-    monkeypatch.delenv("GUNDI_TOKEN_CACHE_URL", raising=False)
-    monkeypatch.setenv("REDIS_HOST", "cache.internal")
-    monkeypatch.setenv("REDIS_PORT", "6380")
-    monkeypatch.setenv("REDIS_TOKEN_CACHE_DB", "7")
-
-    reload_settings()
-
-    assert settings.REDIS_TOKEN_CACHE_DB == 7
-    assert settings.GUNDI_TOKEN_CACHE_URL == "redis://cache.internal:6380/7"
-
-
-def test_token_cache_db_defaults_next_to_state_and_config_dbs(reload_settings, monkeypatch):
-    monkeypatch.delenv("REDIS_TOKEN_CACHE_DB", raising=False)
-    monkeypatch.delenv("GUNDI_TOKEN_CACHE_URL", raising=False)
-
-    reload_settings()
-
+def test_token_cache_db_defaults_next_to_state_and_config_dbs():
+    if os.environ.get("REDIS_TOKEN_CACHE_DB") is not None:
+        pytest.skip("REDIS_TOKEN_CACHE_DB is set in this environment")
     assert settings.REDIS_TOKEN_CACHE_DB == 2
-    assert settings.GUNDI_TOKEN_CACHE_URL.endswith("/2")
 
 
-def test_token_cache_url_env_override_wins(reload_settings, monkeypatch):
-    monkeypatch.setenv("GUNDI_TOKEN_CACHE_URL", "file:///var/cache/gundi-tokens")
-
-    reload_settings()
-
-    assert settings.GUNDI_TOKEN_CACHE_URL == "file:///var/cache/gundi-tokens"
-
-
-@pytest.mark.asyncio
-async def test_api_key_lookup_client_uses_shared_token_cache(mocker, mock_gundi_client_v2_class):
-    mock_gundi_client_v2_class.return_value.get_integration_api_key = mocker.AsyncMock(return_value="an-api-key")
-    mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
-    from app.services.gundi import _get_gundi_api_key
-
-    await _get_gundi_api_key(integration_id="8a0b8b2e-0a3c-4f7a-8f1b-6b0f5d6a4d11")
-
-    mock_gundi_client_v2_class.assert_called_once_with(token_cache_url=settings.GUNDI_TOKEN_CACHE_URL)
+def test_settings_url_is_the_derived_default_or_the_env_override():
+    override = os.environ.get("GUNDI_TOKEN_CACHE_URL")
+    if override is not None:
+        assert settings.GUNDI_TOKEN_CACHE_URL == validated_token_cache_url(override)
+    else:
+        assert settings.GUNDI_TOKEN_CACHE_URL == default_token_cache_url(
+            settings.REDIS_HOST, settings.REDIS_PORT, settings.REDIS_TOKEN_CACHE_DB
+        )
 
 
-@pytest.mark.asyncio
-async def test_config_reload_client_uses_shared_token_cache(
-        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
-):
-    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
-    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
-    from app.services.config_manager import IntegrationConfigurationManager
-
-    await IntegrationConfigurationManager().get_integration(str(integration_v2.id))
-
-    mock_gundi_client_v2_class.assert_called_once_with(token_cache_url=settings.GUNDI_TOKEN_CACHE_URL)
+@pytest.mark.parametrize("good", ["redis://localhost:6379/2", "rediss://cache.internal:6380/0", "file:///var/cache/gundi-tokens"])
+def test_validated_token_cache_url_keeps_a_usable_url(good):
+    assert validated_token_cache_url(good) == good
 
 
-def test_portal_client_is_bare_and_has_redis_token_cache_backend():
-    """The module-level portal client is built at import time, so the only
-    observable is the backend it ended up with. ``_token_store._backend`` is
-    gundi-client-v2 internal API; if this breaks on an upgrade, re-check that
-    ``action_runner._portal`` still passes ``token_cache_url``. Credentials
-    must stay env-driven: bareness is what lets GUNDI_USERNAME/GUNDI_PASSWORD
-    select the password grant."""
-    from gundi_client_v2 import settings as client_settings
+def test_validated_token_cache_url_empty_means_in_process_only():
+    assert validated_token_cache_url("") == ""
+    assert validated_token_cache_url(None) == ""
 
+
+@pytest.mark.parametrize("bad", [
+    "localhost:6379",           # no scheme: TokenCacheConfigError
+    "redis://::1:6379/2",       # unbracketed IPv6: redis-py ValueError
+    "file://relative/dir",      # file URL with a host: TokenCacheConfigError
+])
+def test_validated_token_cache_url_falls_back_to_memory_with_one_warning(bad, caplog):
+    """The portal client is built at import, so a URL the client cannot parse
+    must degrade to in-process sharing instead of crashing the service."""
+    with caplog.at_level(logging.WARNING, logger="app.settings.base"):
+        assert validated_token_cache_url(bad) == ""
+    warnings = [r for r in caplog.records if "GUNDI_TOKEN_CACHE_URL is unusable" in r.getMessage()]
+    assert len(warnings) == 1
+    assert bad not in warnings[0].getMessage(), "a cache URL may carry a password; never log it"
+
+
+def test_runner_url_is_installed_as_the_client_library_default():
+    """gundi-client-v2 reads GUNDI_TOKEN_CACHE_URL from its own settings module
+    at construction time. The runner installs its derived URL there so a bare
+    GundiClient() anywhere in the process (connector code included) shares the
+    backend, not only the sites that pass a kwarg."""
+    assert client_settings.GUNDI_TOKEN_CACHE_URL == settings.GUNDI_TOKEN_CACHE_URL
+
+
+def _expected_backend():
+    # None when the developer opted out of a backend.
+    return token_cache_from_url(settings.GUNDI_TOKEN_CACHE_URL)
+
+
+def _backend_signature(backend):
+    """What a backend points at, comparable across instances. The conftest
+    fixture clears the library's memoized backends between tests, so a client
+    built at import (the portal) and one built now hold different objects for
+    the same URL; object identity is the wrong comparison."""
+    if backend is None:
+        return None
+    if isinstance(backend, RedisTokenCache):
+        kwargs = backend._client.connection_pool.connection_kwargs
+        return ("redis", kwargs.get("host"), kwargs.get("port"), kwargs.get("db"))
+    return (type(backend).__name__, vars(backend))
+
+
+def test_bare_client_uses_the_runner_token_cache_backend():
+    """``_token_store._backend`` is gundi-client-v2 internal API; if this breaks
+    on an upgrade, re-check that the library still reads its settings module
+    for the constructor default."""
+    client = GundiClient(oauth_client_id="svc", oauth_token_url="https://auth.example.com/token")
+
+    assert _backend_signature(client._token_store._backend) == _backend_signature(_expected_backend())
+
+
+def test_portal_client_is_bare_and_shares_the_token_cache_backend():
+    """Credentials must stay env-driven: bareness is what lets
+    GUNDI_USERNAME/GUNDI_PASSWORD select the password grant."""
     from app.services.action_runner import _portal
 
     assert isinstance(_portal, GundiClient)
+    assert _portal.username == client_settings.GUNDI_USERNAME
+    assert _portal.password == client_settings.GUNDI_PASSWORD
     assert _portal.client_id == client_settings.OAUTH_CLIENT_ID
     assert _portal.client_secret == client_settings.OAUTH_CLIENT_SECRET
-    assert settings.GUNDI_TOKEN_CACHE_URL.startswith("redis://")
-    assert isinstance(_portal._token_store._backend, RedisTokenCache)
+    assert _backend_signature(_portal._token_store._backend) == _backend_signature(_expected_backend())
+
+
+def test_default_backend_is_redis():
+    if os.environ.get("GUNDI_TOKEN_CACHE_URL") is not None:
+        pytest.skip("GUNDI_TOKEN_CACHE_URL is overridden in this environment")
+    assert isinstance(_expected_backend(), RedisTokenCache)
+
+
+def test_portal_singleton_token_is_reset_between_tests():
+    """The autouse fixture in conftest resets the module-level portal client's
+    instance token, which get_access_token consults before the shared cache."""
+    from app.services.action_runner import _portal
+
+    assert _portal.cached_token is None
+    _portal.cached_token = "leaked-if-seen-by-the-next-test"

--- a/app/services/tests/test_token_cache.py
+++ b/app/services/tests/test_token_cache.py
@@ -9,10 +9,14 @@ never lets an unusable URL take the service down.
 
 The tests read the loaded settings rather than reloading the settings module
 against a patched environment: a reload re-runs env.read_env(), so a
-developer's repo .env would leak into the assertions.
+developer's repo .env would leak into the assertions. Under pytest the runner
+is configured for in-process sharing only (conftest sets GUNDI_TOKEN_CACHE_URL
+to ""), so the Redis-backend assertions build their URLs explicitly.
 """
 import logging
 import os
+import subprocess
+import sys
 
 import pytest
 from gundi_client_v2 import GundiClient
@@ -51,7 +55,12 @@ def test_settings_url_is_the_derived_default_or_the_env_override():
         )
 
 
-@pytest.mark.parametrize("good", ["redis://localhost:6379/2", "rediss://cache.internal:6380/0", "file:///var/cache/gundi-tokens"])
+@pytest.mark.parametrize("good", [
+    "redis://localhost:6379/2",
+    "rediss://cache.internal:6380/0",
+    "redis://localhost:6379?db=3",
+    "file:///var/cache/gundi-tokens",
+])
 def test_validated_token_cache_url_keeps_a_usable_url(good):
     assert validated_token_cache_url(good) == good
 
@@ -62,9 +71,11 @@ def test_validated_token_cache_url_empty_means_in_process_only():
 
 
 @pytest.mark.parametrize("bad", [
-    "localhost:6379",           # no scheme: TokenCacheConfigError
-    "redis://::1:6379/2",       # unbracketed IPv6: redis-py ValueError
-    "file://relative/dir",      # file URL with a host: TokenCacheConfigError
+    "localhost:6379",                 # no scheme: TokenCacheConfigError
+    "redis://::1:6379/2",             # unbracketed IPv6: redis-py ValueError
+    "file://relative/dir",            # file URL with a host: TokenCacheConfigError
+    "redis://localhost:6379/tokens",  # redis-py would silently use db 0, the state database
+    "redis://localhost:6379",         # no database at all: same
 ])
 def test_validated_token_cache_url_falls_back_to_memory_with_one_warning(bad, caplog):
     """The portal client is built at import, so a URL the client cannot parse
@@ -85,7 +96,7 @@ def test_runner_url_is_installed_as_the_client_library_default():
 
 
 def _expected_backend():
-    # None when the developer opted out of a backend.
+    # None when there is no backend (the pytest default; see conftest).
     return token_cache_from_url(settings.GUNDI_TOKEN_CACHE_URL)
 
 
@@ -102,13 +113,22 @@ def _backend_signature(backend):
     return (type(backend).__name__, vars(backend))
 
 
-def test_bare_client_uses_the_runner_token_cache_backend():
+def test_default_url_builds_a_redis_backend_on_the_named_db():
+    backend = token_cache_from_url(default_token_cache_url("cache.internal", 6380, 7))
+
+    assert _backend_signature(backend) == ("redis", "cache.internal", 6380, 7)
+
+
+def test_bare_client_reads_the_installed_url_at_construction_time(monkeypatch):
     """``_token_store._backend`` is gundi-client-v2 internal API; if this breaks
     on an upgrade, re-check that the library still reads its settings module
-    for the constructor default."""
+    for the constructor default (that is what lets the runner configure every
+    GundiClient() in the process from app.settings)."""
+    monkeypatch.setattr(client_settings, "GUNDI_TOKEN_CACHE_URL", "redis://[::1]:6379/9")
+
     client = GundiClient(oauth_client_id="svc", oauth_token_url="https://auth.example.com/token")
 
-    assert _backend_signature(client._token_store._backend) == _backend_signature(_expected_backend())
+    assert _backend_signature(client._token_store._backend) == ("redis", "::1", 6379, 9)
 
 
 def test_portal_client_is_bare_and_shares_the_token_cache_backend():
@@ -124,10 +144,23 @@ def test_portal_client_is_bare_and_shares_the_token_cache_backend():
     assert _backend_signature(_portal._token_store._backend) == _backend_signature(_expected_backend())
 
 
-def test_default_backend_is_redis():
-    if os.environ.get("GUNDI_TOKEN_CACHE_URL") is not None:
-        pytest.skip("GUNDI_TOKEN_CACHE_URL is overridden in this environment")
-    assert isinstance(_expected_backend(), RedisTokenCache)
+def test_settings_load_before_connector_code_runs():
+    """app.actions executes the connector's handlers module at import. A
+    GundiClient() built at module scope there must already see the runner's
+    token cache URL, so importing app.actions alone has to load app.settings
+    (and install the URL) first. A subprocess, so nothing here is pre-imported."""
+    probe = (
+        "import sys; import app.actions; "
+        "assert 'app.settings' in sys.modules, 'app.settings not loaded by app.actions'; "
+        "from app import settings; from gundi_client_v2 import settings as cs; "
+        "assert cs.GUNDI_TOKEN_CACHE_URL == settings.GUNDI_TOKEN_CACHE_URL; print('ok')"
+    )
+    result = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, timeout=60)
+
+    assert result.returncode == 0, result.stderr
+    # The settings module logs to stdout; a warning about an unusable override
+    # in the developer's environment may precede the probe's own line.
+    assert result.stdout.strip().splitlines()[-1] == "ok"
 
 
 def test_portal_singleton_token_is_reset_between_tests():

--- a/app/services/tests/test_token_cache.py
+++ b/app/services/tests/test_token_cache.py
@@ -1,0 +1,105 @@
+"""Contract tests for the shared OAuth token cache.
+
+gundi-client-v2 3.7 keeps one token per set of credentials in process memory
+and, when a client is given a ``token_cache_url``, in Redis, so runner replicas
+stop minting a fresh Keycloak token for nearly every portal call. These tests
+pin that the runner derives that URL from its Redis settings and hands it to
+every GundiClient it builds.
+"""
+import importlib
+
+import pytest
+from gundi_client_v2 import GundiClient
+from gundi_client_v2.token_cache import RedisTokenCache
+
+from app import settings
+
+
+def _reload_settings():
+    # app.settings re-exports app.settings.base, so the base module has to be
+    # re-evaluated first and the package reloaded to pick up the new values.
+    import app.settings.base
+
+    importlib.reload(app.settings.base)
+    importlib.reload(settings)
+
+
+@pytest.fixture
+def reload_settings():
+    """Re-evaluate app.settings against the patched environment and restore it
+    afterwards. Request it BEFORE ``monkeypatch`` so that the environment is
+    restored before the final reload."""
+    yield _reload_settings
+    _reload_settings()
+
+
+def test_token_cache_url_is_derived_from_redis_settings(reload_settings, monkeypatch):
+    monkeypatch.delenv("GUNDI_TOKEN_CACHE_URL", raising=False)
+    monkeypatch.setenv("REDIS_HOST", "cache.internal")
+    monkeypatch.setenv("REDIS_PORT", "6380")
+    monkeypatch.setenv("REDIS_TOKEN_CACHE_DB", "7")
+
+    reload_settings()
+
+    assert settings.REDIS_TOKEN_CACHE_DB == 7
+    assert settings.GUNDI_TOKEN_CACHE_URL == "redis://cache.internal:6380/7"
+
+
+def test_token_cache_db_defaults_next_to_state_and_config_dbs(reload_settings, monkeypatch):
+    monkeypatch.delenv("REDIS_TOKEN_CACHE_DB", raising=False)
+    monkeypatch.delenv("GUNDI_TOKEN_CACHE_URL", raising=False)
+
+    reload_settings()
+
+    assert settings.REDIS_TOKEN_CACHE_DB == 2
+    assert settings.GUNDI_TOKEN_CACHE_URL.endswith("/2")
+
+
+def test_token_cache_url_env_override_wins(reload_settings, monkeypatch):
+    monkeypatch.setenv("GUNDI_TOKEN_CACHE_URL", "file:///var/cache/gundi-tokens")
+
+    reload_settings()
+
+    assert settings.GUNDI_TOKEN_CACHE_URL == "file:///var/cache/gundi-tokens"
+
+
+@pytest.mark.asyncio
+async def test_api_key_lookup_client_uses_shared_token_cache(mocker, mock_gundi_client_v2_class):
+    mock_gundi_client_v2_class.return_value.get_integration_api_key = mocker.AsyncMock(return_value="an-api-key")
+    mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
+    from app.services.gundi import _get_gundi_api_key
+
+    await _get_gundi_api_key(integration_id="8a0b8b2e-0a3c-4f7a-8f1b-6b0f5d6a4d11")
+
+    mock_gundi_client_v2_class.assert_called_once_with(token_cache_url=settings.GUNDI_TOKEN_CACHE_URL)
+
+
+@pytest.mark.asyncio
+async def test_config_reload_client_uses_shared_token_cache(
+        mocker, mock_redis_empty, mock_gundi_client_v2_class, integration_v2,
+):
+    mocker.patch("app.services.config_manager.redis", mock_redis_empty)
+    mocker.patch("app.services.config_manager.GundiClient", mock_gundi_client_v2_class)
+    from app.services.config_manager import IntegrationConfigurationManager
+
+    await IntegrationConfigurationManager().get_integration(str(integration_v2.id))
+
+    mock_gundi_client_v2_class.assert_called_once_with(token_cache_url=settings.GUNDI_TOKEN_CACHE_URL)
+
+
+def test_portal_client_is_bare_and_has_redis_token_cache_backend():
+    """The module-level portal client is built at import time, so the only
+    observable is the backend it ended up with. ``_token_store._backend`` is
+    gundi-client-v2 internal API; if this breaks on an upgrade, re-check that
+    ``action_runner._portal`` still passes ``token_cache_url``. Credentials
+    must stay env-driven: bareness is what lets GUNDI_USERNAME/GUNDI_PASSWORD
+    select the password grant."""
+    from gundi_client_v2 import settings as client_settings
+
+    from app.services.action_runner import _portal
+
+    assert isinstance(_portal, GundiClient)
+    assert _portal.client_id == client_settings.OAUTH_CLIENT_ID
+    assert _portal.client_secret == client_settings.OAUTH_CLIENT_SECRET
+    assert settings.GUNDI_TOKEN_CACHE_URL.startswith("redis://")
+    assert isinstance(_portal._token_store._backend, RedisTokenCache)

--- a/app/services/tests/test_token_cache.py
+++ b/app/services/tests/test_token_cache.py
@@ -15,8 +15,10 @@ to ""), so the Redis-backend assertions build their URLs explicitly.
 """
 import logging
 import os
+import pathlib
 import subprocess
 import sys
+import tempfile
 
 import pytest
 from gundi_client_v2 import GundiClient
@@ -45,16 +47,55 @@ def test_token_cache_db_defaults_next_to_state_and_config_dbs():
     assert settings.REDIS_TOKEN_CACHE_DB == 2
 
 
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_SUBPROCESS_KEYS = ("GUNDI_TOKEN_CACHE_URL", "REDIS_HOST", "REDIS_PORT", "REDIS_TOKEN_CACHE_DB")
+
+
 def _settings_in_subprocess(env_overrides: dict, probe: str) -> str:
     """Run ``probe`` in a fresh interpreter with the runner's env adjusted, so
     a settings value can be checked without reloading the settings module in
-    this process (a reload re-runs env.read_env()). Returns the last stdout
-    line; the settings module logs to stdout, so a warning may precede it."""
-    env = {k: v for k, v in os.environ.items() if k not in ("GUNDI_TOKEN_CACHE_URL", "REDIS_HOST", "REDIS_PORT", "REDIS_TOKEN_CACHE_DB")}
+    this process (a reload re-runs env.read_env()). Runs from the repo root,
+    with gundi-client-v2's own .env loader pointed at an empty file. The
+    runner's read_env() still finds a repo-root .env, which environs would let
+    win over the keys removed here, so such a .env skips these tests instead
+    of failing them. Returns the last stdout line; the settings module logs to
+    stdout, so a warning may precede it."""
+    repo_dotenv = _REPO_ROOT / ".env"
+    if repo_dotenv.exists():
+        from dotenv import dotenv_values
+
+        clashing = sorted(k for k in dotenv_values(repo_dotenv) if k in _SUBPROCESS_KEYS)
+        if clashing:
+            pytest.skip(f"{repo_dotenv} sets {clashing}; the runner's .env loader would override the test environment")
+    env = {k: v for k, v in os.environ.items() if k not in _SUBPROCESS_KEYS}
     env.update(env_overrides)
-    result = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, timeout=60, env=env)
+    with tempfile.NamedTemporaryFile(prefix="gundi-empty-", suffix=".env") as empty:
+        env["GUNDI_CLIENT_ENVFILE"] = empty.name
+        result = subprocess.run(
+            [sys.executable, "-c", probe], capture_output=True, text=True, timeout=60, env=env, cwd=_REPO_ROOT,
+        )
     assert result.returncode == 0, result.stderr
     return result.stdout.strip().splitlines()[-1]
+
+
+@pytest.mark.parametrize("entry_point", ["app.main", "app.register", "app.services.action_runner", "app.services.config_manager", "app.services.webhooks"])
+def test_runner_settings_load_before_the_client_library(entry_point):
+    """Both the runner and gundi-client-v2 load a .env through environs'
+    read_env(), and the first loader wins per key. app/settings/base.py imports
+    the client only after its own read_env(), so the runner's .env wins wherever
+    app.settings is reached first. Observed by spying on read_env itself:
+    sys.modules order is completion order, so it cannot tell the two apart."""
+    line = _settings_in_subprocess(
+        {},
+        # Env.read_env is a staticmethod in environs.
+        "import inspect, environs; calls = []; orig = environs.Env.read_env\n"
+        "def spy(*a, **k):\n"
+        "    calls.append(inspect.stack()[1].filename); return orig(*a, **k)\n"
+        "environs.Env.read_env = staticmethod(spy)\n"
+        f"import {entry_point}\n"
+        "print(calls[0].replace('\\\\', '/').endswith('app/settings/base.py'), len(calls))",
+    )
+    assert line == "True 2", f"{entry_point}: the first .env loader was not the runner's ({line})"
 
 
 def test_settings_derive_the_url_from_redis_settings_when_not_overridden():

--- a/app/services/tests/test_token_cache.py
+++ b/app/services/tests/test_token_cache.py
@@ -45,20 +45,40 @@ def test_token_cache_db_defaults_next_to_state_and_config_dbs():
     assert settings.REDIS_TOKEN_CACHE_DB == 2
 
 
-def test_settings_url_is_the_derived_default_or_the_env_override():
-    override = os.environ.get("GUNDI_TOKEN_CACHE_URL")
-    if override is not None:
-        assert settings.GUNDI_TOKEN_CACHE_URL == validated_token_cache_url(override)
-    else:
-        assert settings.GUNDI_TOKEN_CACHE_URL == default_token_cache_url(
-            settings.REDIS_HOST, settings.REDIS_PORT, settings.REDIS_TOKEN_CACHE_DB
-        )
+def _settings_in_subprocess(env_overrides: dict, probe: str) -> str:
+    """Run ``probe`` in a fresh interpreter with the runner's env adjusted, so
+    a settings value can be checked without reloading the settings module in
+    this process (a reload re-runs env.read_env()). Returns the last stdout
+    line; the settings module logs to stdout, so a warning may precede it."""
+    env = {k: v for k, v in os.environ.items() if k not in ("GUNDI_TOKEN_CACHE_URL", "REDIS_HOST", "REDIS_PORT", "REDIS_TOKEN_CACHE_DB")}
+    env.update(env_overrides)
+    result = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, timeout=60, env=env)
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip().splitlines()[-1]
+
+
+def test_settings_derive_the_url_from_redis_settings_when_not_overridden():
+    line = _settings_in_subprocess(
+        {"REDIS_HOST": "cache.internal", "REDIS_PORT": "6380", "REDIS_TOKEN_CACHE_DB": "7"},
+        "from app import settings; print(settings.REDIS_TOKEN_CACHE_DB, settings.GUNDI_TOKEN_CACHE_URL)",
+    )
+    assert line == "7 redis://cache.internal:6380/7"
+
+
+def test_settings_honour_the_env_override():
+    line = _settings_in_subprocess(
+        {"GUNDI_TOKEN_CACHE_URL": "file:///var/cache/gundi-tokens"},
+        "from app import settings; print(settings.GUNDI_TOKEN_CACHE_URL)",
+    )
+    assert line == "file:///var/cache/gundi-tokens"
 
 
 @pytest.mark.parametrize("good", [
     "redis://localhost:6379/2",
+    "redis://localhost:6379/2/",           # redis-py reads db 2
     "rediss://cache.internal:6380/0",
     "redis://localhost:6379?db=3",
+    "redis://[::1]:6379/2",
     "file:///var/cache/gundi-tokens",
 ])
 def test_validated_token_cache_url_keeps_a_usable_url(good):
@@ -95,11 +115,6 @@ def test_runner_url_is_installed_as_the_client_library_default():
     assert client_settings.GUNDI_TOKEN_CACHE_URL == settings.GUNDI_TOKEN_CACHE_URL
 
 
-def _expected_backend():
-    # None when there is no backend (the pytest default; see conftest).
-    return token_cache_from_url(settings.GUNDI_TOKEN_CACHE_URL)
-
-
 def _backend_signature(backend):
     """What a backend points at, comparable across instances. The conftest
     fixture clears the library's memoized backends between tests, so a client
@@ -131,9 +146,12 @@ def test_bare_client_reads_the_installed_url_at_construction_time(monkeypatch):
     assert _backend_signature(client._token_store._backend) == ("redis", "::1", 6379, 9)
 
 
-def test_portal_client_is_bare_and_shares_the_token_cache_backend():
+def test_portal_client_is_bare_env_driven():
     """Credentials must stay env-driven: bareness is what lets
-    GUNDI_USERNAME/GUNDI_PASSWORD select the password grant."""
+    GUNDI_USERNAME/GUNDI_PASSWORD select the password grant. (The backend it
+    shares is not asserted here: tests run with no backend, see conftest; the
+    subprocess test below covers that the URL is installed before the portal
+    client is built.)"""
     from app.services.action_runner import _portal
 
     assert isinstance(_portal, GundiClient)
@@ -141,26 +159,25 @@ def test_portal_client_is_bare_and_shares_the_token_cache_backend():
     assert _portal.password == client_settings.GUNDI_PASSWORD
     assert _portal.client_id == client_settings.OAUTH_CLIENT_ID
     assert _portal.client_secret == client_settings.OAUTH_CLIENT_SECRET
-    assert _backend_signature(_portal._token_store._backend) == _backend_signature(_expected_backend())
 
 
 def test_settings_load_before_connector_code_runs():
     """app.actions executes the connector's handlers module at import. A
     GundiClient() built at module scope there must already see the runner's
     token cache URL, so importing app.actions alone has to load app.settings
-    (and install the URL) first. A subprocess, so nothing here is pre-imported."""
+    (and install the URL) first; the portal client built at import must then
+    hold the Redis backend. A subprocess, so nothing here is pre-imported."""
     probe = (
         "import sys; import app.actions; "
         "assert 'app.settings' in sys.modules, 'app.settings not loaded by app.actions'; "
         "from app import settings; from gundi_client_v2 import settings as cs; "
-        "assert cs.GUNDI_TOKEN_CACHE_URL == settings.GUNDI_TOKEN_CACHE_URL; print('ok')"
+        "assert cs.GUNDI_TOKEN_CACHE_URL == settings.GUNDI_TOKEN_CACHE_URL == 'redis://cache.internal:6380/7'; "
+        "from app.services.action_runner import _portal; "
+        "kw = _portal._token_store._backend._client.connection_pool.connection_kwargs; "
+        "print(kw['host'], kw['port'], kw['db'])"
     )
-    result = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, timeout=60)
-
-    assert result.returncode == 0, result.stderr
-    # The settings module logs to stdout; a warning about an unusable override
-    # in the developer's environment may precede the probe's own line.
-    assert result.stdout.strip().splitlines()[-1] == "ok"
+    line = _settings_in_subprocess({"REDIS_HOST": "cache.internal", "REDIS_PORT": "6380", "REDIS_TOKEN_CACHE_DB": "7"}, probe)
+    assert line == "cache.internal 6380 7"
 
 
 def test_portal_singleton_token_is_reset_between_tests():

--- a/app/settings/base.py
+++ b/app/settings/base.py
@@ -1,14 +1,21 @@
 import logging
 import logging.config
 import sys
+from urllib.parse import parse_qs, urlparse
 
 from environs import Env
-from gundi_client_v2 import settings as gundi_client_settings
-from gundi_client_v2.errors import TokenCacheConfigError
-from gundi_client_v2.token_cache import token_cache_from_url
 
 env = Env()
 env.read_env()
+
+# Imported after read_env(): gundi_client_v2.settings loads a .env of its own
+# (walking up from the current directory) and environs never overrides a key
+# that is already set, so whichever loader runs first wins. The runner's, which
+# walks up from this file, keeps precedence as it had before the client was
+# imported here.
+from gundi_client_v2 import settings as gundi_client_settings  # noqa: E402
+from gundi_client_v2.errors import TokenCacheConfigError  # noqa: E402
+from gundi_client_v2.token_cache import token_cache_from_url  # noqa: E402
 
 LOGGING_LEVEL = env.str("LOGGING_LEVEL", "INFO")
 
@@ -66,6 +73,22 @@ def default_token_cache_url(host: str, port: int, db: int) -> str:
     return f"redis://{host}:{port}/{db}"
 
 
+def _require_explicit_redis_db(url: str) -> None:
+    """A redis:// URL must name its database as a number: redis-py maps a
+    missing or non-numeric path (``redis://host:6379``, ``redis://host/tokens``)
+    to db 0 without a word, which is the runner's state database."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("redis", "rediss"):
+        return
+    db = parsed.path.lstrip("/") or (parse_qs(parsed.query).get("db") or [""])[0]
+    if not db.isdigit():
+        raise ValueError(
+            "a redis:// token cache URL must end in a numeric database index "
+            "(e.g. redis://host:6379/2); a missing or non-numeric one would land "
+            "tokens in db 0, the state database"
+        )
+
+
 def validated_token_cache_url(url: str) -> str:
     """Return ``url`` if gundi-client-v2 can build a token cache backend from
     it, else "" (tokens shared within the process only) after one warning.
@@ -79,6 +102,7 @@ def validated_token_cache_url(url: str) -> str:
     if not url:
         return ""
     try:
+        _require_explicit_redis_db(url)
         token_cache_from_url(url)
     except (TokenCacheConfigError, ValueError) as e:
         # Log the failure, not the URL: a redis:// URL may carry a password.

--- a/app/settings/base.py
+++ b/app/settings/base.py
@@ -60,6 +60,17 @@ REDIS_HOST = env.str("REDIS_HOST", "localhost")
 REDIS_PORT = env.int("REDIS_PORT", 6379)
 REDIS_STATE_DB = env.int("REDIS_STATE_DB", 0)
 REDIS_CONFIGS_DB = env.int("REDIS_CONFIGS_DB", 1)  # ToDo: define a convention for DB numbers across services
+REDIS_TOKEN_CACHE_DB = env.int("REDIS_TOKEN_CACHE_DB", 2)
+
+# Shared OAuth token cache (gundi-client-v2 >= 3.7). Every GundiClient the runner
+# builds shares one token per set of credentials, in process memory and in this
+# backend, so replicas stop minting a fresh Keycloak token per portal call.
+# Defaults to the runner's Redis, next to the state (0) and config (1) databases.
+# Override with a redis://, rediss:// or file:///dir URL; set it to an empty
+# string to share tokens within the process only.
+GUNDI_TOKEN_CACHE_URL = env.str(
+    "GUNDI_TOKEN_CACHE_URL", f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_TOKEN_CACHE_DB}"
+)
 
 
 REGISTER_ON_START = env.bool("REGISTER_ON_START", False)

--- a/app/settings/base.py
+++ b/app/settings/base.py
@@ -1,7 +1,6 @@
 import logging
 import logging.config
 import sys
-from urllib.parse import parse_qs, urlparse
 
 from environs import Env
 
@@ -16,6 +15,7 @@ env.read_env()
 from gundi_client_v2 import settings as gundi_client_settings  # noqa: E402
 from gundi_client_v2.errors import TokenCacheConfigError  # noqa: E402
 from gundi_client_v2.token_cache import token_cache_from_url  # noqa: E402
+from redis.connection import parse_url as _parse_redis_url  # noqa: E402
 
 LOGGING_LEVEL = env.str("LOGGING_LEVEL", "INFO")
 
@@ -76,14 +76,14 @@ def default_token_cache_url(host: str, port: int, db: int) -> str:
 def _require_explicit_redis_db(url: str) -> None:
     """A redis:// URL must name its database as a number: redis-py maps a
     missing or non-numeric path (``redis://host:6379``, ``redis://host/tokens``)
-    to db 0 without a word, which is the runner's state database."""
-    parsed = urlparse(url)
-    if parsed.scheme not in ("redis", "rediss"):
+    to db 0 without a word, which is the runner's state database. Judged with
+    redis-py's own parser so the check is by construction what it will do
+    (``/2/`` is db 2; ``?db=3`` beats the path)."""
+    if not url.startswith(("redis://", "rediss://")):
         return
-    db = parsed.path.lstrip("/") or (parse_qs(parsed.query).get("db") or [""])[0]
-    if not db.isdigit():
+    if _parse_redis_url(url).get("db") is None:
         raise ValueError(
-            "a redis:// token cache URL must end in a numeric database index "
+            "a redis:// token cache URL must name a numeric database index "
             "(e.g. redis://host:6379/2); a missing or non-numeric one would land "
             "tokens in db 0, the state database"
         )

--- a/app/settings/base.py
+++ b/app/settings/base.py
@@ -7,11 +7,16 @@ from environs import Env
 env = Env()
 env.read_env()
 
-# Imported after read_env(): gundi_client_v2.settings loads a .env of its own
-# (walking up from the current directory) and environs never overrides a key
-# that is already set, so whichever loader runs first wins. The runner's, which
-# walks up from this file, keeps precedence as it had before the client was
-# imported here.
+# Imported after read_env(). gundi_client_v2.settings loads a .env of its own,
+# walking up from the current working directory, while the runner's read_env()
+# above walks up from this file; environs never overrides a key that is already
+# set, so whichever loader runs first wins per key. The entry points (app.main,
+# app.register, app.services.action_runner and the service modules) import
+# app.settings before anything from gundi_client_v2, so the runner's .env wins
+# there (pinned by a test). A module imported on its own that reaches
+# gundi_client_v2 first lets the client's loader go first; the two only differ
+# when the process runs from a directory outside the repo tree, or from one with
+# its own .env, while another .env sits at the repo root.
 from gundi_client_v2 import settings as gundi_client_settings  # noqa: E402
 from gundi_client_v2.errors import TokenCacheConfigError  # noqa: E402
 from gundi_client_v2.token_cache import token_cache_from_url  # noqa: E402

--- a/app/settings/base.py
+++ b/app/settings/base.py
@@ -1,6 +1,11 @@
+import logging
 import logging.config
 import sys
+
 from environs import Env
+from gundi_client_v2 import settings as gundi_client_settings
+from gundi_client_v2.errors import TokenCacheConfigError
+from gundi_client_v2.token_cache import token_cache_from_url
 
 env = Env()
 env.read_env()
@@ -28,15 +33,6 @@ logging.config.dictConfig(DEFAULT_LOGGING)
 
 DEFAULT_REQUESTS_TIMEOUT = (10, 20)  # Connect, Read
 
-CDIP_API_ENDPOINT = env.str("CDIP_API_ENDPOINT", None)
-CDIP_ADMIN_ENDPOINT = env.str("CDIP_ADMIN_ENDPOINT", None)
-PORTAL_API_ENDPOINT = f"{CDIP_ADMIN_ENDPOINT}/api/v1.0"
-PORTAL_OUTBOUND_INTEGRATIONS_ENDPOINT = (
-    f"{PORTAL_API_ENDPOINT}/integrations/outbound/configurations"
-)
-PORTAL_INBOUND_INTEGRATIONS_ENDPOINT = (
-    f"{PORTAL_API_ENDPOINT}/integrations/inbound/configurations"
-)
 GUNDI_API_BASE_URL = env.str("GUNDI_API_BASE_URL", None)
 GUNDI_API_SSL_VERIFY = env.bool("GUNDI_API_SSL_VERIFY", True)
 SENSORS_API_BASE_URL = env.str("SENSORS_API_BASE_URL", None)
@@ -48,11 +44,9 @@ TRACE_ENVIRONMENT = env.str("TRACE_ENVIRONMENT", "dev")
 GCP_PROJECT_ID = env.str("GCP_PROJECT_ID", "cdip-78ca")
 
 
-KEYCLOAK_ALGORITHMS = env.list("KEYCLOAK_ALGORITHMS", ["RS256", "HS256"])
-KEYCLOAK_AUDIENCE = env.str("KEYCLOAK_AUDIENCE", None)
-KEYCLOAK_AUTH_SERVICE = env.str("KEYCLOAK_AUTH_SERVICE", None)
-KEYCLOAK_REALM = env.str("KEYCLOAK_REALM", None)
-KEYCLOAK_ISSUER = f"{KEYCLOAK_AUTH_SERVICE}/realms/{KEYCLOAK_REALM}"
+# Gundi API authentication is configured through gundi-client-v2's own settings
+# (GUNDI_OAUTH_CLIENT_ID / GUNDI_OAUTH_CLIENT_SECRET / GUNDI_OAUTH_ISSUER, with the
+# OAUTH_* and KEYCLOAK_* spellings as fallbacks); nothing here reads them.
 
 
 # Redis settings for state & config managers
@@ -62,15 +56,64 @@ REDIS_STATE_DB = env.int("REDIS_STATE_DB", 0)
 REDIS_CONFIGS_DB = env.int("REDIS_CONFIGS_DB", 1)  # ToDo: define a convention for DB numbers across services
 REDIS_TOKEN_CACHE_DB = env.int("REDIS_TOKEN_CACHE_DB", 2)
 
+
+def default_token_cache_url(host: str, port: int, db: int) -> str:
+    """The runner's Redis as a token cache URL. redis-py parses the URL with
+    urllib, so an IPv6 literal (which redis.Redis(host=...) accepts bare) has to
+    be bracketed here."""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    return f"redis://{host}:{port}/{db}"
+
+
+def validated_token_cache_url(url: str) -> str:
+    """Return ``url`` if gundi-client-v2 can build a token cache backend from
+    it, else "" (tokens shared within the process only) after one warning.
+
+    The client parses the URL when a GundiClient is constructed, and the portal
+    client is constructed at import, so an unusable URL would otherwise take the
+    whole service down (webhooks, health, config events) over a cache that is an
+    optimization. The backend built here is memoized by the client library, so
+    this costs no extra connection; redis connects lazily, so an unreachable
+    Redis is not detected here and is handled by the client at request time."""
+    if not url:
+        return ""
+    try:
+        token_cache_from_url(url)
+    except (TokenCacheConfigError, ValueError) as e:
+        # Log the failure, not the URL: a redis:// URL may carry a password.
+        logging.getLogger(__name__).warning(
+            "GUNDI_TOKEN_CACHE_URL is unusable (%s: %s); Gundi OAuth tokens will be "
+            "shared within this process only. Check REDIS_HOST/REDIS_PORT/"
+            "REDIS_TOKEN_CACHE_DB or the GUNDI_TOKEN_CACHE_URL override.",
+            type(e).__name__, e,
+        )
+        return ""
+    return url
+
+
 # Shared OAuth token cache (gundi-client-v2 >= 3.7). Every GundiClient the runner
 # builds shares one token per set of credentials, in process memory and in this
 # backend, so replicas stop minting a fresh Keycloak token per portal call.
 # Defaults to the runner's Redis, next to the state (0) and config (1) databases.
 # Override with a redis://, rediss:// or file:///dir URL; set it to an empty
 # string to share tokens within the process only.
-GUNDI_TOKEN_CACHE_URL = env.str(
-    "GUNDI_TOKEN_CACHE_URL", f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_TOKEN_CACHE_DB}"
+#
+# The cache holds OAuth access AND refresh tokens as plaintext JSON for the
+# refresh token's lifetime. Secure that database like the config cache (db 1),
+# which already holds integration credentials, and prefer rediss:// for a Redis
+# reached over a network.
+GUNDI_TOKEN_CACHE_URL = validated_token_cache_url(
+    env.str(
+        "GUNDI_TOKEN_CACHE_URL",
+        default_token_cache_url(REDIS_HOST, REDIS_PORT, REDIS_TOKEN_CACHE_DB),
+    )
 )
+# gundi-client-v2 reads its own settings module for the constructor default (at
+# construction time, not import time). Installing the runner's URL there means
+# every GundiClient() in this process, including bare ones in connector code,
+# uses this backend, instead of only the sites that remember a kwarg.
+gundi_client_settings.GUNDI_TOKEN_CACHE_URL = GUNDI_TOKEN_CACHE_URL
 
 
 REGISTER_ON_START = env.bool("REGISTER_ON_START", False)

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,5 @@
-# Root conftest: runs before pytest imports the `app` package (whose __init__
-# loads app.settings), so this is the only place an environment default can be
-# set ahead of settings.
+# Root conftest: runs before pytest imports anything under app/, so an
+# environment default set here is in place before app.settings loads.
 import os
 
 # Tests share Gundi OAuth tokens within the process only. The runner's default

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+# Root conftest: runs before pytest imports the `app` package (whose __init__
+# loads app.settings), so this is the only place an environment default can be
+# set ahead of settings.
+import os
+
+# Tests share Gundi OAuth tokens within the process only. The runner's default
+# is redis://<REDIS_HOST>:<REDIS_PORT>/2, and a developer with a local Redis up
+# would otherwise have a token minted by one pytest run persisted and served to
+# the next, while CI (no Redis) sees none of it. An explicit value in the
+# environment is respected.
+os.environ.setdefault("GUNDI_TOKEN_CACHE_URL", "")

--- a/local/.env.local.example
+++ b/local/.env.local.example
@@ -2,17 +2,18 @@
 
 
 # Edit this to have a secret from the stage environment (Ask the Gundi Team)
-KEYCLOAK_CLIENT_SECRET="a-secret-from-gundi-stage"
+GUNDI_OAUTH_CLIENT_SECRET="a-secret-from-gundi-stage"
 
 LOG_LEVEL="DEBUG"
 CDIP_ADMIN_ENDPOINT="https://api.stage.gundiservice.org"
 GUNDI_API_BASE_URL="https://api.stage.gundiservice.org"
-KEYCLOAK_AUDIENCE="cdip-admin-portal"
-KEYCLOAK_CLIENT_ID="cdip-integrations"
-KEYCLOAK_ISSUER="https://cdip-auth.pamdas.org/auth/realms/cdip-dev"
+GUNDI_OAUTH_AUDIENCE="cdip-admin-portal"
+GUNDI_OAUTH_CLIENT_ID="cdip-integrations"
+GUNDI_OAUTH_ISSUER="https://cdip-auth.pamdas.org/auth/realms/cdip-dev"
 SENSORS_API_BASE_URL="https://sensors.api.stage.gundiservice.org"
 REDIS_HOST="redis"
 REDIS_PORT="6379"
+# Gundi OAuth tokens are cached in Redis db 2 (REDIS_TOKEN_CACHE_DB) and shared by every client.
 
 
 # These settings are for using a local pubsub emulator.

--- a/local/.env.local.example
+++ b/local/.env.local.example
@@ -5,7 +5,6 @@
 GUNDI_OAUTH_CLIENT_SECRET="a-secret-from-gundi-stage"
 
 LOG_LEVEL="DEBUG"
-CDIP_ADMIN_ENDPOINT="https://api.stage.gundiservice.org"
 GUNDI_API_BASE_URL="https://api.stage.gundiservice.org"
 GUNDI_OAUTH_AUDIENCE="cdip-admin-portal"
 GUNDI_OAUTH_CLIENT_ID="cdip-integrations"

--- a/local/LOCAL_DEVELOPMENT.md
+++ b/local/LOCAL_DEVELOPMENT.md
@@ -16,7 +16,7 @@ Inside the `local` directory, do these things:
 
 Create a copy of `.env.local.example` and name it `.env.local`
 
-Edit the `.env.local` file and set the `KEYCLOAK_CLIENT_SECRET` to a secret from the stage environment (Ask the Gundi Team)
+Edit the `.env.local` file and set the `GUNDI_OAUTH_CLIENT_SECRET` to a secret from the stage environment (Ask the Gundi Team)
 
 **Build and Run**
 

--- a/requirements-base.in
+++ b/requirements-base.in
@@ -4,14 +4,15 @@
 aiohttp
 environs~=9.5.0
 pydantic~=1.10.15
-fastapi~=0.103.2
+# fastapi ~=0.115 (starlette >=0.40): gundi-client-v2 3.x needs httpx 0.28, and
+# starlette <0.37's TestClient passes app= to httpx.Client, which httpx 0.28 removed.
+fastapi~=0.115.0
 uvicorn~=0.23.2
 gundi-core~=1.11.1
-gundi-client-v2~=2.4.0
-# httpx is imported directly by app/services/*; ~=0.24.1 keeps the resolver on
-# gundi-client-v2 2.4.0 — 2.4.1 requires httpx 0.28, which breaks the TestClient
-# shipped with starlette 0.27 (pinned via fastapi~=0.103.2)
-httpx~=0.24.1
+# [redis]: backend for the shared OAuth token cache (see GUNDI_TOKEN_CACHE_URL in app/settings/base.py)
+gundi-client-v2[redis]~=3.7.0
+# httpx is imported directly by app/services/*; must stay on the 0.28 line gundi-client-v2 3.x requires
+httpx~=0.28.1
 stamina~=23.2.0
 redis~=5.0.1
 gcloud-aio-pubsub~=6.0.0

--- a/requirements-base.in
+++ b/requirements-base.in
@@ -13,7 +13,8 @@ gundi-core~=1.11.1
 gundi-client-v2[redis]~=3.7.0
 # httpx is imported directly by app/services/*; must stay on the 0.28 line gundi-client-v2 3.x requires
 httpx~=0.28.1
-stamina~=23.2.0
+# 24.3 is the first release whose `on=` accepts a predicate (app/services/retry_policies.py)
+stamina~=24.3.0
 redis~=5.0.1
 gcloud-aio-pubsub~=6.0.0
 click~=8.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -128,7 +128,7 @@ redis==5.0.8
     #   gundi-client-v2
 sniffio==1.3.1
     # via anyio
-stamina==23.2.0
+stamina==24.3.0
     # via -r requirements-base.in
 starlette==0.46.2
     # via fastapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,7 @@ aiosignal==1.4.0
     # via aiohttp
 anyio==3.7.1
     # via
-    #   fastapi
-    #   httpcore
+    #   httpx
     #   starlette
 async-timeout==5.0.1
     # via
@@ -45,7 +44,7 @@ exceptiongroup==1.3.1
     # via
     #   anyio
     #   pytest
-fastapi==0.103.2
+fastapi==0.115.14
     # via -r requirements-base.in
 frozenlist==1.8.0
     # via
@@ -55,7 +54,7 @@ gcloud-aio-auth==5.5.0
     # via gcloud-aio-pubsub
 gcloud-aio-pubsub==6.0.1
     # via -r requirements-base.in
-gundi-client-v2==2.4.0
+gundi-client-v2[redis]==3.7.0
     # via -r requirements-base.in
 gundi-core==1.11.3
     # via
@@ -65,13 +64,12 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==0.17.3
+httpcore==1.0.8
     # via httpx
-httpx==0.24.1
+httpx==0.28.1
     # via
     #   -r requirements-base.in
     #   gundi-client-v2
-    #   respx
 idna==3.18
     # via
     #   anyio
@@ -125,17 +123,14 @@ python-dotenv==1.2.2
 python-json-logger==2.0.7
     # via -r requirements-base.in
 redis==5.0.8
-    # via -r requirements-base.in
-respx==0.21.1
-    # via gundi-client-v2
-sniffio==1.3.1
     # via
-    #   anyio
-    #   httpcore
-    #   httpx
+    #   -r requirements-base.in
+    #   gundi-client-v2
+sniffio==1.3.1
+    # via anyio
 stamina==23.2.0
     # via -r requirements-base.in
-starlette==0.27.0
+starlette==0.46.2
     # via fastapi
 tenacity==9.1.4
     # via


### PR DESCRIPTION
## Summary

Merges `upstream/main` (PADAS/gundi-integration-action-runner) into ER, bringing in template PR PADAS/gundi-integration-action-runner#106: gundi-client-v2 **2.4.0 → 3.7.0** with the Redis-shared OAuth token cache, the fastapi/httpx/stamina bumps it requires, retry policies that recognise the 3.x client errors, and the `gundi` error category for Gundi-side failures. See that PR for the full description.

### ER-specific resolution

- `requirements-base.in`: took the template's pins, kept ER's `gundi-core~=1.12.0`.
- `requirements.txt`: regenerated with uv (`uv pip compile --python-version 3.10 -o requirements.txt requirements-base.in requirements-dev.in requirements.in`). Direct bumps: fastapi 0.115.14, starlette 0.46.2, httpx 0.28.1, httpcore 1.0.8, stamina 24.3.0, gundi-client-v2 3.7.0. Transitive pins otherwise unchanged.
- `requirements.in`: declares `respx~=0.22.0`. `app/actions/tests/test_er_schema.py` imports it, and it only reached the lockfile before as an accidental transitive dependency of gundi-client-v2 2.4; 0.22 is the httpx 0.28 release.
- `docs/local-development.md`: points at `GUNDI_OAUTH_CLIENT_SECRET`, the name `local/.env.local.example` now uses.
- earthranger-client 1.15 accepts `httpx>=0.23.3`, so the httpx bump needs no ER code change. ER's only direct httpx use (`er_schema.py`) passes nothing httpx 0.28 removed.

### Deployment notes

- No env changes are required: `KEYCLOAK_*` / `OAUTH_*` still work as fallbacks for the new `GUNDI_OAUTH_*` names.
- The token cache uses Redis database **2** on the runner's existing Redis (state is 0, config cache is 1). Override with `GUNDI_TOKEN_CACHE_URL`; an empty value keeps tokens in-process only. It holds tokens in plaintext, so treat it like the config cache.

## Test plan

- [x] Baseline on main: 490 passed
- [x] After the merge with the new pins installed: 557 passed (`.venv/bin/python -m pytest app`)
- [x] `import app.main` succeeds on the new pins
- [ ] Deploy to dev and confirm Keycloak token requests drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)
